### PR TITLE
[No Ticket] Fix Bug in BuiltAt timestamp field

### DIFF
--- a/internal/builds/models.go
+++ b/internal/builds/models.go
@@ -32,7 +32,7 @@ type Build struct {
 	VersionString string
 	CommitSha     string
 	BuildURL      string
-	BuiltAt       time.Time
+	BuiltAt       time.Time `gorm:"autoCreateTime"`
 	CreatedAt     time.Time
 	UpdatedAt     time.Time
 	ServiceID     int

--- a/internal/tools/seed.go
+++ b/internal/tools/seed.go
@@ -2,6 +2,7 @@ package tools
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/broadinstitute/sherlock/internal/builds"
 	"github.com/broadinstitute/sherlock/internal/services"
@@ -78,6 +79,7 @@ func SeedBuilds(db *gorm.DB) ([]builds.Build, error) {
 			VersionString: "gcr.io/workspacemanager:1.2.0",
 			CommitSha:     "6a5s4df",
 			BuildURL:      "https://build.3.log",
+			BuiltAt:       time.Now().Add(-6 * time.Hour),
 			ServiceID:     services[2].ID,
 		},
 	}

--- a/internal/tools/seed.go
+++ b/internal/tools/seed.go
@@ -40,6 +40,9 @@ func SeedServices(db *gorm.DB) ([]services.Service, error) {
 // to populate a postgres DB with fake Build entities
 func SeedBuilds(db *gorm.DB) ([]builds.Build, error) {
 	// get existing services to make sure ids are valid.
+
+	// used to verify we can explicity set BuiltAt rather than just defaulting to current time
+	sixHoursAgo := time.Now().Add(-6 * time.Hour)
 	var services []services.Service
 	if err := db.Find(&services).Error; err != nil {
 		return nil, fmt.Errorf("error retrieving existing services to reference in seeded builds: %v", err)
@@ -79,7 +82,7 @@ func SeedBuilds(db *gorm.DB) ([]builds.Build, error) {
 			VersionString: "gcr.io/workspacemanager:1.2.0",
 			CommitSha:     "6a5s4df",
 			BuildURL:      "https://build.3.log",
-			BuiltAt:       time.Now().Add(-6 * time.Hour),
+			BuiltAt:       sixHoursAgo,
 			ServiceID:     services[2].ID,
 		},
 	}


### PR DESCRIPTION
 In gorm models `CreatedAt` and `UpdatedAt` fields have special magic going on behind the scenes where it will set those timestamps to the current time in postgres unless they are specified ie non-zero value for `time.Time` . To get this same behavior for other timestamp columns such as built at requires a special `gorm` struct tag. This will guarantee that `built_at` column is set to current time when a new build is created if it is not otherwise specified. 

The behavior without this is that a Zero value for go's `time.Time` would be persisted to Postgres in the `built_at` column which can cause non-deterministic results. [Relevant documentation](https://gorm.io/docs/models.html#Creating-Updating-Time-Unix-Milli-Nano-Seconds-Tracking)