### PR TITLE
[No Ticket] Set Sane Default for the host value in DB connection config

### DIFF
--- a/build/local/server/docker-compose.yaml
+++ b/build/local/server/docker-compose.yaml
@@ -14,6 +14,7 @@ services:
     environment: 
       SHERLOCK_DBINIT: "true"
       SHERLOCK_DBPASSWORD: "password"
+      SHERLOCK_DBHOST: "postgres"
     depends_on:
       - database
     networks: 

--- a/internal/sherlock/sherlock.go
+++ b/internal/sherlock/sherlock.go
@@ -89,7 +89,7 @@ func init() {
 	// into config
 	Config.SetEnvPrefix("sherlock")
 
-	Config.SetDefault("dbhost", "postgres")
+	Config.SetDefault("dbhost", "localhost")
 	Config.SetDefault("dbuser", "sherlock")
 	Config.SetDefault("dbname", "sherlock")
 	Config.SetDefault("dbport", "5432")

--- a/internal/testutils/integrationHelpers.go
+++ b/internal/testutils/integrationHelpers.go
@@ -26,7 +26,7 @@ var (
 func initConfig() {
 	config.SetEnvPrefix("sherlock")
 
-	config.SetDefault("dbhost", "postgres")
+	config.SetDefault("dbhost", "localhost")
 	config.SetDefault("dbuser", "sherlock")
 	config.SetDefault("dbname", "sherlock")
 	config.SetDefault("dbport", "5432")

--- a/makefile
+++ b/makefile
@@ -10,7 +10,7 @@ local-down:
 # not sure if this is good make style but it works for now
 integration-test:
 	docker run --name test-postgres -e POSTGRES_PASSWORD=password -e POSTGRES_USER=sherlock -d -p 5432:5432 postgres:13
-	export SHERLOCK_DBHOST="localhost" && export SHERLOCK_DBPASSWORD="password" && go test -v -race ./...
+	export SHERLOCK_DBPASSWORD="password" && go test -v -race ./...
 	docker stop test-postgres
 	docker rm test-postgres
 
@@ -19,7 +19,7 @@ unit-test:
 
 tests-with-coverage:
 	docker run --name test-postgres -e POSTGRES_PASSWORD=password -e POSTGRES_USER=sherlock -d -p 5432:5432 postgres:13
-	export SHERLOCK_DBHOST="localhost" && export SHERLOCK_DBPASSWORD="password" && go test -v -race -coverprofile=cover.out -covermode=atomic ./...
+	export SHERLOCK_DBPASSWORD="password" && go test -v -race -coverprofile=cover.out -covermode=atomic ./...
 	docker stop test-postgres
 	docker rm -f -v test-postgres
 


### PR DESCRIPTION
The default of `postgres` as the host value in the postgres connection string was set to support some now deprecated patterns in sherlock's development. Setting a sane default of `localhost` instead since that is what the integration testing tooling and cloudsql proxy use.