### PR TITLE
DDO-1564 Create New Deploys and List Deploy History for Service/Environment Control Plane Functionality

### DIFF
--- a/db/migrations/000010_add_missing_build_id_to_deploys.down.sql
+++ b/db/migrations/000010_add_missing_build_id_to_deploys.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE deploys
+    DROP COLUMN build_id;

--- a/db/migrations/000010_add_missing_build_id_to_deploys.up.sql
+++ b/db/migrations/000010_add_missing_build_id_to_deploys.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE deploys
+    ADD COLUMN build_id integer REFERENCES builds (id);

--- a/db/migrations/000011_add_versionstring_idx_to_builds.down.sql
+++ b/db/migrations/000011_add_versionstring_idx_to_builds.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX builds_version_string_idx; 

--- a/db/migrations/000011_add_versionstring_idx_to_builds.up.sql
+++ b/db/migrations/000011_add_versionstring_idx_to_builds.up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX builds_version_string_idx ON builds (version_string);

--- a/internal/builds/builds.go
+++ b/internal/builds/builds.go
@@ -96,6 +96,12 @@ func (bc *BuildController) GetByID(id int) (Build, error) {
 	return bc.store.getByID(id)
 }
 
+// GetByVersionString will perform a look up of a build entity using it's unique version string
+// ie image repo + tag
+func (bc *BuildController) GetByVersionString(versionString string) (Build, error) {
+	return bc.store.getByVersionString(versionString)
+}
+
 func (bc *BuildController) serialize(builds ...Build) []BuildResponse {
 	var buildsList []Build
 	buildsList = append(buildsList, builds...)

--- a/internal/builds/builds.go
+++ b/internal/builds/builds.go
@@ -6,7 +6,6 @@ package builds
 // Thhis could eventually be moved to it's own sub-folder if it becomes unwieldy
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/broadinstitute/sherlock/internal/services"
@@ -45,14 +44,9 @@ type CreateBuildRequest struct {
 
 func (bc *BuildController) validateAndCreateNewBuild(newBuild CreateBuildRequest) (Build, error) {
 	var serviceID int
-	serviceID, ok := bc.services.DoesServiceExist(newBuild.ServiceName)
-	// handle case where service doesn't exist already
-	if !ok {
-		var err error
-		serviceID, err = bc.createNewServiceFromBuildRequest(newBuild.ServiceName, newBuild.ServiceRepo)
-		if err != nil {
-			return Build{}, err
-		}
+	serviceID, err := bc.services.FindOrCreate(newBuild.ServiceName)
+	if err != nil {
+		return Build{}, err
 	}
 	build := Build{
 		VersionString: newBuild.VersionString,
@@ -63,19 +57,6 @@ func (bc *BuildController) validateAndCreateNewBuild(newBuild CreateBuildRequest
 	}
 
 	return bc.store.createNew(build)
-}
-
-// when receiving a new build for a service sherlock isn't aware of, create that service
-func (bc *BuildController) createNewServiceFromBuildRequest(name, repoURL string) (int, error) {
-	newServiceRequest := services.CreateServiceRequest{
-		Name:    name,
-		RepoURL: repoURL,
-	}
-	newService, err := bc.services.CreateNew(newServiceRequest)
-	if err != nil {
-		return 0, fmt.Errorf("error creating new service from build request: %v", err)
-	}
-	return newService.ID, nil
 }
 
 // ListAll is the public API on the build controller for listing out all builds

--- a/internal/builds/builds.go
+++ b/internal/builds/builds.go
@@ -46,7 +46,7 @@ func (bc *BuildController) validateAndCreateNewBuild(newBuild CreateBuildRequest
 	var serviceID int
 	serviceID, err := bc.services.FindOrCreate(newBuild.ServiceName)
 	if err != nil {
-		return Build{}, err
+		return Build{}, ErrBadCreateRequest
 	}
 	build := Build{
 		VersionString: newBuild.VersionString,

--- a/internal/builds/builds_test.go
+++ b/internal/builds/builds_test.go
@@ -25,7 +25,6 @@ func TestBuildsIntegrationSuite(t *testing.T) {
 }
 
 func (suite *BuildsIntegrationTestSuite) SetupTest() {
-	// start a new db transaction for each test
 	suite.goodCreateBuildRequest = CreateBuildRequest{
 		VersionString: faker.URL(),
 		CommitSha:     faker.UUIDDigit(),
@@ -102,7 +101,7 @@ func (suite *BuildsIntegrationTestSuite) TestGetByVersionString() {
 		result, err := suite.app.builds.GetByVersionString(suite.goodCreateBuildRequest.VersionString)
 		suite.Assert().NoError(err)
 
-		// make sure the id's match
+		// make sure the ids match
 		suite.Assert().Equal(existingBuild.ID, result.ID)
 	})
 

--- a/internal/builds/builds_test.go
+++ b/internal/builds/builds_test.go
@@ -96,6 +96,29 @@ func (suite *BuildsIntegrationTestSuite) TestGetByID() {
 	})
 }
 
+func (suite *BuildsIntegrationTestSuite) TestGetByVersionString() {
+	suite.Run("successful looks up existing build by version string", func() {
+		testutils.Cleanup(suite.T(), suite.app.db)
+
+		// create a build instance to look up
+		existingBuild, err := suite.app.builds.CreateNew(suite.goodCreateBuildRequest)
+		suite.Require().NoError(err)
+
+		result, err := suite.app.builds.GetByVersionString(suite.goodCreateBuildRequest.VersionString)
+		suite.Assert().NoError(err)
+
+		// make sure the id's match
+		suite.Assert().Equal(existingBuild.ID, result.ID)
+	})
+
+	suite.Run("errors not found for non-existent version string", func() {
+		testutils.Cleanup(suite.T(), suite.app.db)
+
+		_, err := suite.app.builds.GetByVersionString("does-not-exist")
+		suite.Assert().ErrorIs(err, ErrBuildNotFound)
+	})
+}
+
 type testApplication struct {
 	builds *BuildController
 	db     *gorm.DB

--- a/internal/builds/builds_test.go
+++ b/internal/builds/builds_test.go
@@ -1,6 +1,7 @@
 package builds
 
 import (
+	"database/sql"
 	"testing"
 	"time"
 
@@ -120,6 +121,6 @@ func initTestApp(t *testing.T) *testApplication {
 	dbConn := testutils.ConnectAndMigrate(t)
 	return &testApplication{
 		builds: NewController(dbConn),
-		db:     dbConn.Begin(),
+		db:     dbConn.Begin(&sql.TxOptions{Isolation: sql.LevelRepeatableRead}),
 	}
 }

--- a/internal/builds/builds_test.go
+++ b/internal/builds/builds_test.go
@@ -34,7 +34,7 @@ func (suite *BuildsIntegrationTestSuite) SetupSuite() {
 
 }
 
-func (suite *BuildsIntegrationTestSuite) BeforeTest(suiteName, testName string) {
+func (suite *BuildsIntegrationTestSuite) SetupTest() {
 	// start a new db transaction for each test
 	suite.app = initTestApp(suite.T())
 }

--- a/internal/builds/builds_test.go
+++ b/internal/builds/builds_test.go
@@ -23,7 +23,8 @@ func TestBuildsIntegrationSuite(t *testing.T) {
 	suite.Run(t, new(BuildsIntegrationTestSuite))
 }
 
-func (suite *BuildsIntegrationTestSuite) SetupSuite() {
+func (suite *BuildsIntegrationTestSuite) SetupTest() {
+	// start a new db transaction for each test
 	suite.goodCreateBuildRequest = CreateBuildRequest{
 		VersionString: "docker.io/broad/rawls:12.3.",
 		CommitSha:     "asdfewrf",
@@ -32,12 +33,12 @@ func (suite *BuildsIntegrationTestSuite) SetupSuite() {
 		ServiceName:   "rawls",
 		ServiceRepo:   "github.com/broadinstitute/rawls",
 	}
-
+	suite.app = initTestApp(suite.T())
 }
 
-func (suite *BuildsIntegrationTestSuite) SetupTest() {
-	// start a new db transaction for each test
-	suite.app = initTestApp(suite.T())
+func (suite *BuildsIntegrationTestSuite) TearDownSuite() {
+	// ensure we clean the db at the very end
+	testutils.Cleanup(suite.T(), suite.app.db)
 }
 
 func (suite *BuildsIntegrationTestSuite) TestCreateBuild() {

--- a/internal/builds/builds_test.go
+++ b/internal/builds/builds_test.go
@@ -58,7 +58,7 @@ func (suite *BuildsIntegrationTestSuite) TestCreateBuildEmptyRequest() {
 
 	_, err := suite.app.builds.CreateNew(newBuild)
 
-	suite.Require().Error(err)
+	suite.Assert().ErrorIs(err, ErrBadCreateRequest)
 }
 
 func (suite *BuildsIntegrationTestSuite) TestCreateNonUniqueVersion() {

--- a/internal/builds/builds_test.go
+++ b/internal/builds/builds_test.go
@@ -1,11 +1,11 @@
 package builds
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
 	"github.com/broadinstitute/sherlock/internal/testutils"
+	"github.com/bxcodec/faker/v3"
 	"github.com/stretchr/testify/suite"
 	"gorm.io/gorm"
 )
@@ -26,11 +26,11 @@ func TestBuildsIntegrationSuite(t *testing.T) {
 func (suite *BuildsIntegrationTestSuite) SetupTest() {
 	// start a new db transaction for each test
 	suite.goodCreateBuildRequest = CreateBuildRequest{
-		VersionString: "docker.io/broad/rawls:12.3.",
-		CommitSha:     "asdfewrf",
-		BuildURL:      "https://jenkins.job/1",
+		VersionString: faker.URL(),
+		CommitSha:     faker.UUIDDigit(),
+		BuildURL:      faker.URL(),
 		BuiltAt:       time.Now(),
-		ServiceName:   "rawls",
+		ServiceName:   faker.UUIDHyphenated(),
 		ServiceRepo:   "github.com/broadinstitute/rawls",
 	}
 	suite.app = initTestApp(suite.T())
@@ -113,7 +113,6 @@ func (suite *BuildsIntegrationTestSuite) TestGetByVersionString() {
 
 		// make sure the id's match
 		suite.Assert().Equal(existingBuild.ID, result.ID)
-		fmt.Println(result)
 	})
 
 	suite.Run("errors not found for non-existent version string", func() {

--- a/internal/builds/builds_test.go
+++ b/internal/builds/builds_test.go
@@ -121,6 +121,6 @@ func initTestApp(t *testing.T) *testApplication {
 	dbConn := testutils.ConnectAndMigrate(t)
 	return &testApplication{
 		builds: NewController(dbConn),
-		db:     dbConn.Begin(&sql.TxOptions{Isolation: sql.LevelRepeatableRead}),
+		db:     dbConn.Begin(&sql.TxOptions{Isolation: sql.LevelSerializable}),
 	}
 }

--- a/internal/builds/builds_test.go
+++ b/internal/builds/builds_test.go
@@ -1,6 +1,7 @@
 package builds
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -111,6 +112,7 @@ func (suite *BuildsIntegrationTestSuite) TestGetByVersionString() {
 
 		// make sure the id's match
 		suite.Assert().Equal(existingBuild.ID, result.ID)
+		fmt.Println(result)
 	})
 
 	suite.Run("errors not found for non-existent version string", func() {

--- a/internal/builds/builds_test.go
+++ b/internal/builds/builds_test.go
@@ -23,9 +23,6 @@ func TestBuildsIntegrationSuite(t *testing.T) {
 }
 
 func (suite *BuildsIntegrationTestSuite) SetupSuite() {
-	suite.app = initTestApp(suite.T())
-	// ensure the db is clean before running suite
-	testutils.Cleanup(suite.T(), suite.app.db)
 	suite.goodCreateBuildRequest = CreateBuildRequest{
 		VersionString: "docker.io/broad/rawls:12.3.",
 		CommitSha:     "asdfewrf",
@@ -35,6 +32,11 @@ func (suite *BuildsIntegrationTestSuite) SetupSuite() {
 		ServiceRepo:   "github.com/broadinstitute/rawls",
 	}
 
+}
+
+func (suite *BuildsIntegrationTestSuite) BeforeTest(suiteName, testName string) {
+	// start a new db transaction for each test
+	suite.app = initTestApp(suite.T())
 }
 
 func (suite *BuildsIntegrationTestSuite) TestCreateBuild() {

--- a/internal/builds/builds_test.go
+++ b/internal/builds/builds_test.go
@@ -1,7 +1,6 @@
 package builds
 
 import (
-	"database/sql"
 	"testing"
 	"time"
 
@@ -37,6 +36,8 @@ func (suite *BuildsIntegrationTestSuite) SetupTest() {
 }
 
 func (suite *BuildsIntegrationTestSuite) TearDownTest() {
+	// each test runs in its own isolated transaction
+	// this ensures we cleanup after each test as it completes
 	suite.app.db.Rollback()
 }
 
@@ -119,7 +120,10 @@ type testApplication struct {
 
 func initTestApp(t *testing.T) *testApplication {
 	dbConn := testutils.ConnectAndMigrate(t)
-	dbConn = dbConn.Begin(&sql.TxOptions{Isolation: sql.LevelSerializable})
+	// ensures each test will run in it's own isolated transaction
+	// The transaction will be rolled back after each test
+	// regardless of pass or fail
+	dbConn = dbConn.Begin()
 	return &testApplication{
 		builds: NewController(dbConn),
 		db:     dbConn,

--- a/internal/builds/handlers_test.go
+++ b/internal/builds/handlers_test.go
@@ -433,6 +433,11 @@ func (m *mockBuildStore) getByID(id int) (Build, error) {
 	return retVal.Get(0).(Build), retVal.Error(1)
 }
 
+func (m *mockBuildStore) getByVersionString(versionString string) (Build, error) {
+	retVal := m.Called(versionString)
+	return retVal.Get(0).(Build), retVal.Error(1)
+}
+
 func addBuildRequestToContext(t *testing.T, c *gin.Context, bodyData CreateBuildRequest) {
 	t.Helper()
 

--- a/internal/builds/models.go
+++ b/internal/builds/models.go
@@ -29,7 +29,7 @@ type dataStore struct {
 // Build is the structure used to represent a build entity in sherlock's db persistence layer
 type Build struct {
 	ID            int
-	VersionString string
+	VersionString string `gorm:"not null;default:null"`
 	CommitSha     string
 	BuildURL      string
 	BuiltAt       time.Time `gorm:"autoCreateTime"`
@@ -88,7 +88,7 @@ func (db dataStore) getByID(id int) (Build, error) {
 func (db dataStore) getByVersionString(versionString string) (Build, error) {
 	build := Build{}
 
-	if err := db.Preload("Service").Where(&Build{VersionString: versionString}).Find(&build).Error; err != nil {
+	if err := db.Preload("Service").First(&build, &Build{VersionString: versionString}).Error; err != nil {
 		return Build{}, err
 	}
 

--- a/internal/builds/models.go
+++ b/internal/builds/models.go
@@ -67,7 +67,7 @@ func (db dataStore) createNew(newBuild Build) (Build, error) {
 		if strings.Contains(err.Error(), duplicateVersionStringErrorCheck) {
 			return Build{}, ErrDuplicateVersionString
 		}
-		return Build{}, fmt.Errorf("error persisting new build: %v", err)
+		return Build{}, ErrBadCreateRequest
 	}
 	// retrieve the same build record back from DB so it can be returned with associations updated
 	// gorm will not update the associations in the input struct when performing create operations,

--- a/internal/builds/models.go
+++ b/internal/builds/models.go
@@ -88,7 +88,7 @@ func (db dataStore) getByID(id int) (Build, error) {
 func (db dataStore) getByVersionString(versionString string) (Build, error) {
 	build := Build{}
 
-	if err := db.Preload("Service").Where(&Build{VersionString: versionString}).First(&build).Error; err != nil {
+	if err := db.Preload("Service").Where(&Build{VersionString: versionString}).Find(&build).Error; err != nil {
 		return Build{}, err
 	}
 

--- a/internal/builds/models.go
+++ b/internal/builds/models.go
@@ -43,6 +43,7 @@ type buildStore interface {
 	listAll() ([]Build, error)
 	createNew(Build) (Build, error)
 	getByID(int) (Build, error)
+	getByVersionString(string) (Build, error)
 }
 
 func newBuildStore(dbConn *gorm.DB) dataStore {
@@ -81,5 +82,15 @@ func (db dataStore) getByID(id int) (Build, error) {
 	if err := db.Preload("Service").First(&build, id).Error; err != nil {
 		return Build{}, err
 	}
+	return build, nil
+}
+
+func (db dataStore) getByVersionString(versionString string) (Build, error) {
+	build := Build{}
+
+	if err := db.Preload("Service").Where(&Build{VersionString: versionString}).First(&build).Error; err != nil {
+		return Build{}, err
+	}
+
 	return build, nil
 }

--- a/internal/deploys/deploys.go
+++ b/internal/deploys/deploys.go
@@ -8,9 +8,9 @@ import (
 )
 
 var (
-	// ErrBuildNotFound is returned by the create deploy methhod when trying to create
-	// a deploy of a build that doesn't already exist
-	ErrBuildNotFound = errors.New("unable to create deploy, build does not exist")
+	// ErrServiceMismatch is an error returned when creating a deploy where the build and service instance
+	// reference different service entities.
+	ErrServiceMismatch = errors.New("service referenced by build and service instance do not match")
 )
 
 // DeployController is a type used to contain all the top level functionality for managing

--- a/internal/deploys/deploys.go
+++ b/internal/deploys/deploys.go
@@ -43,8 +43,7 @@ type CreateDeployRequest struct {
 // version string
 func (dc *DeployController) CreateNew(newDeployRequest CreateDeployRequest) (Deploy, error) {
 	// look up the service instance associated with this deploy
-	serviceInstance, err := dc.serviceInsances.GetByEnvironmentAndServiceName(newDeployRequest.EnvironmentName, newDeployRequest.ServiceName)
-	// for now just error if it doesn't exist
+	serviceInstanceID, err := dc.serviceInsances.FindOrCreate(newDeployRequest.EnvironmentName, newDeployRequest.ServiceName)
 	if err != nil {
 		return Deploy{}, err
 	}
@@ -56,5 +55,5 @@ func (dc *DeployController) CreateNew(newDeployRequest CreateDeployRequest) (Dep
 		return Deploy{}, err
 	}
 
-	return dc.store.createDeploy(build.ID, serviceInstance.ID)
+	return dc.store.createDeploy(build.ID, serviceInstanceID)
 }

--- a/internal/deploys/deploys.go
+++ b/internal/deploys/deploys.go
@@ -1,0 +1,60 @@
+package deploys
+
+import (
+	"errors"
+
+	"github.com/broadinstitute/sherlock/internal/builds"
+	"gorm.io/gorm"
+)
+
+var (
+	// ErrBuildNotFound is returned by the create deploy methhod when trying to create
+	// a deploy of a build that doesn't already exist
+	ErrBuildNotFound = errors.New("unable to create deploy, build does not exist")
+)
+
+// DeployController is a type used to contain all the top level functionality for managing
+// Deploy entities.
+type DeployController struct {
+	store           deployStore
+	serviceInsances *ServiceInstanceController
+	builds          *builds.BuildController
+}
+
+// NewDeployController accepts a gorm db connection and returns
+// a controller struct used for the management of deploy entities
+func NewDeployController(dbConn *gorm.DB) *DeployController {
+	return &DeployController{
+		store:           newDeployStore(dbConn),
+		serviceInsances: NewServiceInstanceController(dbConn),
+		builds:          builds.NewController(dbConn),
+	}
+}
+
+// CreateDeployRequest is a struct used to contain all the information
+// that is necessary to provision a new deploy
+type CreateDeployRequest struct {
+	EnvironmentName    string
+	ServiceName        string
+	BuildVersionString string
+}
+
+// CreateNew is used to create a new deploy based on a service name, environment name and build
+// version string
+func (dc *DeployController) CreateNew(newDeployRequest CreateDeployRequest) (Deploy, error) {
+	// look up the service instance associated with this deploy
+	serviceInstance, err := dc.serviceInsances.GetByEnvironmentAndServiceName(newDeployRequest.EnvironmentName, newDeployRequest.ServiceName)
+	// for now just error if it doesn't exist
+	if err != nil {
+		return Deploy{}, err
+	}
+
+	// look up the build based on provided version string
+	build, err := dc.builds.GetByVersionString(newDeployRequest.BuildVersionString)
+	// for now just error if not exists
+	if err != nil {
+		return Deploy{}, err
+	}
+
+	return dc.store.createDeploy(build.ID, serviceInstance.ID)
+}

--- a/internal/deploys/deploys_test.go
+++ b/internal/deploys/deploys_test.go
@@ -1,0 +1,82 @@
+package deploys
+
+import (
+	"testing"
+
+	"github.com/broadinstitute/sherlock/internal/builds"
+	"github.com/broadinstitute/sherlock/internal/testutils"
+	"github.com/bxcodec/faker/v3"
+	"github.com/stretchr/testify/suite"
+	"gorm.io/gorm"
+)
+
+type DeployIntegrationTestSuite struct {
+	suite.Suite
+	app *testDeployController
+}
+
+type testDeployController struct {
+	deploys *DeployController
+	db      *gorm.DB
+}
+
+func initTestDeployController(t *testing.T) *testDeployController {
+	dbConn := testutils.ConnectAndMigrate(t)
+	return &testDeployController{
+		deploys: NewDeployController(dbConn),
+		db:      dbConn,
+	}
+}
+
+func TestDeployIntegrationSuite(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+	suite.Run(t, new(DeployIntegrationTestSuite))
+}
+
+func (suite *DeployIntegrationTestSuite) SetupSuite() {
+	suite.app = initTestDeployController(suite.T())
+	// ensure we start the suite with a clean db
+	testutils.Cleanup(suite.T(), suite.app.db)
+}
+
+func (suite *DeployIntegrationTestSuite) TestCreateDeploy() {
+	suite.Run("creates deploy from pre-existing service instance and build", func() {
+		testutils.Cleanup(suite.T(), suite.app.db)
+
+		// populate a build to deploy
+		existingBuildReq := builds.CreateBuildRequest{
+			VersionString: faker.URL(),
+			CommitSha:     faker.UUIDDigit(),
+			ServiceName:   faker.Word(),
+		}
+		existingBuild, err := suite.app.deploys.builds.CreateNew(existingBuildReq)
+		suite.Require().NoError(err)
+
+		// populate a service instance to deploy to
+		existingServiceInstanceReq := CreateServiceInstanceRequest{
+			EnvironmentName: faker.Word(),
+			ServiceName:     existingBuildReq.ServiceName,
+		}
+		existingServiceInstance, err := suite.app.deploys.serviceInsances.CreateNew(existingServiceInstanceReq)
+		suite.Require().NoError(err)
+
+		// actually create the deploy
+		newDeployReq := CreateDeployRequest{
+			EnvironmentName:    existingServiceInstance.Environment.Name,
+			ServiceName:        existingServiceInstance.Service.Name,
+			BuildVersionString: existingBuild.VersionString,
+		}
+
+		result, err := suite.app.deploys.CreateNew(newDeployReq)
+		suite.Assert().NoError(err)
+
+		// assert the deploy contains expected info from the pre-existing service instance and build
+		suite.Assert().Equal(existingBuildReq.ServiceName, result.Build.Service.Name)
+		// make sure both build and service instance reference the same service
+		suite.Assert().Equal(result.Build.Service.ID, result.ServiceInstance.Service.ID)
+		suite.Assert().Equal(existingBuildReq.VersionString, result.Build.VersionString)
+		suite.Assert().Equal(existingServiceInstanceReq.EnvironmentName, result.ServiceInstance.Environment.Name)
+	})
+}

--- a/internal/deploys/deploys_test.go
+++ b/internal/deploys/deploys_test.go
@@ -23,9 +23,10 @@ type testDeployController struct {
 
 func initTestDeployController(t *testing.T) *testDeployController {
 	dbConn := testutils.ConnectAndMigrate(t)
+	dbConn.Begin(&sql.TxOptions{Isolation: sql.LevelSerializable})
 	return &testDeployController{
 		deploys: NewDeployController(dbConn),
-		db:      dbConn.Begin(&sql.TxOptions{Isolation: sql.LevelSerializable}),
+		db:      dbConn,
 	}
 }
 

--- a/internal/deploys/deploys_test.go
+++ b/internal/deploys/deploys_test.go
@@ -149,6 +149,7 @@ func (suite *DeployIntegrationTestSuite) TestGetDeploysByServiceAndEnvironment()
 		suite.Require().NoError(err)
 
 		result, err := suite.app.deploys.GetDeploysByEnvironmentAndService(newDeployReq.EnvironmentName, newDeployReq.ServiceName)
+		suite.Assert().NoError(err)
 
 		// expect to get one deploy back
 		suite.Assert().Equal(1, len(result))

--- a/internal/deploys/deploys_test.go
+++ b/internal/deploys/deploys_test.go
@@ -109,4 +109,19 @@ func (suite *DeployIntegrationTestSuite) TestCreateDeploy() {
 		suite.Assert().Equal(newDeployReq.EnvironmentName, result.ServiceInstance.Environment.Name)
 		suite.Assert().Equal(newDeployReq.ServiceName, result.ServiceInstance.Service.Name)
 	})
+
+	// there should never be a situation where sherlock tries to register a deploy
+	// of a build that doesn't already exist, so this should error
+	suite.Run("fails if build doesn't exist", func() {
+		testutils.Cleanup(suite.T(), suite.app.db)
+
+		newDeployReq := CreateDeployRequest{
+			EnvironmentName:    faker.Word(),
+			ServiceName:        faker.Word(),
+			BuildVersionString: faker.URL(),
+		}
+
+		_, err := suite.app.deploys.CreateNew(newDeployReq)
+		suite.Assert().ErrorIs(err, builds.ErrBuildNotFound)
+	})
 }

--- a/internal/deploys/deploys_test.go
+++ b/internal/deploys/deploys_test.go
@@ -35,19 +35,9 @@ func TestDeployIntegrationSuite(t *testing.T) {
 	suite.Run(t, new(DeployIntegrationTestSuite))
 }
 
-func (suite *DeployIntegrationTestSuite) SetupSuite() {
-	suite.app = initTestDeployController(suite.T())
-	// ensure we start the suite with a clean db
-	testutils.Cleanup(suite.T(), suite.app.db)
-}
-
 func (suite *DeployIntegrationTestSuite) BeforeTest(suiteName, testName string) {
 	// start a new db transaction for each test
-	suite.app.db = suite.app.db.Begin()
-}
-
-func (suite *DeployIntegrationTestSuite) AfterTest(suiteName, testName string) {
-	suite.app.db = suite.app.db.Rollback()
+	suite.app = initTestDeployController(suite.T())
 }
 
 func (suite *DeployIntegrationTestSuite) TestCreateDeploy() {

--- a/internal/deploys/deploys_test.go
+++ b/internal/deploys/deploys_test.go
@@ -35,14 +35,19 @@ func TestDeployIntegrationSuite(t *testing.T) {
 	suite.Run(t, new(DeployIntegrationTestSuite))
 }
 
-func (suite *DeployIntegrationTestSuite) BeforeTest(suiteName, testName string) {
+func (suite *DeployIntegrationTestSuite) SetupTest() {
 	// start a new db transaction for each test
 	suite.app = initTestDeployController(suite.T())
 }
 
+func (suite *DeployIntegrationTestSuite) TearDownSuite() {
+	// make sure to clean db at the end
+	testutils.Cleanup(suite.T(), suite.app.db)
+}
+
 func (suite *DeployIntegrationTestSuite) TestCreateDeploy() {
 	suite.Run("creates deploy from pre-existing service instance and build", func() {
-
+		testutils.Cleanup(suite.T(), suite.app.db)
 		// populate a build to deploy
 		existingBuildReq := builds.CreateBuildRequest{
 			VersionString: faker.URL(),
@@ -79,6 +84,7 @@ func (suite *DeployIntegrationTestSuite) TestCreateDeploy() {
 	})
 
 	suite.Run("creates service instance if not exists", func() {
+		testutils.Cleanup(suite.T(), suite.app.db)
 
 		// populate a build to deploy
 		existingBuildReq := builds.CreateBuildRequest{
@@ -110,6 +116,7 @@ func (suite *DeployIntegrationTestSuite) TestCreateDeploy() {
 	// there should never be a situation where sherlock tries to register a deploy
 	// of a build that doesn't already exist, so this should error
 	suite.Run("fails if build doesn't exist", func() {
+		testutils.Cleanup(suite.T(), suite.app.db)
 
 		newDeployReq := CreateDeployRequest{
 			EnvironmentName:    faker.Word(),
@@ -124,6 +131,7 @@ func (suite *DeployIntegrationTestSuite) TestCreateDeploy() {
 
 func (suite *DeployIntegrationTestSuite) TestGetDeploysByServiceAndEnvironment() {
 	suite.Run("returns a single deploy", func() {
+		testutils.Cleanup(suite.T(), suite.app.db)
 
 		// populate a build to deploy
 		existingBuildReq := builds.CreateBuildRequest{
@@ -151,6 +159,7 @@ func (suite *DeployIntegrationTestSuite) TestGetDeploysByServiceAndEnvironment()
 	})
 
 	suite.Run("returns multiple deploys", func() {
+		testutils.Cleanup(suite.T(), suite.app.db)
 
 		// populate multiple deploys to search for
 		serviceName := faker.Word()

--- a/internal/deploys/deploys_test.go
+++ b/internal/deploys/deploys_test.go
@@ -1,6 +1,7 @@
 package deploys
 
 import (
+	"database/sql"
 	"testing"
 
 	"github.com/broadinstitute/sherlock/internal/builds"
@@ -24,7 +25,7 @@ func initTestDeployController(t *testing.T) *testDeployController {
 	dbConn := testutils.ConnectAndMigrate(t)
 	return &testDeployController{
 		deploys: NewDeployController(dbConn),
-		db:      dbConn.Begin(),
+		db:      dbConn.Begin(&sql.TxOptions{Isolation: sql.LevelRepeatableRead}),
 	}
 }
 

--- a/internal/deploys/deploys_test.go
+++ b/internal/deploys/deploys_test.go
@@ -75,12 +75,9 @@ func (suite *DeployIntegrationTestSuite) TestCreateDeploy() {
 		result, err := suite.app.deploys.CreateNew(newDeployReq)
 		suite.Assert().NoError(err)
 
-		// assert the deploy contains expected info from the pre-existing service instance and build
-		suite.Assert().Equal(existingBuildReq.ServiceName, result.Build.Service.Name)
 		// make sure both build and service instance reference the same service
-		suite.Assert().Equal(result.Build.Service.ID, result.ServiceInstance.Service.ID)
-		suite.Assert().Equal(existingBuildReq.VersionString, result.Build.VersionString)
-		suite.Assert().Equal(existingServiceInstanceReq.EnvironmentName, result.ServiceInstance.Environment.Name)
+		suite.Assert().Equal(existingBuild.ID, result.BuildID)
+		suite.Assert().Equal(existingServiceInstance.ID, result.ServiceInstanceID)
 	})
 
 	suite.Run("creates service instance if not exists", func() {
@@ -104,13 +101,9 @@ func (suite *DeployIntegrationTestSuite) TestCreateDeploy() {
 		result, err := suite.app.deploys.CreateNew(newDeployReq)
 		suite.Assert().NoError(err)
 
-		// assert the deploy contains expected info from the pre-existing service instance and build
-		suite.Assert().Equal(existingBuildReq.ServiceName, result.Build.Service.Name)
 		// make sure both build and service instance reference the same service
-		suite.Assert().Equal(result.Build.Service.ID, result.ServiceInstance.Service.ID)
-		suite.Assert().Equal(existingBuildReq.VersionString, result.Build.VersionString)
-		suite.Assert().Equal(newDeployReq.EnvironmentName, result.ServiceInstance.Environment.Name)
-		suite.Assert().Equal(newDeployReq.ServiceName, result.ServiceInstance.Service.Name)
+		suite.Assert().Equal(existingBuild.ID, result.BuildID)
+		suite.Assert().NotEqual(0, result.ServiceInstanceID)
 	})
 
 	// there should never be a situation where sherlock tries to register a deploy

--- a/internal/deploys/deploys_test.go
+++ b/internal/deploys/deploys_test.go
@@ -25,7 +25,7 @@ func initTestDeployController(t *testing.T) *testDeployController {
 	dbConn := testutils.ConnectAndMigrate(t)
 	return &testDeployController{
 		deploys: NewDeployController(dbConn),
-		db:      dbConn.Begin(&sql.TxOptions{Isolation: sql.LevelRepeatableRead}),
+		db:      dbConn.Begin(&sql.TxOptions{Isolation: sql.LevelSerializable}),
 	}
 }
 
@@ -59,7 +59,7 @@ func (suite *DeployIntegrationTestSuite) TestCreateDeploy() {
 
 		// populate a service instance to deploy to
 		existingServiceInstanceReq := CreateServiceInstanceRequest{
-			EnvironmentName: faker.Word(),
+			EnvironmentName: faker.UUIDHyphenated(),
 			ServiceName:     existingBuildReq.ServiceName,
 		}
 		existingServiceInstance, err := suite.app.deploys.serviceInstances.CreateNew(existingServiceInstanceReq)

--- a/internal/deploys/mocks.go
+++ b/internal/deploys/mocks.go
@@ -18,8 +18,8 @@ func (m *mockServiceInstanceStore) createNew(serviceID, environmentID int) (Serv
 	return retVal.Get(0).(ServiceInstance), retVal.Error(1)
 }
 
-func (m *mockServiceInstanceStore) getByEnvironmentAndServiceName(environmentName, serviceName string) (ServiceInstance, error) {
-	retVal := m.Called(environmentName, serviceName)
+func (m *mockServiceInstanceStore) getByEnvironmentAndServiceID(environmentID, serviceID int) (ServiceInstance, error) {
+	retVal := m.Called(environmentID, serviceID)
 	return retVal.Get(0).(ServiceInstance), retVal.Error(1)
 }
 

--- a/internal/deploys/models.go
+++ b/internal/deploys/models.go
@@ -35,7 +35,7 @@ type ServiceInstance struct {
 type serviceInstanceStore interface {
 	listAll() ([]ServiceInstance, error)
 	createNew(environmentID int, serviceID int) (ServiceInstance, error)
-	getByEnvironmentAndServiceName(environmentName, serviceName string) (ServiceInstance, error)
+	getByEnvironmentAndServiceID(environmentID, serviceID int) (ServiceInstance, error)
 }
 
 func newServiceInstanceStore(dbConn *gorm.DB) dataStore {
@@ -61,20 +61,10 @@ func (db dataStore) createNew(environmentID, serviceID int) (ServiceInstance, er
 	return newServiceInstance, err
 }
 
-func (db dataStore) getByEnvironmentAndServiceName(environmentName, serviceName string) (ServiceInstance, error) {
+func (db dataStore) getByEnvironmentAndServiceID(environmentID, serviceID int) (ServiceInstance, error) {
 	var serviceInstance ServiceInstance
 
-	// using gorms struct query features to set the WHERE clause
-	queryStruct := ServiceInstance{
-		Environment: environments.Environment{
-			Name: environmentName,
-		},
-		Service: services.Service{
-			Name: serviceName,
-		},
-	}
-
-	err := db.Preload("Service").Preload("Environment").Where(&queryStruct).First(&serviceInstance).Error
+	err := db.Preload("Service").Preload("Environment").Where(&ServiceInstance{ServiceID: serviceID, EnvironmentID: environmentID}).Find(&serviceInstance).Error
 	return serviceInstance, err
 }
 

--- a/internal/deploys/models.go
+++ b/internal/deploys/models.go
@@ -4,13 +4,14 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/broadinstitute/sherlock/internal/builds"
 	"github.com/broadinstitute/sherlock/internal/environments"
 	"github.com/broadinstitute/sherlock/internal/services"
 	"gorm.io/gorm"
 )
 
 var (
-	// ErrServiceNotFound is a wrapper around gorms failed lookup error specifically
+	// ErrServiceInstanceNotFound is a wrapper around gorms failed lookup error specifically
 	// for failure to find a service instance
 	ErrServiceInstanceNotFound = gorm.ErrRecordNotFound
 )
@@ -86,4 +87,46 @@ func (db dataStore) listAll() ([]ServiceInstance, error) {
 	}
 
 	return serviceInstances, nil
+}
+
+// Deploy is the type  defining the database model for a deployment. It is an association
+// between a service instance and a build
+type Deploy struct {
+	ID                int
+	ServiceInstanceID int
+	ServiceInstance   ServiceInstance `gorm:"foreignKey:ServiceInstanceID;references:ID"`
+	BuildID           int
+	Build             builds.Build `gorm:"foreignKey:BuildID;references:ID"`
+	CreatedAt         time.Time
+	UpdatedAt         time.Time
+}
+
+type deployStore interface {
+	createDeploy(buildID, serviceInstanceID int) (Deploy, error)
+}
+
+func newDeployStore(dbConn *gorm.DB) dataStore {
+	return dataStore{dbConn}
+}
+
+func (db dataStore) createDeploy(buildID, serviceInstanceID int) (Deploy, error) {
+	newDeploy := Deploy{
+		ServiceInstanceID: serviceInstanceID,
+		BuildID:           buildID,
+	}
+
+	if err := db.Create(&newDeploy).Error; err != nil {
+		return Deploy{}, err
+	}
+
+	// retrieve the same deploy record back from the db but now with all the
+	// associations populated.
+	err := db.Preload("ServiceInstance").
+		Preload("ServiceInstance.Service").
+		Preload("ServiceInstance.Environment").
+		Preload("Build").
+		Preload("Build.Service").
+		First(&newDeploy, newDeploy.ID).Error
+
+	return newDeploy, err
 }

--- a/internal/deploys/models.go
+++ b/internal/deploys/models.go
@@ -110,6 +110,7 @@ func (db dataStore) createDeploy(buildID, serviceInstanceID int) (Deploy, error)
 func (db dataStore) getDeploysByServiceInstance(serviceInstanceID int) ([]Deploy, error) {
 	var deploys []Deploy
 
+	// TODO: If we ever hit DB bottlenecks this is a likely suspect
 	err := db.Preload("ServiceInstance").
 		Preload("ServiceInstance.Service").
 		Preload("ServiceInstance.Environment").

--- a/internal/deploys/models.go
+++ b/internal/deploys/models.go
@@ -52,19 +52,13 @@ func (db dataStore) createNew(environmentID, serviceID int) (ServiceInstance, er
 		return ServiceInstance{}, fmt.Errorf("error persisting service instance: %v", err)
 	}
 
-	// retrieve the same service instance record back from the db but now with all the
-	// associations populated.
-	err := db.Preload("Service").
-		Preload("Environment").
-		First(&newServiceInstance, newServiceInstance.ID).Error
-
-	return newServiceInstance, err
+	return newServiceInstance, nil
 }
 
 func (db dataStore) getByEnvironmentAndServiceID(environmentID, serviceID int) (ServiceInstance, error) {
 	var serviceInstance ServiceInstance
 
-	err := db.Preload("Service").Preload("Environment").Where(&ServiceInstance{ServiceID: serviceID, EnvironmentID: environmentID}).Find(&serviceInstance).Error
+	err := db.Preload("Service").Preload("Environment").First(&serviceInstance, &ServiceInstance{ServiceID: serviceID, EnvironmentID: environmentID}).Error
 	return serviceInstance, err
 }
 
@@ -110,16 +104,7 @@ func (db dataStore) createDeploy(buildID, serviceInstanceID int) (Deploy, error)
 		return Deploy{}, err
 	}
 
-	// retrieve the same deploy record back from the db but now with all the
-	// associations populated.
-	err := db.Preload("ServiceInstance").
-		Preload("ServiceInstance.Service").
-		Preload("ServiceInstance.Environment").
-		Preload("Build").
-		Preload("Build.Service").
-		First(&newDeploy, newDeploy.ID).Error
-
-	return newDeploy, err
+	return newDeploy, nil
 }
 
 func (db dataStore) getDeploysByServiceInstance(serviceInstanceID int) ([]Deploy, error) {
@@ -130,8 +115,7 @@ func (db dataStore) getDeploysByServiceInstance(serviceInstanceID int) ([]Deploy
 		Preload("ServiceInstance.Environment").
 		Preload("Build").
 		Preload("Build.Service").
-		Where(&Deploy{ServiceInstanceID: serviceInstanceID}).
-		Find(&deploys).
+		Find(&deploys, &Deploy{ServiceInstanceID: serviceInstanceID}).
 		Error
 
 	return deploys, err

--- a/internal/deploys/serviceInstance.go
+++ b/internal/deploys/serviceInstance.go
@@ -65,7 +65,19 @@ func (sic *ServiceInstanceController) CreateNew(newServiceInstance CreateService
 // GetByEnvironmentAndServiceName accepts environment and service names as strings and will return the Service_Instance entity
 // representing the association between them if it exists
 func (sic *ServiceInstanceController) GetByEnvironmentAndServiceName(environmentName, serviceName string) (ServiceInstance, error) {
-	return sic.store.getByEnvironmentAndServiceName(environmentName, serviceName)
+	// retrieve the service id if exists
+	serviceID, exists := sic.services.DoesServiceExist(serviceName)
+	if !exists {
+		return ServiceInstance{}, ErrServiceInstanceNotFound
+	}
+
+	// retrieve environmentID if exists
+	environmentID, exists := sic.environments.DoesEnvironmentExist(environmentName)
+	if !exists {
+		return ServiceInstance{}, ErrServiceInstanceNotFound
+	}
+
+	return sic.store.getByEnvironmentAndServiceID(environmentID, serviceID)
 }
 
 // FindOrCreate will check if a service instance with the given name and environment already exists

--- a/internal/deploys/serviceInstance_test.go
+++ b/internal/deploys/serviceInstance_test.go
@@ -83,8 +83,8 @@ func (suite *ServiceInstanceIntegrationTestSuite) TestCreateServiceInstance() {
 		result, err := suite.app.serviceInstances.CreateNew(newServiceInstanceReq)
 		suite.Require().NoError(err)
 
-		suite.Assert().Equal(preExistingService.Name, result.Service.Name)
-		suite.Assert().Equal(preExistingEnv.Name, result.Environment.Name)
+		suite.Assert().Equal(preExistingService.ID, result.ServiceID)
+		suite.Assert().Equal(preExistingEnv.ID, result.EnvironmentID)
 	})
 
 	suite.Run("creates an environment if not exists", func() {
@@ -102,7 +102,7 @@ func (suite *ServiceInstanceIntegrationTestSuite) TestCreateServiceInstance() {
 		result, err := suite.app.serviceInstances.CreateNew(newServiceInstanceReq)
 		suite.Require().NoError(err)
 
-		suite.Assert().Equal(newServiceInstanceReq.EnvironmentName, result.Environment.Name)
+		suite.Assert().NotEqual(0, result.EnvironmentID)
 	})
 
 	suite.Run("creates a service if not exists", func() {
@@ -120,7 +120,7 @@ func (suite *ServiceInstanceIntegrationTestSuite) TestCreateServiceInstance() {
 		result, err := suite.app.serviceInstances.CreateNew(newServiceInstanceReq)
 		suite.Require().NoError(err)
 
-		suite.Assert().Equal(newServiceInstanceReq.ServiceName, result.Service.Name)
+		suite.Assert().NotEqual(0, result.ServiceID)
 	})
 
 	suite.Run("cannot create the same service instance twice", func() {
@@ -173,7 +173,7 @@ func (suite *ServiceInstanceIntegrationTestSuite) TestGetByEnvironmentAndService
 		result, err := suite.app.serviceInstances.GetByEnvironmentAndServiceName(preExistingEnv.Name, preExistingService.Name)
 		suite.Require().NoError(err)
 
-		suite.Assert().Equal(existingServiceInstance.Environment.Name, result.Environment.Name)
+		suite.Assert().Equal(existingServiceInstance.EnvironmentID, result.EnvironmentID)
 	})
 
 	suite.Run("it returns error not found for non-existent record", func() {

--- a/internal/deploys/serviceInstance_test.go
+++ b/internal/deploys/serviceInstance_test.go
@@ -52,7 +52,7 @@ func initTestApp(t *testing.T) *testApplication {
 	dbConn := testutils.ConnectAndMigrate(t)
 	return &testApplication{
 		serviceInstances: NewServiceInstanceController(dbConn),
-		db:               dbConn.Begin(&sql.TxOptions{Isolation: sql.LevelRepeatableRead}),
+		db:               dbConn.Begin(&sql.TxOptions{Isolation: sql.LevelSerializable}),
 	}
 }
 

--- a/internal/deploys/serviceInstance_test.go
+++ b/internal/deploys/serviceInstance_test.go
@@ -26,7 +26,8 @@ func TestServiceInstanceIntegrationSuite(t *testing.T) {
 	suite.Run(t, new(ServiceInstanceIntegrationTestSuite))
 }
 
-func (suite *ServiceInstanceIntegrationTestSuite) SetupSuite() {
+func (suite *ServiceInstanceIntegrationTestSuite) SetupTest() {
+	suite.app = initTestApp(suite.T())
 	suite.goodEnvironmentReq = environments.CreateEnvironmentRequest{
 		Name: faker.Word(),
 	}
@@ -37,9 +38,8 @@ func (suite *ServiceInstanceIntegrationTestSuite) SetupSuite() {
 	}
 }
 
-func (suite *ServiceInstanceIntegrationTestSuite) BeforeTest(suiteName, testName string) {
-	// start a new db transaction for each test
-	suite.app = initTestApp(suite.T())
+func (suite *ServiceInstanceIntegrationTestSuite) TearDownSuite() {
+	testutils.Cleanup(suite.T(), suite.app.db)
 }
 
 type testApplication struct {

--- a/internal/deploys/serviceInstance_test.go
+++ b/internal/deploys/serviceInstance_test.go
@@ -1,7 +1,6 @@
 package deploys
 
 import (
-	"database/sql"
 	"errors"
 	"testing"
 
@@ -40,6 +39,8 @@ func (suite *ServiceInstanceIntegrationTestSuite) SetupTest() {
 }
 
 func (suite *ServiceInstanceIntegrationTestSuite) TearDownTest() {
+	// each test runs in its own isolated transaction
+	// this ensures we cleanup after each test as it completes
 	suite.app.db.Rollback()
 }
 
@@ -50,7 +51,10 @@ type testApplication struct {
 
 func initTestApp(t *testing.T) *testApplication {
 	dbConn := testutils.ConnectAndMigrate(t)
-	dbConn = dbConn.Begin(&sql.TxOptions{Isolation: sql.LevelSerializable})
+	// ensures each test will run in it's own isolated transaction
+	// The transaction will be rolled back after each test
+	// regardless of pass or fail
+	dbConn = dbConn.Begin()
 	return &testApplication{
 		serviceInstances: NewServiceInstanceController(dbConn),
 		db:               dbConn,

--- a/internal/deploys/serviceInstance_test.go
+++ b/internal/deploys/serviceInstance_test.go
@@ -2,7 +2,6 @@ package deploys
 
 import (
 	"errors"
-	"fmt"
 	"testing"
 
 	"github.com/broadinstitute/sherlock/internal/environments"
@@ -174,7 +173,6 @@ func (suite *ServiceInstanceIntegrationTestSuite) TestGetByEnvironmentAndService
 		suite.Require().NoError(err)
 
 		suite.Assert().Equal(existingServiceInstance.Environment.Name, result.Environment.Name)
-		fmt.Printf("%#v\n", result)
 	})
 
 	suite.Run("it returns error not found for non-existent record", func() {

--- a/internal/deploys/serviceInstance_test.go
+++ b/internal/deploys/serviceInstance_test.go
@@ -34,7 +34,7 @@ func (suite *ServiceInstanceIntegrationTestSuite) SetupTest() {
 	}
 
 	suite.goodServiceReq = services.CreateServiceRequest{
-		Name:    faker.Word(),
+		Name:    faker.UUIDHyphenated(),
 		RepoURL: faker.URL(),
 	}
 }
@@ -50,9 +50,10 @@ type testApplication struct {
 
 func initTestApp(t *testing.T) *testApplication {
 	dbConn := testutils.ConnectAndMigrate(t)
+	dbConn = dbConn.Begin(&sql.TxOptions{Isolation: sql.LevelSerializable})
 	return &testApplication{
 		serviceInstances: NewServiceInstanceController(dbConn),
-		db:               dbConn.Begin(&sql.TxOptions{Isolation: sql.LevelSerializable}),
+		db:               dbConn,
 	}
 }
 

--- a/internal/deploys/serviceInstance_test.go
+++ b/internal/deploys/serviceInstance_test.go
@@ -1,6 +1,7 @@
 package deploys
 
 import (
+	"database/sql"
 	"errors"
 	"testing"
 
@@ -51,7 +52,7 @@ func initTestApp(t *testing.T) *testApplication {
 	dbConn := testutils.ConnectAndMigrate(t)
 	return &testApplication{
 		serviceInstances: NewServiceInstanceController(dbConn),
-		db:               dbConn.Begin(),
+		db:               dbConn.Begin(&sql.TxOptions{Isolation: sql.LevelRepeatableRead}),
 	}
 }
 

--- a/internal/deploys/serviceInstance_test.go
+++ b/internal/deploys/serviceInstance_test.go
@@ -27,10 +27,6 @@ func TestServiceInstanceIntegrationSuite(t *testing.T) {
 }
 
 func (suite *ServiceInstanceIntegrationTestSuite) SetupSuite() {
-	suite.app = initTestApp(suite.T())
-	// ensure the db is clean before running suite
-	testutils.Cleanup(suite.T(), suite.app.db)
-
 	suite.goodEnvironmentReq = environments.CreateEnvironmentRequest{
 		Name: faker.Word(),
 	}
@@ -39,6 +35,11 @@ func (suite *ServiceInstanceIntegrationTestSuite) SetupSuite() {
 		Name:    faker.Word(),
 		RepoURL: faker.URL(),
 	}
+}
+
+func (suite *ServiceInstanceIntegrationTestSuite) BeforeTest(suiteName, testName string) {
+	// start a new db transaction for each test
+	suite.app = initTestApp(suite.T())
 }
 
 type testApplication struct {

--- a/internal/environments/environments_test.go
+++ b/internal/environments/environments_test.go
@@ -3,6 +3,7 @@
 package environments
 
 import (
+	"database/sql"
 	"errors"
 	"testing"
 
@@ -37,12 +38,16 @@ func TestIntegrationEnvironmentsSuite(t *testing.T) {
 func (suite *EnvironmentTestSuite) SetupTest() {
 	suite.testApp = initTestApp(suite.T())
 	suite.goodEnvironmentRequest = CreateEnvironmentRequest{
-		Name: "terra-juyang-opera-fish",
+		Name: faker.UUIDHyphenated(),
 	}
 	suite.anotherEnvironmentRequest = CreateEnvironmentRequest{
-		Name: "terra-mflinn-prime-sawfly",
+		Name: faker.UUIDHyphenated(),
 	}
 	suite.badEnvironmentRequest = CreateEnvironmentRequest{}
+}
+
+func (suite *EnvironmentTestSuite) TearDownTest() {
+	suite.testApp.db.Rollback()
 }
 
 //
@@ -58,14 +63,11 @@ type TestApplication struct {
 // connect to DB and create the Application
 func initTestApp(t *testing.T) *TestApplication {
 	dbConn := testutils.ConnectAndMigrate(t)
-	app := &TestApplication{
+	dbConn = dbConn.Begin(&sql.TxOptions{Isolation: sql.LevelSerializable})
+	return &TestApplication{
 		Environments: NewController(dbConn),
 		db:           dbConn,
 	}
-
-	testutils.Cleanup(t, app.db)
-
-	return app
 }
 
 //
@@ -135,26 +137,28 @@ func (suite *EnvironmentTestSuite) TestIntegrationCreateEnvironments() {
 
 	// Testing Code
 	for _, testCase := range testCases {
+		// creating a temporary test app instance with its own transaction for each
+		// testcase so they don't step on eachother
+		tempApp := initTestApp(suite.T())
 		suite.Run(testCase.name, func() {
-			testutils.Cleanup(suite.T(), suite.testApp.db)
 
 			// create all non-final environments as setup
 			for _, request := range testCase.requests[:len(testCase.requests)-1] {
-				_, err := suite.testApp.Environments.CreateNew(request)
+				_, err := tempApp.Environments.CreateNew(request)
 				assert.NoError(suite.T(), err)
 			}
 
 			// create and test the last environment
-			newEnvironment, err := suite.testApp.Environments.CreateNew(testCase.requests[len(testCase.requests)-1])
+			newEnvironment, err := tempApp.Environments.CreateNew(testCase.requests[len(testCase.requests)-1])
 			assert.Equal(suite.T(), testCase.expectedEnvironment.Name, newEnvironment.Name)
 			assert.Equal(suite.T(), testCase.expectedError, err)
 		})
+		tempApp.db.Rollback()
 	}
 }
 
 func (suite *EnvironmentTestSuite) TestIntegrationEnvironmentGetByName() {
 	suite.Run("GetByName gets an environment by name", func() {
-		testutils.Cleanup(suite.T(), suite.testApp.db)
 
 		_, err := suite.testApp.Environments.CreateNew(suite.goodEnvironmentRequest)
 		assert.NoError(suite.T(), err)
@@ -167,9 +171,11 @@ func (suite *EnvironmentTestSuite) TestIntegrationEnvironmentGetByName() {
 	})
 
 	suite.Run("GetByName returns error if not found", func() {
-		testutils.Cleanup(suite.T(), suite.testApp.db)
+		var envRequest CreateEnvironmentRequest
+		err := faker.FakeData(&envRequest)
+		suite.Require().NoError(err)
 
-		_, err := suite.testApp.Environments.CreateNew(suite.goodEnvironmentRequest)
+		_, err = suite.testApp.Environments.CreateNew(envRequest)
 		assert.NoError(suite.T(), err)
 
 		foundEnvironment, err := suite.testApp.Environments.GetByName("this-doesnt-exist")
@@ -181,45 +187,44 @@ func (suite *EnvironmentTestSuite) TestIntegrationEnvironmentGetByName() {
 
 func (suite *EnvironmentTestSuite) TestIntegrationEnvironmentListAll() {
 	suite.Run("ListAll returns nothing", func() {
-		testutils.Cleanup(suite.T(), suite.testApp.db)
 
 		foundEnvironments, err := suite.testApp.Environments.ListAll()
 
-		assert.Equal(suite.T(), len(foundEnvironments), 0)
+		assert.GreaterOrEqual(suite.T(), len(foundEnvironments), 0)
 		assert.NoError(suite.T(), err)
 	})
 
 	suite.Run("ListAll returns one Environment", func() {
-		testutils.Cleanup(suite.T(), suite.testApp.db)
 
 		_, err := suite.testApp.Environments.CreateNew(suite.goodEnvironmentRequest)
 		assert.NoError(suite.T(), err)
 
 		foundEnvironments, err := suite.testApp.Environments.ListAll()
 
-		assert.Equal(suite.T(), len(foundEnvironments), 1)
-		assert.Equal(suite.T(), foundEnvironments[0].Name, suite.goodEnvironmentRequest.Name)
+		assert.GreaterOrEqual(suite.T(), len(foundEnvironments), 1)
 		assert.NoError(suite.T(), err)
 	})
 
 	suite.Run("ListAll returns many Environments", func() {
-		testutils.Cleanup(suite.T(), suite.testApp.db)
 
-		_, err := suite.testApp.Environments.CreateNew(suite.goodEnvironmentRequest)
+		var randomEnvRequest CreateEnvironmentRequest
+		err := faker.FakeData(&randomEnvRequest)
+		suite.Require().NoError(err)
+
+		_, err = suite.testApp.Environments.CreateNew(randomEnvRequest)
 		assert.NoError(suite.T(), err)
 		_, err = suite.testApp.Environments.CreateNew(suite.anotherEnvironmentRequest)
 		assert.NoError(suite.T(), err)
 
 		foundEnvironments, err := suite.testApp.Environments.ListAll()
 
-		assert.Equal(suite.T(), len(foundEnvironments), 2)
+		assert.GreaterOrEqual(suite.T(), len(foundEnvironments), 3)
 		assert.NoError(suite.T(), err)
 	})
 }
 
 func (suite *EnvironmentTestSuite) TestIntegrationEnvironmentDoesEnvironmentExist() {
 	suite.Run("EnvironmentDoesExist returns true when exists", func() {
-		testutils.Cleanup(suite.T(), suite.testApp.db)
 
 		newEnvironment, _ := suite.testApp.Environments.CreateNew(suite.goodEnvironmentRequest)
 
@@ -230,9 +235,8 @@ func (suite *EnvironmentTestSuite) TestIntegrationEnvironmentDoesEnvironmentExis
 	})
 
 	suite.Run("EnvironmentDoesExist returns false when not exists", func() {
-		testutils.Cleanup(suite.T(), suite.testApp.db)
 
-		_, err := suite.testApp.Environments.CreateNew(suite.goodEnvironmentRequest)
+		_, err := suite.testApp.Environments.CreateNew(suite.anotherEnvironmentRequest)
 		assert.NoError(suite.T(), err)
 
 		environmentID, doesEnvironmentExist := suite.testApp.Environments.DoesEnvironmentExist("no-environment-here")
@@ -246,7 +250,6 @@ func (suite *EnvironmentTestSuite) TestIntegrationEnvironmentDoesEnvironmentExis
 // to expecting the correct response types.
 func (suite *EnvironmentTestSuite) TestIntegrationEnvironmentSerialize() {
 	suite.Run("Serialize returns JSON one environment", func() {
-		testutils.Cleanup(suite.T(), suite.testApp.db)
 
 		newEnvironment, _ := suite.testApp.Environments.CreateNew(suite.goodEnvironmentRequest)
 
@@ -258,7 +261,6 @@ func (suite *EnvironmentTestSuite) TestIntegrationEnvironmentSerialize() {
 	})
 
 	suite.Run("Serialize returns JSON for many environments", func() {
-		testutils.Cleanup(suite.T(), suite.testApp.db)
 
 		var environments []Environment
 		var newEnvironment Environment
@@ -276,7 +278,6 @@ func (suite *EnvironmentTestSuite) TestIntegrationEnvironmentSerialize() {
 	})
 
 	suite.Run("Serialize returns empty environment for bad environments", func() {
-		testutils.Cleanup(suite.T(), suite.testApp.db)
 
 		newEnvironment, _ := suite.testApp.Environments.CreateNew(suite.badEnvironmentRequest)
 		environmentResponses := suite.testApp.Environments.serialize(newEnvironment)
@@ -288,7 +289,6 @@ func (suite *EnvironmentTestSuite) TestIntegrationEnvironmentSerialize() {
 
 func (suite *EnvironmentTestSuite) TestFindOrCreate() {
 	suite.Run("retrieves an environment that already exists", func() {
-		testutils.Cleanup(suite.T(), suite.testApp.db)
 
 		existingEnvironment, err := suite.testApp.Environments.CreateNew(suite.goodEnvironmentRequest)
 		suite.Require().NoError(err)
@@ -300,7 +300,6 @@ func (suite *EnvironmentTestSuite) TestFindOrCreate() {
 	})
 
 	suite.Run("creates a new environment that doesn't exist already", func() {
-		testutils.Cleanup(suite.T(), suite.testApp.db)
 
 		newEnvironmentID, err := suite.testApp.Environments.FindOrCreate(faker.Word())
 		suite.Assert().NoError(err)

--- a/internal/environments/environments_test.go
+++ b/internal/environments/environments_test.go
@@ -194,7 +194,7 @@ func (suite *EnvironmentTestSuite) TestIntegrationEnvironmentListAll() {
 
 		foundEnvironments, err := suite.testApp.Environments.ListAll()
 
-		assert.GreaterOrEqual(suite.T(), len(foundEnvironments), 0)
+		assert.Equal(suite.T(), len(foundEnvironments), 0)
 		assert.NoError(suite.T(), err)
 	})
 
@@ -205,7 +205,8 @@ func (suite *EnvironmentTestSuite) TestIntegrationEnvironmentListAll() {
 
 		foundEnvironments, err := suite.testApp.Environments.ListAll()
 
-		assert.GreaterOrEqual(suite.T(), len(foundEnvironments), 1)
+		assert.Equal(suite.T(), len(foundEnvironments), 1)
+		assert.Equal(suite.T(), foundEnvironments[0].Name, suite.goodEnvironmentRequest.Name)
 		assert.NoError(suite.T(), err)
 	})
 
@@ -222,7 +223,7 @@ func (suite *EnvironmentTestSuite) TestIntegrationEnvironmentListAll() {
 
 		foundEnvironments, err := suite.testApp.Environments.ListAll()
 
-		assert.GreaterOrEqual(suite.T(), len(foundEnvironments), 3)
+		assert.Equal(suite.T(), len(foundEnvironments), 3)
 		assert.NoError(suite.T(), err)
 	})
 }

--- a/internal/services/services_test.go
+++ b/internal/services/services_test.go
@@ -64,7 +64,7 @@ func (suite *ServicesIntegrationTestSuite) TestListServices() {
 
 		services, err := suite.app.services.ListAll()
 
-		suite.Assert().Equal(0, len(services))
+		suite.Assert().GreaterOrEqual(len(services), 0)
 		suite.Assert().NoError(err)
 	})
 
@@ -80,8 +80,7 @@ func (suite *ServicesIntegrationTestSuite) TestListServices() {
 
 		services, err := suite.app.services.ListAll()
 
-		suite.Assert().Equal(1, len(services))
-		suite.Assert().Equal(services[0].Name, newService.Name)
+		suite.Assert().GreaterOrEqual(len(services), 1)
 		suite.Assert().NoError(err)
 	})
 
@@ -101,7 +100,7 @@ func (suite *ServicesIntegrationTestSuite) TestListServices() {
 		services, err := suite.app.services.ListAll()
 		suite.Require().NoError(err)
 
-		suite.Assert().Equal(4, len(services))
+		suite.Assert().GreaterOrEqual(len(services), 4)
 	})
 }
 

--- a/internal/services/services_test.go
+++ b/internal/services/services_test.go
@@ -14,9 +14,12 @@ type ServicesIntegrationTestSuite struct {
 	app *testApplication
 }
 
-func (suite *ServicesIntegrationTestSuite) SetupSuite() {
+func (suite *ServicesIntegrationTestSuite) SetupTest() {
 	suite.app = initTestApp(suite.T())
-	// ensure the db is clean before running suite
+}
+
+func (suite *ServicesIntegrationTestSuite) TearDownSuite() {
+	// ensure we clean the db at end of suite
 	testutils.Cleanup(suite.T(), suite.app.db)
 }
 

--- a/internal/services/services_test.go
+++ b/internal/services/services_test.go
@@ -1,7 +1,6 @@
 package services
 
 import (
-	"database/sql"
 	"testing"
 
 	"github.com/broadinstitute/sherlock/internal/testutils"
@@ -20,7 +19,8 @@ func (suite *ServicesIntegrationTestSuite) SetupTest() {
 }
 
 func (suite *ServicesIntegrationTestSuite) TearDownTest() {
-	// ensure we clean the db at end of suite
+	// each test runs in its own isolated transaction
+	// this ensures we cleanup after each test as it completes
 	suite.app.db.Rollback()
 }
 
@@ -176,7 +176,10 @@ type testApplication struct {
 
 func initTestApp(t *testing.T) *testApplication {
 	dbConn := testutils.ConnectAndMigrate(t)
-	dbConn = dbConn.Begin(&sql.TxOptions{Isolation: sql.LevelSerializable})
+	// ensures each test will run in it's own isolated transaction
+	// The transaction will be rolled back after each test
+	// regardless of pass or fail
+	dbConn = dbConn.Begin()
 	return &testApplication{
 		services: NewController(dbConn),
 		db:       dbConn,

--- a/internal/services/services_test.go
+++ b/internal/services/services_test.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"database/sql"
 	"testing"
 
 	"github.com/broadinstitute/sherlock/internal/testutils"
@@ -18,9 +19,9 @@ func (suite *ServicesIntegrationTestSuite) SetupTest() {
 	suite.app = initTestApp(suite.T())
 }
 
-func (suite *ServicesIntegrationTestSuite) TearDownSuite() {
+func (suite *ServicesIntegrationTestSuite) TearDownTest() {
 	// ensure we clean the db at end of suite
-	testutils.Cleanup(suite.T(), suite.app.db)
+	suite.app.db.Rollback()
 }
 
 func (suite *ServicesIntegrationTestSuite) TestCreateService() {
@@ -187,6 +188,6 @@ func initTestApp(t *testing.T) *testApplication {
 	dbConn := testutils.ConnectAndMigrate(t)
 	return &testApplication{
 		services: NewController(dbConn),
-		db:       dbConn,
+		db:       dbConn.Begin(&sql.TxOptions{Isolation: sql.LevelRepeatableRead}),
 	}
 }

--- a/internal/services/services_test.go
+++ b/internal/services/services_test.go
@@ -64,7 +64,7 @@ func (suite *ServicesIntegrationTestSuite) TestListServices() {
 
 		services, err := suite.app.services.ListAll()
 
-		suite.Assert().GreaterOrEqual(len(services), 0)
+		suite.Assert().Equal(len(services), 0)
 		suite.Assert().NoError(err)
 	})
 
@@ -80,7 +80,8 @@ func (suite *ServicesIntegrationTestSuite) TestListServices() {
 
 		services, err := suite.app.services.ListAll()
 
-		suite.Assert().GreaterOrEqual(len(services), 1)
+		suite.Assert().Equal(len(services), 1)
+		suite.Assert().Equal(newService.Name, services[0].Name)
 		suite.Assert().NoError(err)
 	})
 
@@ -100,7 +101,7 @@ func (suite *ServicesIntegrationTestSuite) TestListServices() {
 		services, err := suite.app.services.ListAll()
 		suite.Require().NoError(err)
 
-		suite.Assert().GreaterOrEqual(len(services), 4)
+		suite.Assert().Equal(len(services), 4)
 	})
 }
 

--- a/internal/services/services_test.go
+++ b/internal/services/services_test.go
@@ -154,7 +154,7 @@ func (suite *ServicesIntegrationTestSuite) TestFindOrCreate() {
 
 	suite.Run("creates service if not exists", func() {
 
-		newServiceID, err := suite.app.services.FindOrCreate(faker.Word())
+		newServiceID, err := suite.app.services.FindOrCreate(faker.UUIDHyphenated())
 		suite.Assert().NoError(err)
 		// assert the service was actually created by verifying its ID is non-zero
 		suite.Assert().NotEqual(0, newServiceID)

--- a/internal/services/services_test.go
+++ b/internal/services/services_test.go
@@ -102,7 +102,7 @@ func (suite *ServicesIntegrationTestSuite) TestListServices() {
 		services, err := suite.app.services.ListAll()
 		suite.Require().NoError(err)
 
-		suite.Assert().Equal(len(services), 3)
+		suite.Assert().Equal(3, len(services))
 	})
 }
 

--- a/internal/services/services_test.go
+++ b/internal/services/services_test.go
@@ -71,7 +71,7 @@ func (suite *ServicesIntegrationTestSuite) TestListServices() {
 		suite.Assert().NoError(err)
 	})
 
-	suite.Run("ListAll returns one Environment", func() {
+	suite.Run("ListAll returns one service", func() {
 		testutils.Cleanup(suite.T(), suite.app.db)
 
 		newService := CreateServiceRequest{
@@ -89,7 +89,7 @@ func (suite *ServicesIntegrationTestSuite) TestListServices() {
 		suite.Assert().NoError(err)
 	})
 
-	suite.Run("ListAll returns multiple environments", func() {
+	suite.Run("ListAll returns multiple services", func() {
 		testutils.Cleanup(suite.T(), suite.app.db)
 
 		// populate multiple services
@@ -188,6 +188,6 @@ func initTestApp(t *testing.T) *testApplication {
 	dbConn := testutils.ConnectAndMigrate(t)
 	return &testApplication{
 		services: NewController(dbConn),
-		db:       dbConn.Begin(&sql.TxOptions{Isolation: sql.LevelRepeatableRead}),
+		db:       dbConn.Begin(&sql.TxOptions{Isolation: sql.LevelSerializable}),
 	}
 }

--- a/internal/testutils/integrationHelpers.go
+++ b/internal/testutils/integrationHelpers.go
@@ -26,13 +26,12 @@ var (
 func initConfig() {
 	config.SetEnvPrefix("sherlock")
 
-	config.SetDefault("dbhost", "localhost")
+	config.SetDefault("dbhost", "postgres")
 	config.SetDefault("dbuser", "sherlock")
 	config.SetDefault("dbname", "sherlock")
 	config.SetDefault("dbport", "5432")
 	config.SetDefault("dbssl", "disable")
 	config.SetDefault("dbinit", true)
-	config.SetDefault("dbpassword", "password")
 
 	config.AutomaticEnv()
 }

--- a/internal/testutils/integrationHelpers.go
+++ b/internal/testutils/integrationHelpers.go
@@ -84,6 +84,6 @@ func Truncate(db *gorm.DB) error {
 // ensure each case starts with a clean database
 func Cleanup(t *testing.T, dbConn *gorm.DB) {
 	if err := Truncate(dbConn); err != nil {
-		t.Fatalf("error cleaning db after test run: %v", err)
+		t.Logf("error cleaning db after test run: %v", err)
 	}
 }

--- a/internal/testutils/integrationHelpers.go
+++ b/internal/testutils/integrationHelpers.go
@@ -26,12 +26,13 @@ var (
 func initConfig() {
 	config.SetEnvPrefix("sherlock")
 
-	config.SetDefault("dbhost", "postgres")
+	config.SetDefault("dbhost", "localhost")
 	config.SetDefault("dbuser", "sherlock")
 	config.SetDefault("dbname", "sherlock")
 	config.SetDefault("dbport", "5432")
 	config.SetDefault("dbssl", "disable")
 	config.SetDefault("dbinit", true)
+	config.SetDefault("dbpassword", "password")
 
 	config.AutomaticEnv()
 }

--- a/makefile
+++ b/makefile
@@ -21,11 +21,11 @@ tests-with-coverage:
 	docker run --name test-postgres -e POSTGRES_PASSWORD=password -e POSTGRES_USER=sherlock -d -p 5432:5432 postgres:13
 	export SHERLOCK_DBHOST="localhost" && export SHERLOCK_DBPASSWORD="password" && go test -v -race -coverprofile=cover.out -covermode=atomic ./...
 	docker stop test-postgres
-	docker rm test-postgres
+	docker rm -f -v test-postgres
 
 make pg-up:
 	docker run --name test-postgres -e POSTGRES_PASSWORD=password -e POSTGRES_USER=sherlock -d -p 5432:5432 postgres:13
 
 pg-down:
 	docker stop test-postgres
-	docker rm test-postgres
+	docker rm -f -v test-postgres

--- a/makefile
+++ b/makefile
@@ -23,6 +23,9 @@ tests-with-coverage:
 	docker stop test-postgres
 	docker rm test-postgres
 
+make pg-up:
+	docker run --name test-postgres -e POSTGRES_PASSWORD=password -e POSTGRES_USER=sherlock -d -p 5432:5432 postgres:13
+
 pg-down:
 	docker stop test-postgres
 	docker rm test-postgres


### PR DESCRIPTION
Ok, so there is a bit of chonk here as implementing the core functionality for this ticket exposed some issues in our integration test suite. 

This PR essentially does 2 things.
1. It implements the core control plane functionality to track deploy entities. These are the essential component to calculating accelerate metrics. They are essentially an association between a service, environment, and build version at a point in time. It is this functionality that will be instrumented to track metrics like deploy frequency and lead time to prod.
2. The deploy tracking functionality involves some more heavyweight database operations. This exposed some previously unnoticed database race conditions in our integration test suite. This pr also fixes those data base race conditions. It accomplishes this by running each test in its own isolated transaction that gets rolled back after the test completes. Also any logic in tests that previously expected an empty database has been removed, this more closely mirrors an actual database anyways. I nice side effect of this improvement is that the tests can all be run in parallel now without stepping on each other. 