### PR TITLE
Update Codecov to ignore dir with generated clients

### DIFF
--- a/codecov.yaml
+++ b/codecov.yaml
@@ -9,3 +9,4 @@ coverage:
 
 ignore:
   - "docs"
+  - "client"


### PR DESCRIPTION
The generated client libs are going to destroy our codecoverage stat without this.