### PR TITLE
DDO-1532 Serializers for service and build responses

### DIFF
--- a/internal/builds/builds.go
+++ b/internal/builds/builds.go
@@ -1,4 +1,9 @@
+// Package builds contains the definitions for a control plan for sherlock's
+// build management systems. It also defines api routes for that control plane
 package builds
+
+// builds.go contains the "business" logic for operations relating to build entities.
+// Thhis could eventually be moved to it's own sub-folder if it becomes unwieldy
 
 import (
 	"fmt"

--- a/internal/builds/handlers.go
+++ b/internal/builds/handlers.go
@@ -53,7 +53,7 @@ func (bc *BuildController) createBuild(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusCreated, Response{Builds: []Build{*build}})
+	c.JSON(http.StatusCreated, Response{Builds: []BuildResponse{build}})
 }
 
 func (bc *BuildController) getByID(c *gin.Context) {
@@ -76,5 +76,5 @@ func (bc *BuildController) getByID(c *gin.Context) {
 		}
 	}
 
-	c.JSON(http.StatusOK, Response{Builds: []Build{*build}})
+	c.JSON(http.StatusOK, Response{Builds: []BuildResponse{build}})
 }

--- a/internal/builds/handlers.go
+++ b/internal/builds/handlers.go
@@ -1,5 +1,8 @@
 package builds
 
+// handlers.go contains all the logic for parsing requests and sending responses for
+// the /builds api group. No business logic or database logic should be present in this file.
+
 import (
 	"errors"
 	"net/http"

--- a/internal/builds/handlers_test.go
+++ b/internal/builds/handlers_test.go
@@ -138,7 +138,8 @@ func TestListBuilds(t *testing.T) {
 			if testCase.expectedError != nil {
 				expectedResponse = Response{Error: testCase.expectedError.Error()}
 			} else {
-				expectedResponse = Response{Builds: testCase.expectedBuilds}
+				expectationSerializer := BuildsSerializer{Builds: testCase.expectedBuilds}
+				expectedResponse = Response{Builds: expectationSerializer.Response()}
 			}
 
 			if diff := cmp.Diff(gotResponse, expectedResponse); diff != "" {
@@ -317,7 +318,8 @@ func TestCreateBuild(t *testing.T) {
 			if testCase.expectedError != nil {
 				expectedResponse = Response{Error: testCase.expectedError.Error()}
 			} else {
-				expectedResponse = Response{Builds: []Build{*expectedBuild}}
+				expectationSerializer := BuildSerializer{*expectedBuild}
+				expectedResponse = Response{Builds: []BuildResponse{expectationSerializer.Response()}}
 			}
 
 			validateResponse(t, response, expectedResponse)
@@ -402,7 +404,8 @@ func TestGetBuildByID(t *testing.T) {
 			if testCase.expectedError != nil {
 				expectedResponse = Response{Error: testCase.expectedError.Error()}
 			} else {
-				expectedResponse = Response{Builds: []Build{testCase.expectedBuild}}
+				expectationSerializer := BuildSerializer{testCase.expectedBuild}
+				expectedResponse = Response{Builds: []BuildResponse{expectationSerializer.Response()}}
 			}
 
 			validateResponse(t, response, expectedResponse)

--- a/internal/builds/models.go
+++ b/internal/builds/models.go
@@ -1,5 +1,9 @@
 package builds
 
+// models.go contains the type for modeling build entities in sherlocks database
+// and methods for interacting with the persistence layer. It should only contain
+// logic related to interacting with build entities in sherlock's db
+
 import (
 	"errors"
 	"fmt"

--- a/internal/builds/serializers.go
+++ b/internal/builds/serializers.go
@@ -1,0 +1,51 @@
+package builds
+
+import (
+	"time"
+
+	"github.com/broadinstitute/sherlock/internal/services"
+)
+
+// Response is a type that allows all data returned from the /builds api group to share a consistent structure
+type Response struct {
+	Builds []BuildResponse `json:"builds"`
+	Error  string          `json:"error,omitempty"`
+}
+
+type BuildResponse struct {
+	ID            int                      `json:"id"`
+	VersionString string                   `json:"version_string"`
+	CommitSha     string                   `json:"commit_sha"`
+	BuildURL      string                   `json:"build_url,omitempty"`
+	BuiltAt       time.Time                `json:"built_at,omitempty"`
+	Service       services.ServiceResponse `json:"service"`
+}
+
+type BuildSerializer struct {
+	Build
+}
+
+func (bs *BuildSerializer) Response() BuildResponse {
+	service := services.ServiceSerializer{bs.Service}
+	return BuildResponse{
+		ID:            bs.ID,
+		VersionString: bs.VersionString,
+		CommitSha:     bs.CommitSha,
+		BuildURL:      bs.BuildURL,
+		BuiltAt:       bs.BuiltAt,
+		Service:       service.Response(),
+	}
+}
+
+type BuildsSerializer struct {
+	Builds []Build
+}
+
+func (bs *BuildsSerializer) Response() []BuildResponse {
+	builds := []BuildResponse{}
+	for _, build := range bs.Builds {
+		serializer := BuildSerializer{build}
+		builds = append(builds, serializer.Response())
+	}
+	return builds
+}

--- a/internal/builds/serializers.go
+++ b/internal/builds/serializers.go
@@ -12,6 +12,8 @@ type Response struct {
 	Error  string          `json:"error,omitempty"`
 }
 
+// BuildResponse is the type used to ensure that response bodies from the /builds api group have a consistent
+// structure
 type BuildResponse struct {
 	ID            int                      `json:"id"`
 	VersionString string                   `json:"version_string"`
@@ -21,10 +23,12 @@ type BuildResponse struct {
 	Service       services.ServiceResponse `json:"service"`
 }
 
+// BuildSerializer takes a Build model entity and translates it into a response
 type BuildSerializer struct {
 	Build
 }
 
+// Response method performs the serialization from a Build entity to Build Response
 func (bs *BuildSerializer) Response() BuildResponse {
 	service := services.ServiceSerializer{bs.Service}
 	return BuildResponse{
@@ -37,10 +41,12 @@ func (bs *BuildSerializer) Response() BuildResponse {
 	}
 }
 
+// BuildsSerializer is used to transform a slice of builds into the Response type
 type BuildsSerializer struct {
 	Builds []Build
 }
 
+// Response transforms a list of build model entities into BuildResponse's
 func (bs *BuildsSerializer) Response() []BuildResponse {
 	builds := []BuildResponse{}
 	for _, build := range bs.Builds {

--- a/internal/builds/serializers.go
+++ b/internal/builds/serializers.go
@@ -25,18 +25,18 @@ type BuildResponse struct {
 
 // BuildSerializer takes a Build model entity and translates it into a response
 type BuildSerializer struct {
-	Build
+	Build Build
 }
 
 // Response method performs the serialization from a Build entity to Build Response
 func (bs *BuildSerializer) Response() BuildResponse {
-	service := services.ServiceSerializer{bs.Service}
+	service := services.ServiceSerializer{Service: bs.Build.Service}
 	return BuildResponse{
-		ID:            bs.ID,
-		VersionString: bs.VersionString,
-		CommitSha:     bs.CommitSha,
-		BuildURL:      bs.BuildURL,
-		BuiltAt:       bs.BuiltAt,
+		ID:            bs.Build.ID,
+		VersionString: bs.Build.VersionString,
+		CommitSha:     bs.Build.CommitSha,
+		BuildURL:      bs.Build.BuildURL,
+		BuiltAt:       bs.Build.BuiltAt,
 		Service:       service.Response(),
 	}
 }

--- a/internal/builds/serializers.go
+++ b/internal/builds/serializers.go
@@ -1,5 +1,11 @@
 package builds
 
+// serializers.go contains logic for building
+// http responses from the builds data base model while avoiding
+// dependencies on the database model in the route handling logic directly.
+// This is an essentially an abstraction layer to give use more control over
+// what is returned from api endpoints
+
 import (
 	"time"
 

--- a/internal/services/handlers.go
+++ b/internal/services/handlers.go
@@ -1,5 +1,8 @@
 package services
 
+// handlers.go contains all the logic for parsing requests and sending responses for
+// the /builds api group. No business logic or database logic should be present in this file.
+
 import (
 	"errors"
 	"net/http"

--- a/internal/services/handlers.go
+++ b/internal/services/handlers.go
@@ -44,7 +44,7 @@ func (sc *ServiceController) getServiceByName(c *gin.Context) {
 		}
 	}
 
-	c.JSON(http.StatusOK, Response{Services: []*Service{service}})
+	c.JSON(http.StatusOK, Response{Services: []ServiceResponse{service}})
 }
 
 func (sc *ServiceController) createService(c *gin.Context) {
@@ -65,5 +65,5 @@ func (sc *ServiceController) createService(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusCreated, Response{Services: []*Service{savedService}})
+	c.JSON(http.StatusCreated, Response{Services: []ServiceResponse{savedService}})
 }

--- a/internal/services/handlers_test.go
+++ b/internal/services/handlers_test.go
@@ -16,19 +16,19 @@ import (
 func TestListServices(t *testing.T) {
 	testCases := []struct {
 		name             string
-		expectedServices []*Service
+		expectedServices []Service
 		expectedError    error
 		expectedCode     int
 	}{
 		{
 			name:             "no existing services",
-			expectedServices: []*Service{},
+			expectedServices: []Service{},
 			expectedCode:     http.StatusOK,
 			expectedError:    nil,
 		},
 		{
 			name: "one existing service",
-			expectedServices: []*Service{
+			expectedServices: []Service{
 				{
 					Name:    "test",
 					RepoURL: "http://test.repo",
@@ -39,7 +39,7 @@ func TestListServices(t *testing.T) {
 		},
 		{
 			name: "multiple existing services",
-			expectedServices: []*Service{
+			expectedServices: []Service{
 				{
 					Name:    "cromwell",
 					RepoURL: "https://github.com/broadinstitute/cromwell",
@@ -58,7 +58,7 @@ func TestListServices(t *testing.T) {
 		},
 		{
 			name:             "internal error",
-			expectedServices: []*Service{},
+			expectedServices: []Service{},
 			expectedCode:     http.StatusInternalServerError,
 			expectedError:    errors.New("some internal error"),
 		},
@@ -85,11 +85,15 @@ func TestListServices(t *testing.T) {
 				t.Fatalf("error decoding response body: %v\n", err)
 			}
 
+			// serialize the expectations using to get expected json response data
+
 			var expectedResponse Response
 			if testCase.expectedError != nil {
 				expectedResponse = Response{Error: testCase.expectedError.Error()}
 			} else {
-				expectedResponse = Response{Services: testCase.expectedServices}
+				expectationSerializer := ServicesSerializer{testCase.expectedServices}
+				expectedServices := expectationSerializer.Response()
+				expectedResponse = Response{Services: expectedServices}
 			}
 
 			if diff := cmp.Diff(gotResponse, expectedResponse); diff != "" {
@@ -167,7 +171,9 @@ func TestGetServiceByName(t *testing.T) {
 			if testCase.expectedError != nil {
 				expectedResponse = Response{Error: testCase.expectedError.Error()}
 			} else {
-				expectedResponse = Response{Services: []*Service{testCase.expectedService}}
+				expectationSerializer := ServiceSerializer{*testCase.expectedService}
+				expectedService := expectationSerializer.response()
+				expectedResponse = Response{Services: []ServiceResponse{expectedService}}
 			}
 
 			if diff := cmp.Diff(gotResponse, expectedResponse); diff != "" {
@@ -295,7 +301,9 @@ func TestCreateService(t *testing.T) {
 			if testCase.expectedError != nil {
 				expectedResponse = Response{Error: testCase.expectedError.Error()}
 			} else {
-				expectedResponse = Response{Services: []*Service{testCase.expectedService}}
+				expectationSerializer := ServiceSerializer{*testCase.expectedService}
+				expectedService := expectationSerializer.response()
+				expectedResponse = Response{Services: []ServiceResponse{expectedService}}
 			}
 
 			if diff := cmp.Diff(gotResponse, expectedResponse); diff != "" {

--- a/internal/services/handlers_test.go
+++ b/internal/services/handlers_test.go
@@ -91,6 +91,7 @@ func TestListServices(t *testing.T) {
 			if testCase.expectedError != nil {
 				expectedResponse = Response{Error: testCase.expectedError.Error()}
 			} else {
+				// Serialize the expected service entity to a Service Response type
 				expectationSerializer := ServicesSerializer{testCase.expectedServices}
 				expectedServices := expectationSerializer.Response()
 				expectedResponse = Response{Services: expectedServices}
@@ -172,7 +173,7 @@ func TestGetServiceByName(t *testing.T) {
 				expectedResponse = Response{Error: testCase.expectedError.Error()}
 			} else {
 				expectationSerializer := ServiceSerializer{*testCase.expectedService}
-				expectedService := expectationSerializer.response()
+				expectedService := expectationSerializer.Response()
 				expectedResponse = Response{Services: []ServiceResponse{expectedService}}
 			}
 
@@ -302,7 +303,7 @@ func TestCreateService(t *testing.T) {
 				expectedResponse = Response{Error: testCase.expectedError.Error()}
 			} else {
 				expectationSerializer := ServiceSerializer{*testCase.expectedService}
-				expectedService := expectationSerializer.response()
+				expectedService := expectationSerializer.Response()
 				expectedResponse = Response{Services: []ServiceResponse{expectedService}}
 			}
 

--- a/internal/services/mocks.go
+++ b/internal/services/mocks.go
@@ -2,6 +2,8 @@ package services
 
 import "github.com/stretchr/testify/mock"
 
+// MockServiceStore is used for mocking underlying database operations for
+// services in unit tests
 type MockServiceStore struct {
 	mock.Mock
 }

--- a/internal/services/mocks.go
+++ b/internal/services/mocks.go
@@ -7,9 +7,9 @@ type MockServiceStore struct {
 }
 
 // this is boilerplate code for the testify mock library
-func (m *MockServiceStore) listAll() ([]*Service, error) {
+func (m *MockServiceStore) listAll() ([]Service, error) {
 	retVal := m.Called()
-	return retVal.Get(0).([]*Service), retVal.Error(1)
+	return retVal.Get(0).([]Service), retVal.Error(1)
 }
 
 func (m *MockServiceStore) createNew(newService CreateServiceRequest) (*Service, error) {

--- a/internal/services/models.go
+++ b/internal/services/models.go
@@ -30,7 +30,7 @@ type Service struct {
 // serviceStore is the interface type that defines the methods required for implementing the persistence layer
 // for services entities
 type serviceStore interface {
-	listAll() ([]*Service, error)
+	listAll() ([]Service, error)
 	createNew(CreateServiceRequest) (*Service, error)
 	getByName(string) (*Service, error)
 }
@@ -41,12 +41,12 @@ func newServiceStore(db *gorm.DB) dataStore {
 
 // ListAll retrieves all service entities from a postgres database and
 // returns them as a slice
-func (db dataStore) listAll() ([]*Service, error) {
-	services := []*Service{}
+func (db dataStore) listAll() ([]Service, error) {
+	services := []Service{}
 
 	err := db.Find(&services).Error
 	if err != nil {
-		return []*Service{}, fmt.Errorf("Error retriving services: %v", err)
+		return []Service{}, fmt.Errorf("Error retriving services: %v", err)
 	}
 
 	return services, nil
@@ -69,7 +69,7 @@ func (db dataStore) getByName(name string) (*Service, error) {
 	service := &Service{}
 
 	if err := db.Where(&Service{Name: name}).First(service).Error; err != nil {
-		return nil, err
+		return &Service{}, err
 	}
 
 	return service, nil

--- a/internal/services/models.go
+++ b/internal/services/models.go
@@ -1,5 +1,9 @@
 package services
 
+// models.go contains the type for modeling build entities in sherlocks database
+// and methods for interacting with the persistence layer. It should only contain
+// logic related to interacting with build entities in sherlock's db
+
 import (
 	"fmt"
 	"time"

--- a/internal/services/serializers.go
+++ b/internal/services/serializers.go
@@ -11,15 +11,15 @@ type ServiceResponse struct {
 // ServiceSerializer is used to serializer a single Service model
 // to a used to generate responses from the /services api group
 type ServiceSerializer struct {
-	Service
+	Service Service
 }
 
 // Response takes a Service Model entity and transforms it into a ServiceResponse
 func (ss *ServiceSerializer) Response() ServiceResponse {
 	return ServiceResponse{
-		ID:      ss.ID,
-		Name:    ss.Name,
-		RepoURL: ss.RepoURL,
+		ID:      ss.Service.ID,
+		Name:    ss.Service.Name,
+		RepoURL: ss.Service.RepoURL,
 	}
 }
 

--- a/internal/services/serializers.go
+++ b/internal/services/serializers.go
@@ -14,6 +14,7 @@ type ServiceSerializer struct {
 	Service
 }
 
+// Response takes a Service Model entity and transforms it into a ServiceResponse
 func (ss *ServiceSerializer) Response() ServiceResponse {
 	return ServiceResponse{
 		ID:      ss.ID,

--- a/internal/services/serializers.go
+++ b/internal/services/serializers.go
@@ -1,5 +1,11 @@
 package services
 
+// serializers.go contains logic for building
+// http responses from the builds data base model while avoiding
+// dependencies on the database model in the route handling logic directly.
+// This is an essentially an abstraction layer to give use more control over
+// what is returned from api endpoints
+
 // ServiceResponse is the type used to serialize Service data that is returned
 // to clients of the sherlock api
 type ServiceResponse struct {

--- a/internal/services/serializers.go
+++ b/internal/services/serializers.go
@@ -8,11 +8,13 @@ type ServiceResponse struct {
 	RepoURL string `json:"repo_url"`
 }
 
+// ServiceSerializer is used to serializer a single Service model
+// to a used to generate responses from the /services api group
 type ServiceSerializer struct {
 	Service
 }
 
-func (ss *ServiceSerializer) response() ServiceResponse {
+func (ss *ServiceSerializer) Response() ServiceResponse {
 	return ServiceResponse{
 		ID:      ss.ID,
 		Name:    ss.Name,
@@ -20,6 +22,8 @@ func (ss *ServiceSerializer) response() ServiceResponse {
 	}
 }
 
+// ServicesSerializer is used to serialize a ServiceModel
+// entity to a a format used in http response bodies
 type ServicesSerializer struct {
 	Services []Service
 }
@@ -29,7 +33,7 @@ func (ss *ServicesSerializer) Response() []ServiceResponse {
 	services := []ServiceResponse{}
 	for _, service := range ss.Services {
 		serializer := ServiceSerializer{service}
-		services = append(services, serializer.response())
+		services = append(services, serializer.Response())
 	}
 	return services
 }

--- a/internal/services/serializers.go
+++ b/internal/services/serializers.go
@@ -1,0 +1,41 @@
+package services
+
+// ServiceResponse is the type used to serialize Service data that is returned
+// to clients of the sherlock api
+type ServiceResponse struct {
+	ID      int    `json:"id"`
+	Name    string `json:"name"`
+	RepoURL string `json:"repo_url"`
+}
+
+type ServiceSerializer struct {
+	Service
+}
+
+func (ss *ServiceSerializer) response() ServiceResponse {
+	return ServiceResponse{
+		ID:      ss.ID,
+		Name:    ss.Name,
+		RepoURL: ss.RepoURL,
+	}
+}
+
+type ServicesSerializer struct {
+	Services []Service
+}
+
+// Response serializes Service models into Service Responses
+func (ss *ServicesSerializer) Response() []ServiceResponse {
+	services := []ServiceResponse{}
+	for _, service := range ss.Services {
+		serializer := ServiceSerializer{service}
+		services = append(services, serializer.response())
+	}
+	return services
+}
+
+// Response is a type that allows all data returned from the /service api group to share a consistent structure
+type Response struct {
+	Services []ServiceResponse `json:"services"`
+	Error    string            `json:"error,omitempty"`
+}

--- a/internal/services/services.go
+++ b/internal/services/services.go
@@ -38,9 +38,12 @@ func (sc *ServiceController) DoesServiceExist(name string) (id int, ok bool) {
 // the data store
 func (sc *ServiceController) CreateNew(newService CreateServiceRequest) (ServiceResponse, error) {
 	resultService, err := sc.store.createNew(newService)
-	result := ServiceSerializer{*resultService}
+	if err != nil {
+		return ServiceResponse{}, err
+	}
 
-	return result.response(), err
+	result := ServiceSerializer{*resultService}
+	return result.Response(), err
 }
 
 // ListAll is the public api for listing out all services tracked by sherlock
@@ -57,7 +60,7 @@ func (sc *ServiceController) GetByName(name string) (ServiceResponse, error) {
 		return ServiceResponse{}, err
 	}
 	result := ServiceSerializer{*resultService}
-	return result.response(), err
+	return result.Response(), err
 }
 
 // CreateServiceRequest is a type used to represent the information required to register a new service in sherlock

--- a/internal/services/services.go
+++ b/internal/services/services.go
@@ -42,17 +42,17 @@ func (sc *ServiceController) CreateNew(newService CreateServiceRequest) (Service
 		return ServiceResponse{}, err
 	}
 	result := ServiceSerializer{*resultService}
-	return result.Response(), err
+	return result.Response(), nil
 }
 
 // ListAll is the public api for listing out all services tracked by sherlock
 func (sc *ServiceController) ListAll() ([]ServiceResponse, error) {
 	resultServices, err := sc.store.listAll()
 	if err != nil {
-		return []ServiceResponse{}, nil
+		return []ServiceResponse{}, err
 	}
 	result := ServicesSerializer{Services: resultServices}
-	return result.Response(), err
+	return result.Response(), nil
 }
 
 // GetByName is the public API for looking up a service from the data store by name
@@ -62,7 +62,7 @@ func (sc *ServiceController) GetByName(name string) (ServiceResponse, error) {
 		return ServiceResponse{}, err
 	}
 	result := ServiceSerializer{*resultService}
-	return result.Response(), err
+	return result.Response(), nil
 }
 
 // CreateServiceRequest is a type used to represent the information required to register a new service in sherlock

--- a/internal/services/services.go
+++ b/internal/services/services.go
@@ -1,8 +1,10 @@
-// Package services defines data structure representing
-// a service instance and methods for interacting with them
-// it is left to concrete implementations in package db or others to
-// implement these interfaces
+// Package services defines the control plane for sherlock's
+// service entities and api routes for interating with those control
+// plane methods
 package services
+
+// builds.go contains the "business" logic for operations relating to service entities.
+// This could eventually be moved to it's own sub-folder if it becomes unwieldy
 
 import (
 	"errors"

--- a/internal/services/services.go
+++ b/internal/services/services.go
@@ -36,18 +36,28 @@ func (sc *ServiceController) DoesServiceExist(name string) (id int, ok bool) {
 
 // CreateNew is the public api on the serviceController for persisting a new service entity to
 // the data store
-func (sc *ServiceController) CreateNew(newService CreateServiceRequest) (*Service, error) {
-	return sc.store.createNew(newService)
+func (sc *ServiceController) CreateNew(newService CreateServiceRequest) (ServiceResponse, error) {
+	resultService, err := sc.store.createNew(newService)
+	result := ServiceSerializer{*resultService}
+
+	return result.response(), err
 }
 
 // ListAll is the public api for listing out all services tracked by sherlock
-func (sc *ServiceController) ListAll() ([]*Service, error) {
-	return sc.store.listAll()
+func (sc *ServiceController) ListAll() ([]ServiceResponse, error) {
+	resultServices, err := sc.store.listAll()
+	result := ServicesSerializer{Services: resultServices}
+	return result.Response(), err
 }
 
 // GetByName is the public API for looking up a service from the data store by name
-func (sc *ServiceController) GetByName(name string) (*Service, error) {
-	return sc.store.getByName(name)
+func (sc *ServiceController) GetByName(name string) (ServiceResponse, error) {
+	resultService, err := sc.store.getByName(name)
+	if err != nil {
+		return ServiceResponse{}, err
+	}
+	result := ServiceSerializer{*resultService}
+	return result.response(), err
 }
 
 // CreateServiceRequest is a type used to represent the information required to register a new service in sherlock
@@ -63,10 +73,4 @@ func (cr *CreateServiceRequest) service() *Service {
 		Name:    cr.Name,
 		RepoURL: cr.RepoURL,
 	}
-}
-
-// Response is a type that allows all data returned from the /service api group to share a consistent structure
-type Response struct {
-	Services []*Service `json:"services"`
-	Error    string     `json:"error,omitempty"`
 }

--- a/internal/services/services.go
+++ b/internal/services/services.go
@@ -41,7 +41,6 @@ func (sc *ServiceController) CreateNew(newService CreateServiceRequest) (Service
 	if err != nil {
 		return ServiceResponse{}, err
 	}
-
 	result := ServiceSerializer{*resultService}
 	return result.Response(), err
 }
@@ -49,6 +48,9 @@ func (sc *ServiceController) CreateNew(newService CreateServiceRequest) (Service
 // ListAll is the public api for listing out all services tracked by sherlock
 func (sc *ServiceController) ListAll() ([]ServiceResponse, error) {
 	resultServices, err := sc.store.listAll()
+	if err != nil {
+		return []ServiceResponse{}, nil
+	}
 	result := ServicesSerializer{Services: resultServices}
 	return result.Response(), err
 }

--- a/internal/sherlock/sherlock_integration_test.go
+++ b/internal/sherlock/sherlock_integration_test.go
@@ -200,7 +200,8 @@ func Test_sherlockServerIntegration(t *testing.T) {
 			t.Fatalf("error seeding builds: %v", err)
 		}
 
-		expectedBuildsResponse := &builds.Response{Builds: expectedBuilds}
+		expectedBuildsSerializer := builds.BuildsSerializer{Builds: expectedBuilds}
+		expectedBuildsResponse := &builds.Response{Builds: expectedBuildsSerializer.Response()}
 
 		req, err := http.NewRequest(http.MethodGet, "/builds", nil)
 		if err != nil {
@@ -333,7 +334,8 @@ func Test_sherlockServerIntegration(t *testing.T) {
 			t.Fatalf("error seeding builds: %v", err)
 		}
 
-		expectedBuildResponse := builds.Response{Builds: []builds.Build{expectedBuilds[0]}}
+		expectedBuildsSerializer := builds.BuildSerializer{expectedBuilds[0]}
+		expectedBuildResponse := builds.Response{Builds: []builds.BuildResponse{expectedBuildsSerializer.Response()}}
 
 		req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("/builds/%d", expectedBuilds[0].ID), nil)
 		if err != nil {

--- a/internal/sherlock/sherlock_integration_test.go
+++ b/internal/sherlock/sherlock_integration_test.go
@@ -44,7 +44,8 @@ func Test_sherlockServerIntegration(t *testing.T) {
 			t.Fatalf("error seeding services: %v", err)
 		}
 
-		expectedServicesResponse := &services.Response{Services: expectedServices}
+		expectationSerializer := services.ServicesSerializer{Services: expectedServices}
+		expectedServicesResponse := &services.Response{Services: expectationSerializer.Response()}
 
 		req, err := http.NewRequest(http.MethodGet, "/services", nil)
 		if err != nil {
@@ -141,7 +142,9 @@ func Test_sherlockServerIntegration(t *testing.T) {
 		if err != nil {
 			t.Fatalf("error seeding services: %v", err)
 		}
-		expectedServicesResponse := &services.Response{Services: []*services.Service{expectedServices[0]}}
+
+		expectationSerializer := services.ServicesSerializer{Services: []services.Service{expectedServices[0]}}
+		expectedServicesResponse := &services.Response{Services: expectationSerializer.Response()}
 
 		req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("/services/%s", expectedServices[0].Name), nil)
 		if err != nil {

--- a/internal/sherlock/sherlock_integration_test.go
+++ b/internal/sherlock/sherlock_integration_test.go
@@ -334,7 +334,7 @@ func Test_sherlockServerIntegration(t *testing.T) {
 			t.Fatalf("error seeding builds: %v", err)
 		}
 
-		expectedBuildsSerializer := builds.BuildSerializer{expectedBuilds[0]}
+		expectedBuildsSerializer := builds.BuildSerializer{Build: expectedBuilds[0]}
 		expectedBuildResponse := builds.Response{Builds: []builds.BuildResponse{expectedBuildsSerializer.Response()}}
 
 		req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("/builds/%d", expectedBuilds[0].ID), nil)

--- a/internal/tools/seed.go
+++ b/internal/tools/seed.go
@@ -10,8 +10,8 @@ import (
 
 // SeedServices is a test utility that will populate a database with a predetermined list of "services"
 // to be used for running integration tests against a real database
-func SeedServices(db *gorm.DB) ([]*services.Service, error) {
-	services := []*services.Service{
+func SeedServices(db *gorm.DB) ([]services.Service, error) {
+	services := []services.Service{
 		{
 			Name:    "cromwell",
 			RepoURL: "https://github.com/broadinstitute/cromwell",


### PR DESCRIPTION
This pr was inspired by @choover-broad 's comment [here](https://github.com/broadinstitute/sherlock/pull/8#discussion_r708553219). The goal here is to create serializers to convert the model type for Sherlock's entities to a type that is used generate http response bodies. 

This means that the DB model type is now fully decoupled from requests and responses. This is important for giving us more granular control over what information we show in these api responses. This also makes it easier to hide implementation details and support backwards compatibility if needed.

These changes are based on [this pattern](https://github.com/gothinkster/golang-gin-realworld-example-app/blob/master/articles/serializers.go) from the gin example repo.
