### PR TITLE
DDO-1684 Fix for Artificially increasing lead times

### DIFF
--- a/internal/deploys/deploys.go
+++ b/internal/deploys/deploys.go
@@ -79,6 +79,16 @@ func (dc *DeployController) GetDeploysByEnvironmentAndService(environmentName, s
 	return dc.store.getDeploysByServiceInstance(serviceInstance.ID)
 }
 
+// GetMostRecentDeploy will look up the most recent ie currently active deploy for a given service instance
+func (dc *DeployController) GetMostRecentDeploy(environmentName, serviceName string) (Deploy, error) {
+	serviceInstance, err := dc.serviceInstances.GetByEnvironmentAndServiceName(environmentName, serviceName)
+	if err != nil {
+		return Deploy{}, ErrServiceInstanceNotFound
+	}
+
+	return dc.store.getMostRecentDeployByServiceInstance(serviceInstance.ID)
+}
+
 // Serialize takes a variable number of deploy entities and serializes them into types suitable for use in
 // client responses
 func (dc *DeployController) Serialize(deploy ...Deploy) []DeployResponse {

--- a/internal/deploys/models.go
+++ b/internal/deploys/models.go
@@ -15,6 +15,9 @@ var (
 	// ErrServiceInstanceNotFound is a wrapper around gorms failed lookup error specifically
 	// for failure to find a service instance
 	ErrServiceInstanceNotFound = gorm.ErrRecordNotFound
+	// ErrDeployNotFound is a wrapper around gorms failed lookup error specifically
+	// for failure to find a service instance
+	ErrDeployNotFound = gorm.ErrRecordNotFound
 )
 
 type dataStore struct {
@@ -118,6 +121,7 @@ type Deploy struct {
 type deployStore interface {
 	createDeploy(buildID, serviceInstanceID int) (Deploy, error)
 	getDeploysByServiceInstance(serviceInstanceID int) ([]Deploy, error)
+	getMostRecentDeployByServiceInstance(serviceInstanceID int) (Deploy, error)
 }
 
 func newDeployStore(dbConn *gorm.DB) dataStore {
@@ -159,4 +163,15 @@ func (db dataStore) getDeploysByServiceInstance(serviceInstanceID int) ([]Deploy
 		Error
 
 	return deploys, err
+}
+
+func (db dataStore) getMostRecentDeployByServiceInstance(serviceInstanceID int) (Deploy, error) {
+	var mostRecentDeploy Deploy
+
+	err := db.Preload("Build").
+		Order("created_at DESC").
+		First(&mostRecentDeploy).
+		Error
+
+	return mostRecentDeploy, err
 }


### PR DESCRIPTION
Previously sherlock was increasing lead time artificially when the same build was deployed to an environment multiple times in a row by recalculating the time diff between image creation and current deploy time for each redeploy. This PR adds a check so that lead time will only be updated if a new build version is being deployed. These re-deploy events are still recorded in sherlock's db and count towards deploy frequency.