### PR TITLE
DDO-1564 Complete Necessary functionality for service instances

### DIFF
--- a/db/migrations/000009_add_unique_contstraint_to_service_instances.down.sql
+++ b/db/migrations/000009_add_unique_contstraint_to_service_instances.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE service_instances
+    DROP CONSTRAINT uq_service_environment;

--- a/db/migrations/000009_add_unique_contstraint_to_service_instances.up.sql
+++ b/db/migrations/000009_add_unique_contstraint_to_service_instances.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE service_instances
+    ADD CONSTRAINT uq_service_environment UNIQUE(service_id, environment_id);

--- a/internal/deploys/mocks.go
+++ b/internal/deploys/mocks.go
@@ -14,7 +14,12 @@ func (m *mockServiceInstanceStore) listAll() ([]ServiceInstance, error) {
 }
 
 func (m *mockServiceInstanceStore) createNew(serviceID, environmentID int) (ServiceInstance, error) {
-	retVal := m.Called()
+	retVal := m.Called(serviceID, environmentID)
+	return retVal.Get(0).(ServiceInstance), retVal.Error(1)
+}
+
+func (m *mockServiceInstanceStore) getByEnvironmentAndServiceName(environmentName, serviceName string) (ServiceInstance, error) {
+	retVal := m.Called(environmentName, serviceName)
 	return retVal.Get(0).(ServiceInstance), retVal.Error(1)
 }
 

--- a/internal/deploys/mocks.go
+++ b/internal/deploys/mocks.go
@@ -13,6 +13,11 @@ func (m *mockServiceInstanceStore) listAll() ([]ServiceInstance, error) {
 	return retVal.Get(0).([]ServiceInstance), retVal.Error(1)
 }
 
+func (m *mockServiceInstanceStore) createNew(serviceID, environmentID int) (ServiceInstance, error) {
+	retVal := m.Called()
+	return retVal.Get(0).(ServiceInstance), retVal.Error(1)
+}
+
 // NewMockController returns an EnvironmentController instance with the provided mock
 // of the storage layer for use in unit tests
 func NewMockController(mockStore *mockServiceInstanceStore) *ServiceInstanceController {

--- a/internal/deploys/models.go
+++ b/internal/deploys/models.go
@@ -63,6 +63,7 @@ func (db dataStore) createNew(environmentID, serviceID int) (ServiceInstance, er
 func (db dataStore) getByEnvironmentAndServiceName(environmentName, serviceName string) (ServiceInstance, error) {
 	var serviceInstance ServiceInstance
 
+	// using gorms struct query features to set the WHERE clause
 	queryStruct := ServiceInstance{
 		Environment: environments.Environment{
 			Name: environmentName,

--- a/internal/deploys/models.go
+++ b/internal/deploys/models.go
@@ -18,19 +18,39 @@ type dataStore struct {
 type ServiceInstance struct {
 	ID            int
 	ServiceID     int
-	Service       services.Service
+	Service       services.Service `gorm:"foreignKey:ServiceID;references:ID"`
 	EnvironmentID int
-	Environment   environments.Environment
+	Environment   environments.Environment `gorm:"foreignKey:EnvironmentID;references:ID"`
 	CreatedAt     time.Time
 	UpdatedAt     time.Time
 }
 
 type serviceInstanceStore interface {
 	listAll() ([]ServiceInstance, error)
+	createNew(environmentID int, serviceID int) (ServiceInstance, error)
 }
 
 func newServiceInstanceStore(dbConn *gorm.DB) dataStore {
 	return dataStore{dbConn}
+}
+
+func (db dataStore) createNew(environmentID, serviceID int) (ServiceInstance, error) {
+	newServiceInstance := ServiceInstance{
+		ServiceID:     serviceID,
+		EnvironmentID: environmentID,
+	}
+
+	if err := db.Create(&newServiceInstance).Error; err != nil {
+		return ServiceInstance{}, fmt.Errorf("error persisting service instance: %v", err)
+	}
+
+	// retrieve the same service instance record back from the db but now with all the
+	// associations populated.
+	err := db.Preload("Service").
+		Preload("Environment").
+		First(&newServiceInstance, newServiceInstance.ID).Error
+
+	return newServiceInstance, err
 }
 
 func (db dataStore) listAll() ([]ServiceInstance, error) {

--- a/internal/deploys/serviceInstance.go
+++ b/internal/deploys/serviceInstance.go
@@ -5,12 +5,27 @@ package deploys
 // that is used to build the association between a build, service, and environment
 // at a specific point in time which is needed to represent a deploy
 
-import "gorm.io/gorm"
+import (
+	"fmt"
+
+	"github.com/broadinstitute/sherlock/internal/environments"
+	"github.com/broadinstitute/sherlock/internal/services"
+	"gorm.io/gorm"
+)
 
 // ServiceInstanceController is the type used to manage logic related to working with
 // ServiceInstance entities
 type ServiceInstanceController struct {
-	store serviceInstanceStore
+	store        serviceInstanceStore
+	services     *services.ServiceController
+	environments *environments.EnvironmentController
+}
+
+// CreateServiceInstanceRequest is a type containing the name of an environment and service
+// that sherlock uses to create a new association between the two.
+type CreateServiceInstanceRequest struct {
+	EnvironmentName string
+	ServiceName     string
 }
 
 // NewServiceInstanceController expects a gorm.DB connection and will provision
@@ -18,13 +33,31 @@ type ServiceInstanceController struct {
 func NewServiceInstanceController(dbConn *gorm.DB) *ServiceInstanceController {
 	store := newServiceInstanceStore(dbConn)
 	return &ServiceInstanceController{
-		store: store,
+		store:        store,
+		services:     services.NewController(dbConn),
+		environments: environments.NewController(dbConn),
 	}
 }
 
 // ListAll retrieves all service_instance entities from the backing data store
 func (sic *ServiceInstanceController) ListAll() ([]ServiceInstance, error) {
 	return sic.store.listAll()
+}
+
+func (sic *ServiceInstanceController) CreateNew(newServiceInstance CreateServiceInstanceRequest) (ServiceInstance, error) {
+	// check if the environment already exists
+	environmentID, doesExist := sic.environments.DoesEnvironmentExist(newServiceInstance.EnvironmentName)
+	if !doesExist {
+		return ServiceInstance{}, fmt.Errorf("environment: %s does not exist", newServiceInstance.EnvironmentName)
+	}
+
+	// check if the service already exists
+	serviceID, doesExist := sic.services.DoesServiceExist(newServiceInstance.ServiceName)
+	if !doesExist {
+		return ServiceInstance{}, fmt.Errorf("service: %s does not exist", newServiceInstance.ServiceName)
+	}
+
+	return sic.store.createNew(environmentID, serviceID)
 }
 
 // Serialize takes a variable number of service instance entities and serializes them into types suitable for use in

--- a/internal/deploys/serviceInstance.go
+++ b/internal/deploys/serviceInstance.go
@@ -6,8 +6,6 @@ package deploys
 // at a specific point in time which is needed to represent a deploy
 
 import (
-	"fmt"
-
 	"github.com/broadinstitute/sherlock/internal/environments"
 	"github.com/broadinstitute/sherlock/internal/services"
 	"gorm.io/gorm"
@@ -54,9 +52,9 @@ func (sic *ServiceInstanceController) CreateNew(newServiceInstance CreateService
 	}
 
 	// check if the service already exists
-	serviceID, doesExist := sic.services.DoesServiceExist(newServiceInstance.ServiceName)
-	if !doesExist {
-		return ServiceInstance{}, fmt.Errorf("service: %s does not exist", newServiceInstance.ServiceName)
+	serviceID, err := sic.services.FindOrCreate(newServiceInstance.ServiceName)
+	if err != nil {
+		return ServiceInstance{}, err
 	}
 
 	return sic.store.createNew(environmentID, serviceID)

--- a/internal/deploys/serviceInstance.go
+++ b/internal/deploys/serviceInstance.go
@@ -44,6 +44,8 @@ func (sic *ServiceInstanceController) ListAll() ([]ServiceInstance, error) {
 	return sic.store.listAll()
 }
 
+// CreateNew accepts the name of an environment and a service. It will perform find or create operations for both
+// and their create an association between them
 func (sic *ServiceInstanceController) CreateNew(newServiceInstance CreateServiceInstanceRequest) (ServiceInstance, error) {
 	// check if the environment already exists
 	environmentID, err := sic.environments.FindOrCreate(newServiceInstance.EnvironmentName)
@@ -58,6 +60,12 @@ func (sic *ServiceInstanceController) CreateNew(newServiceInstance CreateService
 	}
 
 	return sic.store.createNew(environmentID, serviceID)
+}
+
+// GetByEnvironmentAndServiceName accepts environment and service names as strings and will return the Service_Instance entity
+// representing the association between them if it exists
+func (sic *ServiceInstanceController) GetByEnvironmentAndServiceName(environmentName, serviceName string) (ServiceInstance, error) {
+	return sic.store.getByEnvironmentAndServiceName(environmentName, serviceName)
 }
 
 // Serialize takes a variable number of service instance entities and serializes them into types suitable for use in

--- a/internal/deploys/serviceInstance.go
+++ b/internal/deploys/serviceInstance.go
@@ -46,9 +46,9 @@ func (sic *ServiceInstanceController) ListAll() ([]ServiceInstance, error) {
 
 func (sic *ServiceInstanceController) CreateNew(newServiceInstance CreateServiceInstanceRequest) (ServiceInstance, error) {
 	// check if the environment already exists
-	environmentID, doesExist := sic.environments.DoesEnvironmentExist(newServiceInstance.EnvironmentName)
-	if !doesExist {
-		return ServiceInstance{}, fmt.Errorf("environment: %s does not exist", newServiceInstance.EnvironmentName)
+	environmentID, err := sic.environments.FindOrCreate(newServiceInstance.EnvironmentName)
+	if err != nil {
+		return ServiceInstance{}, err
 	}
 
 	// check if the service already exists

--- a/internal/deploys/serviceInstance_test.go
+++ b/internal/deploys/serviceInstance_test.go
@@ -4,14 +4,19 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/broadinstitute/sherlock/internal/environments"
+	"github.com/broadinstitute/sherlock/internal/services"
 	"github.com/broadinstitute/sherlock/internal/testutils"
+	"github.com/bxcodec/faker/v3"
 	"github.com/stretchr/testify/suite"
 	"gorm.io/gorm"
 )
 
 type ServiceInstanceIntegrationTestSuite struct {
 	suite.Suite
-	app *testApplication
+	app                *testApplication
+	goodEnvironmentReq environments.CreateEnvironmentRequest
+	goodServiceReq     services.CreateServiceRequest
 }
 
 func TestServiceInstanceIntegrationSuite(t *testing.T) {
@@ -25,18 +30,27 @@ func (suite *ServiceInstanceIntegrationTestSuite) SetupSuite() {
 	suite.app = initTestApp(suite.T())
 	// ensure the db is clean before running suite
 	testutils.Cleanup(suite.T(), suite.app.db)
+
+	suite.goodEnvironmentReq = environments.CreateEnvironmentRequest{
+		Name: faker.Word(),
+	}
+
+	suite.goodServiceReq = services.CreateServiceRequest{
+		Name:    faker.Word(),
+		RepoURL: faker.URL(),
+	}
 }
 
 type testApplication struct {
-	builds *ServiceInstanceController
-	db     *gorm.DB
+	serviceInstances *ServiceInstanceController
+	db               *gorm.DB
 }
 
 func initTestApp(t *testing.T) *testApplication {
 	dbConn := testutils.ConnectAndMigrate(t)
 	return &testApplication{
-		builds: NewServiceInstanceController(dbConn),
-		db:     dbConn,
+		serviceInstances: NewServiceInstanceController(dbConn),
+		db:               dbConn,
 	}
 }
 
@@ -45,6 +59,31 @@ func (suite *ServiceInstanceIntegrationTestSuite) TestListServiceInstancesError(
 	controller := setupMockController(suite.T(), []ServiceInstance{}, targetError, "listAll")
 	_, err := controller.ListAll()
 	suite.Assert().ErrorIs(err, targetError, "expected an internal error from DB layer, received some other error")
+}
+
+func (suite *ServiceInstanceIntegrationTestSuite) TestCreateServiceInstance() {
+	suite.Run("creates association between existing service and environment", func() {
+		testutils.Cleanup(suite.T(), suite.app.db)
+
+		// prepoulate an environment
+		preExistingEnv, err := suite.app.serviceInstances.environments.CreateNew(suite.goodEnvironmentReq)
+		suite.Require().NoError(err)
+
+		// pre-populate an existing service
+		preExistingService, err := suite.app.serviceInstances.services.CreateNew(suite.goodServiceReq)
+		suite.Require().NoError(err)
+
+		// attempt to create a service instance from the above
+		newServiceInstanceReq := CreateServiceInstanceRequest{
+			EnvironmentName: preExistingEnv.Name,
+			ServiceName:     preExistingService.Name,
+		}
+
+		result, err := suite.app.serviceInstances.CreateNew(newServiceInstanceReq)
+		suite.Require().NoError(err)
+
+		suite.Assert().Equal(preExistingService.Name, result.Service.Name)
+	})
 }
 
 func setupMockController(

--- a/internal/deploys/serviceInstance_test.go
+++ b/internal/deploys/serviceInstance_test.go
@@ -83,6 +83,7 @@ func (suite *ServiceInstanceIntegrationTestSuite) TestCreateServiceInstance() {
 		suite.Require().NoError(err)
 
 		suite.Assert().Equal(preExistingService.Name, result.Service.Name)
+		suite.Assert().Equal(preExistingEnv.Name, result.Environment.Name)
 	})
 }
 

--- a/internal/deploys/serviceInstance_test.go
+++ b/internal/deploys/serviceInstance_test.go
@@ -87,7 +87,7 @@ func (suite *ServiceInstanceIntegrationTestSuite) TestCreateServiceInstance() {
 		suite.Assert().Equal(preExistingEnv.Name, result.Environment.Name)
 	})
 
-	suite.Run("creates an environment if it doesn't already exist", func() {
+	suite.Run("creates an environment if not exists", func() {
 		testutils.Cleanup(suite.T(), suite.app.db)
 
 		// pre-poulate an existing service
@@ -103,6 +103,24 @@ func (suite *ServiceInstanceIntegrationTestSuite) TestCreateServiceInstance() {
 		suite.Require().NoError(err)
 
 		suite.Assert().Equal(newServiceInstanceReq.EnvironmentName, result.Environment.Name)
+	})
+
+	suite.Run("creates a service if not exists", func() {
+		testutils.Cleanup(suite.T(), suite.app.db)
+
+		// pre-populate an existing environment
+		preExistingEnv, err := suite.app.serviceInstances.environments.CreateNew(suite.goodEnvironmentReq)
+		suite.Require().NoError(err)
+
+		newServiceInstanceReq := CreateServiceInstanceRequest{
+			EnvironmentName: preExistingEnv.Name,
+			ServiceName:     "does-not-exist",
+		}
+
+		result, err := suite.app.serviceInstances.CreateNew(newServiceInstanceReq)
+		suite.Require().NoError(err)
+
+		suite.Assert().Equal(newServiceInstanceReq.ServiceName, result.Service.Name)
 	})
 
 	suite.Run("cannot create the same service instance twice", func() {

--- a/internal/environments/environments.go
+++ b/internal/environments/environments.go
@@ -8,6 +8,7 @@ package environments
 
 import (
 	"errors"
+	"fmt"
 
 	"gorm.io/gorm"
 )
@@ -53,6 +54,20 @@ func (environmentController *EnvironmentController) ListAll() ([]Environment, er
 func (environmentController *EnvironmentController) GetByName(name string) (Environment, error) {
 	return environmentController.store.getByName(name)
 
+}
+
+func (environmentController *EnvironmentController) FindOrCreate(name string) (int, error) {
+	environmentID, exists := environmentController.DoesEnvironmentExist(name)
+
+	if !exists {
+		newEnvironment := CreateEnvironmentRequest{Name: name}
+		createdEnvironment, err := environmentController.CreateNew(newEnvironment)
+		if err != nil {
+			return 0, fmt.Errorf("error creating environment %s: %v", name, err)
+		}
+		return createdEnvironment.ID, nil
+	}
+	return environmentID, nil
 }
 
 // Takes an GORM Environment object and returns a JSON for environment

--- a/internal/environments/environments.go
+++ b/internal/environments/environments.go
@@ -56,6 +56,8 @@ func (environmentController *EnvironmentController) GetByName(name string) (Envi
 
 }
 
+// FindOrCreate will attempt to look an environment by name and return its ID if successful
+// if unsuccessful it will create a new environment from the provider name and return that id
 func (environmentController *EnvironmentController) FindOrCreate(name string) (int, error) {
 	environmentID, exists := environmentController.DoesEnvironmentExist(name)
 
@@ -65,7 +67,7 @@ func (environmentController *EnvironmentController) FindOrCreate(name string) (i
 		if err != nil {
 			return 0, fmt.Errorf("error creating environment %s: %v", name, err)
 		}
-		return createdEnvironment.ID, nil
+		environmentID = createdEnvironment.ID
 	}
 	return environmentID, nil
 }

--- a/internal/environments/environments_test.go
+++ b/internal/environments/environments_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/broadinstitute/sherlock/internal/testutils"
+	"github.com/bxcodec/faker/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 	"gorm.io/gorm"
@@ -282,5 +283,29 @@ func (suite *EnvironmentTestSuite) TestIntegrationEnvironmentSerialize() {
 
 		assert.Equal(suite.T(), 1, len(environmentResponses))
 		assert.IsType(suite.T(), EnvironmentResponse{}, environmentResponses[0])
+	})
+}
+
+func (suite *EnvironmentTestSuite) TestFindOrCreate() {
+	suite.Run("retrieves an environment that already exists", func() {
+		testutils.Cleanup(suite.T(), suite.testApp.db)
+
+		existingEnvironment, err := suite.testApp.Environments.CreateNew(suite.goodEnvironmentRequest)
+		suite.Require().NoError(err)
+
+		foundEnvironmentID, err := suite.testApp.Environments.FindOrCreate(suite.goodEnvironmentRequest.Name)
+		suite.Require().NoError(err)
+
+		suite.Assert().Equal(existingEnvironment.ID, foundEnvironmentID)
+	})
+
+	suite.Run("creates a new environment that doesn't exist already", func() {
+		testutils.Cleanup(suite.T(), suite.testApp.db)
+
+		newEnvironmentID, err := suite.testApp.Environments.FindOrCreate(faker.Word())
+		suite.Assert().NoError(err)
+
+		// assert the env was created by verifying it has a non-zero id
+		suite.Assert().NotEqual(0, newEnvironmentID)
 	})
 }

--- a/internal/services/services.go
+++ b/internal/services/services.go
@@ -8,6 +8,7 @@ package services
 
 import (
 	"errors"
+	"fmt"
 
 	"gorm.io/gorm"
 )
@@ -50,6 +51,23 @@ func (sc *ServiceController) ListAll() ([]Service, error) {
 // GetByName is the public API for looking up a service from the data store by name
 func (sc *ServiceController) GetByName(name string) (Service, error) {
 	return sc.store.getByName(name)
+}
+
+// FindOrCreate will attempt to look an environment by name and return its ID if successful
+// if unsuccessful it will create a new environment from the provider name and return that id
+func (sc *ServiceController) FindOrCreate(name string) (int, error) {
+	serviceID, exists := sc.DoesServiceExist(name)
+
+	if !exists {
+		// then make the new service
+		newService := CreateServiceRequest{Name: name}
+		createdService, err := sc.CreateNew(newService)
+		if err != nil {
+			return 0, fmt.Errorf("error creating service %s: %v", name, err)
+		}
+		serviceID = createdService.ID
+	}
+	return serviceID, nil
 }
 
 func (sc *ServiceController) serialize(services ...Service) []ServiceResponse {

--- a/internal/services/services_test.go
+++ b/internal/services/services_test.go
@@ -139,6 +139,34 @@ func (suite *ServicesIntegrationTestSuite) TestGetByName() {
 	})
 }
 
+func (suite *ServicesIntegrationTestSuite) TestFindOrCreate() {
+	suite.Run("retrieves an existing service", func() {
+		testutils.Cleanup(suite.T(), suite.app.db)
+
+		newService := CreateServiceRequest{}
+
+		// populate the create request with dummy data
+		err := faker.FakeData(&newService)
+		suite.Require().NoError(err)
+
+		existingService, err := suite.app.services.CreateNew(newService)
+		suite.Require().NoError(err)
+
+		foundServiceID, err := suite.app.services.FindOrCreate(newService.Name)
+		suite.Assert().NoError(err)
+		suite.Assert().Equal(existingService.ID, foundServiceID)
+	})
+
+	suite.Run("creates service if not exists", func() {
+		testutils.Cleanup(suite.T(), suite.app.db)
+
+		newServiceID, err := suite.app.services.FindOrCreate(faker.Word())
+		suite.Assert().NoError(err)
+		// assert the service was actually created by verifying its ID is non-zero
+		suite.Assert().NotEqual(0, newServiceID)
+	})
+}
+
 func TestServicesIntegrationSuite(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")

--- a/makefile
+++ b/makefile
@@ -26,3 +26,7 @@ tests-with-coverage:
 	go test -v -race -coverprofile=cover.out -covermode=atomic ./...
 	docker stop test-postgres
 	docker rm test-postgres
+
+pg-down:
+	docker stop test-postgres
+	docker rm test-postgres

--- a/makefile
+++ b/makefile
@@ -9,10 +9,8 @@ local-down:
 
 # not sure if this is good make style but it works for now
 integration-test:
-	export SHERLOCK_DBHOST="localhost"
-	export SHERLOCK_DBPASSWORD="password"
 	docker run --name test-postgres -e POSTGRES_PASSWORD=password -e POSTGRES_USER=sherlock -d -p 5432:5432 postgres:13
-	go test -v -race ./...
+	export SHERLOCK_DBHOST="localhost" && export SHERLOCK_DBPASSWORD="password" && go test -v -race ./...
 	docker stop test-postgres
 	docker rm test-postgres
 
@@ -20,10 +18,8 @@ unit-test:
 	go test -v -short -race ./...
 
 tests-with-coverage:
-	export SHERLOCK_DBHOST="localhost"
-	export SHERLOCK_DBPASSWORD="password"
 	docker run --name test-postgres -e POSTGRES_PASSWORD=password -e POSTGRES_USER=sherlock -d -p 5432:5432 postgres:13
-	go test -v -race -coverprofile=cover.out -covermode=atomic ./...
+	export SHERLOCK_DBHOST="localhost" && export SHERLOCK_DBPASSWORD="password" && go test -v -race -coverprofile=cover.out -covermode=atomic ./...
 	docker stop test-postgres
 	docker rm test-postgres
 


### PR DESCRIPTION
This PR implements the remaining `ServiceInstance` aka association between service and environment, needed for accelerate metrics. There are two key functionalities implemented here:

1. The ability to create new service instances. This functionality performs a check to make sure that both the service and environment exist and will create them if not before actually persisting the association to the `service_instances` table. To facilitate this functionality `FindOrCreate` methods were added to both the services and environments controllers. The combination of service and environment together are required to be unique
2. The ability to look up service instances given the environment and service names, this is a critical functionality for the eventual `deploys` route handlers.

This PR does not contain any api handlers as the service instances functionality is internal only logic and it is essentially just an associations table of service and environment ids. I don't think it necessarily makes sense to expose this implementation detail in the api directly. The `deploys` api will use this functionality under the hood.