### PR TITLE
DDO-1658 Support Auth in CLI

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	golang.org/x/oauth2 v0.0.0-20211005180243-6b3c2da341f1 // indirect
 	golang.org/x/sys v0.0.0-20211007075335-d3039528d8ac // indirect
 	golang.org/x/text v0.3.7 // indirect
-	google.golang.org/api v0.58.0 // indirect
+	google.golang.org/api v0.59.0 // indirect
 	google.golang.org/genproto v0.0.0-20211008145708-270636b82663 // indirect
 	google.golang.org/grpc v1.41.0 // indirect
 	gorm.io/driver/postgres v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -1072,6 +1072,8 @@ google.golang.org/api v0.56.0/go.mod h1:38yMfeP1kfjsl8isn0tliTjIb1rJXcQi4UXlbqiv
 google.golang.org/api v0.57.0/go.mod h1:dVPlbZyBo2/OjBpmvNdpn2GRm6rPy75jyU7bmhdrMgI=
 google.golang.org/api v0.58.0 h1:MDkAbYIB1JpSgCTOCYYoIec/coMlKK4oVbpnBLLcyT0=
 google.golang.org/api v0.58.0/go.mod h1:cAbP2FsxoGVNwtgNAmmn3y5G1TWAiVYRmg4yku3lv+E=
+google.golang.org/api v0.59.0 h1:fPfFO7gttlXYo2ALuD3HxJzh8vaF++4youI0BkFL6GE=
+google.golang.org/api v0.59.0/go.mod h1:sT2boj7M9YJxZzgeZqXogmhfmRWDtPzT31xkieUbuZU=
 google.golang.org/appengine v1.0.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.2.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -9,9 +9,11 @@ import (
 )
 
 var (
-	cfgFile           string
-	sherlockServerURL string
-	rootCmd           = &cobra.Command{
+	cfgFile               string
+	sherlockServerURL     string
+	clientCredentials     string
+	useServiceAccountAuth bool
+	rootCmd               = &cobra.Command{
 		Use:   "sherlock",
 		Short: "sherlock tracks and manages Terra's environments",
 		Long: `Sherlock is an inventory and tracking service for Terra's
@@ -36,6 +38,8 @@ func init() {
 
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.sherlock.yaml")
 	rootCmd.PersistentFlags().StringVar(&sherlockServerURL, "sherlock-url", "https://sherlock.dsp-devops.broadinstitute.org", "Address of the sherlock server")
+	rootCmd.PersistentFlags().StringVar(&clientCredentials, "credentials-file", "/app/sherlock/client-sa.json", "Path to the file containing service account credentials for auth in automated workflows")
+	rootCmd.PersistentFlags().BoolVar(&useServiceAccountAuth, "use-sa-auth", false, "Whether or not to use service account credentials for oauth")
 
 	err := viper.BindPFlags(rootCmd.PersistentFlags())
 	cobra.CheckErr(err)


### PR DESCRIPTION
This PR adds support for using google's [idtoken](https://pkg.go.dev/google.golang.org/api/idtoken#pkg-index) package to support authenticating the sherlock CLI via a service account for automated workflow runs. This auth mechanism is disbaled by default and must be opted into with the `--use-sa-auth` flag