### PR TITLE
DDO-1602 CLI command for creating deploys

### DIFF
--- a/internal/cli/createBuild.go
+++ b/internal/cli/createBuild.go
@@ -67,7 +67,7 @@ func createBuild(cmd *cobra.Command, args []string) error {
 
 	result, rawResponseBody, err := dispatchCreateBuildRequest(newBuild)
 	if err != nil {
-		return fmt.Errorf("ERROR: %V", err)
+		return fmt.Errorf("ERROR: %v", err)
 	}
 
 	// check for errors returned in response

--- a/internal/cli/createDeploy.go
+++ b/internal/cli/createDeploy.go
@@ -1,0 +1,91 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"github.com/broadinstitute/sherlock/internal/deploys"
+	"github.com/go-resty/resty/v2"
+	"github.com/spf13/cobra"
+)
+
+const (
+	deployEnvironmentNameHelpText = "the name of the environment being deployed to"
+	deployServiceNameHelpText     = "the name of the service that is being deployed"
+)
+
+var (
+	deployEnvironmentName string
+	deployServiceName     string
+	createDeployCmd       = &cobra.Command{
+		Use:   "create",
+		Short: "create a new deploy",
+		Long:  `creates a new deploy of service which will be tracked by sherlock.`,
+
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 1 {
+				return errInvalidArgs
+			}
+			return nil
+		},
+		RunE: createDeploy,
+	}
+)
+
+func init() {
+	createDeployCmd.Flags().StringVar(&deployEnvironmentName, "enivronment", "", deployEnvironmentNameHelpText)
+	_ = createDeployCmd.MarkFlagRequired("environment")
+
+	createDeployCmd.Flags().StringVar(&deployServiceName, "service", "", deployServiceNameHelpText)
+	_ = createDeployCmd.MarkFlagRequired("service")
+
+	deployCmd.AddCommand(createDeployCmd)
+}
+
+func createDeploy(cmd *cobra.Command, args []string) error {
+	// version string ie docker image url and tag is passed as first
+	// positional arg
+	versionString := args[0]
+	newDeployRequest := deploys.CreateDeployRequestBody{
+		VersionString: versionString,
+	}
+
+	result, rawResponseBody, err := dispatchCreateDeployRequest(newDeployRequest, deployEnvironmentName, deployServiceName)
+	if err != nil {
+		return fmt.Errorf("ERROR: %v", err)
+	}
+
+	// check for errors returned in response
+	if result.Error != "" {
+		return fmt.Errorf("ERROR: %v", result.Error)
+	}
+
+	// pretty print the sherlock api response
+	var prettyResult bytes.Buffer
+	if err := json.Indent(&prettyResult, rawResponseBody, "", "  "); err != nil {
+		return fmt.Errorf("error pretty formatting response body: %v", err)
+	}
+
+	fmt.Fprint(cmd.OutOrStdout(), prettyResult.String())
+	return nil
+}
+func dispatchCreateDeployRequest(newDeploy deploys.CreateDeployRequestBody, environment, service string) (*deploys.Response, []byte, error) {
+	client := resty.New()
+	urlPath := fmt.Sprintf("%s/%s/%s", sherlockServerURL, environment, service)
+	resp, err := client.R().
+		SetHeader("Content-Type", "application/json").
+		SetBody(newDeploy).
+		Post(urlPath)
+	if err != nil {
+		return nil, []byte{}, fmt.Errorf("ERROR sending POST deploy request: %v", err)
+	}
+
+	var result deploys.Response
+	responseBodyBytes := bytes.NewBuffer(resp.Body())
+	if err := json.NewDecoder(responseBodyBytes).Decode(&result); err != nil {
+		return nil, []byte{}, fmt.Errorf("error parsing create deploy response: %v", err)
+	}
+
+	return &result, resp.Body(), nil
+}

--- a/internal/cli/createDeploy.go
+++ b/internal/cli/createDeploy.go
@@ -34,7 +34,7 @@ var (
 )
 
 func init() {
-	createDeployCmd.Flags().StringVar(&deployEnvironmentName, "enivronment", "", deployEnvironmentNameHelpText)
+	createDeployCmd.Flags().StringVar(&deployEnvironmentName, "environment", "", deployEnvironmentNameHelpText)
 	_ = createDeployCmd.MarkFlagRequired("environment")
 
 	createDeployCmd.Flags().StringVar(&deployServiceName, "service", "", deployServiceNameHelpText)
@@ -72,7 +72,7 @@ func createDeploy(cmd *cobra.Command, args []string) error {
 }
 func dispatchCreateDeployRequest(newDeploy deploys.CreateDeployRequestBody, environment, service string) (*deploys.Response, []byte, error) {
 	client := resty.New()
-	urlPath := fmt.Sprintf("%s/%s/%s", sherlockServerURL, environment, service)
+	urlPath := fmt.Sprintf("%s/deploys/%s/%s", sherlockServerURL, environment, service)
 	resp, err := client.R().
 		SetHeader("Content-Type", "application/json").
 		SetBody(newDeploy).

--- a/internal/cli/createDeploy.go
+++ b/internal/cli/createDeploy.go
@@ -70,6 +70,7 @@ func createDeploy(cmd *cobra.Command, args []string) error {
 	fmt.Fprint(cmd.OutOrStdout(), prettyResult.String())
 	return nil
 }
+
 func dispatchCreateDeployRequest(newDeploy deploys.CreateDeployRequestBody, environment, service string) (*deploys.Response, []byte, error) {
 	client := resty.New()
 	urlPath := fmt.Sprintf("%s/deploys/%s/%s", sherlockServerURL, environment, service)

--- a/internal/cli/createDeploy_test.go
+++ b/internal/cli/createDeploy_test.go
@@ -1,0 +1,130 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/broadinstitute/sherlock/internal/builds"
+	"github.com/broadinstitute/sherlock/internal/deploys"
+	"github.com/broadinstitute/sherlock/internal/environments"
+	"github.com/broadinstitute/sherlock/internal/services"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_createDeployCommand(t *testing.T) {
+	testCases := []struct {
+		name               string
+		cliArgs            []string
+		mockServerResponse http.HandlerFunc
+		expectError        error
+	}{
+		{
+			name: "successful create",
+			cliArgs: []string{
+				"deploys",
+				"create",
+				"docker.io/my-repo/my-app:1.0.0",
+				"--environment",
+				"dev",
+				"--service",
+				"my-app",
+			},
+			mockServerResponse: func(w http.ResponseWriter, r *http.Request) {
+				_ = json.NewEncoder(w).Encode(&deploys.Response{
+					Deploys: []deploys.DeployResponse{
+						{
+							ID: 1,
+							ServiceInstance: deploys.ServiceInstanceResponse{
+								ID: 1,
+								Service: services.ServiceResponse{
+									ID:   1,
+									Name: "my-app",
+								},
+								Environment: environments.EnvironmentResponse{
+									ID:   1,
+									Name: "dev",
+								},
+							},
+							Build: builds.BuildResponse{
+								ID:            1,
+								VersionString: "docker.io/my-repo/my-app:1.0.0",
+								BuiltAt:       time.Now(),
+								Service: services.ServiceResponse{
+									ID:   1,
+									Name: "my-app",
+								},
+							},
+						},
+					},
+				})
+			},
+			expectError: nil,
+		},
+		{
+			name: "error from server",
+			cliArgs: []string{
+				"deploys",
+				"create",
+				"gcr.io./broad/test-service:1.0.0",
+				"--environment",
+				"qa",
+				"--service",
+				"test-service",
+			},
+			mockServerResponse: func(w http.ResponseWriter, r *http.Request) {
+				_ = json.NewEncoder(w).Encode(&builds.Response{
+					Error: "some error from sherlock server",
+				})
+			},
+			expectError: errors.New("some error from sherlock server"),
+		},
+		{
+			name: "unparseable response",
+			cliArgs: []string{
+				"deploys",
+				"create",
+				"gcr.io./broad/test-service:1.0.0",
+				"--environment",
+				"terra-prod",
+				"--service",
+				"cromwell",
+			},
+			mockServerResponse: func(w http.ResponseWriter, r *http.Request) {
+				fmt.Fprint(w, "invalid response")
+			},
+			expectError: errors.New("error parsing create deploy response"),
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			// set up a mock server of the sherlock api
+			testServer := httptest.NewServer(testCase.mockServerResponse)
+
+			sherlockServerURL = testServer.URL
+			output, _ := executeCommand(rootCmd, "deploys", "create", testCase.cliArgs[2], "--environment", testCase.cliArgs[4], "--service", testCase.cliArgs[6])
+			outputBytes := bytes.NewBufferString(output)
+
+			if testCase.expectError == nil {
+				// parse the output back into a builds.Response so that we can examine it
+				var cliResponse deploys.Response
+				if err := json.NewDecoder(outputBytes).Decode(&cliResponse); err != nil {
+					t.Errorf("error decoding cli output: %v", err)
+				}
+
+				assert.Equal(t, cliResponse.Deploys[0].ServiceInstance.Environment.Name, testCase.cliArgs[4])
+				assert.Equal(t, cliResponse.Deploys[0].ServiceInstance.Service.Name, testCase.cliArgs[6])
+				assert.Equal(t, cliResponse.Deploys[0].Build.VersionString, testCase.cliArgs[2])
+			} else {
+				assert.Contains(t, output, testCase.expectError.Error())
+			}
+		})
+	}
+
+}

--- a/internal/cli/deploys.go
+++ b/internal/cli/deploys.go
@@ -1,0 +1,19 @@
+package cli
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var (
+	deployCmd = &cobra.Command{
+		Use:   "deploys",
+		Short: "deploys is a group of commands for interacting with sherlock deploy events",
+		Long: `deploys contains a group of commands for viewing existing builds and creating new deploys.
+Currently supported commands:
+	1. create - creates a new deploy event`,
+	}
+)
+
+func init() {
+	rootCmd.AddCommand(deployCmd)
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -35,7 +35,7 @@ func init() {
 	cobra.OnInitialize(initConfig)
 
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.sherlock.yaml")
-	rootCmd.PersistentFlags().StringVar(&sherlockServerURL, "sherlock-url", "http://localhost:8080", "Address of the sherlock server")
+	rootCmd.PersistentFlags().StringVar(&sherlockServerURL, "sherlock-url", "https://sherlock.dsp-devops.broadinstitute.org", "Address of the sherlock server")
 
 	err := viper.BindPFlags(rootCmd.PersistentFlags())
 	cobra.CheckErr(err)

--- a/internal/testutils/integrationHelpers.go
+++ b/internal/testutils/integrationHelpers.go
@@ -26,13 +26,12 @@ var (
 func initConfig() {
 	config.SetEnvPrefix("sherlock")
 
-	config.SetDefault("dbhost", "localhost")
+	config.SetDefault("dbhost", "postgres")
 	config.SetDefault("dbuser", "sherlock")
 	config.SetDefault("dbname", "sherlock")
 	config.SetDefault("dbport", "5432")
 	config.SetDefault("dbssl", "disable")
 	config.SetDefault("dbinit", true)
-	config.SetDefault("dbpassword", "password")
 
 	config.AutomaticEnv()
 }


### PR DESCRIPTION
This pr implements the `sherlock deploys create` functionality in sherlock's cli interface. This is essentially a POST to sherlock's `deploys/:environment/:service` endpoint.