### PR TITLE
DDO-2264 Fix POST status annotation and add ci for client lib generation

### DIFF
--- a/.github/workflows/gen-swagger.yaml
+++ b/.github/workflows/gen-swagger.yaml
@@ -7,6 +7,9 @@ on:
     #   - closed
 # concurrency: commits-to-mainline
 
+env:
+  SWAGGER_CMD: docker run --rm -it  --user $(id -u):$(id -g) -e GOPATH=/go -v $(go env GOPATH):/go -v $HOME:$HOME -w $(pwd) quay.io/goswagger/swagger
+
 jobs:
   gen-swagger:
     name: generate-swagger-spec
@@ -28,8 +31,7 @@ jobs:
       - name: Install go-swagger
         shell: bash
         run: |
-          alias swagger='docker run --rm -it  --user $(id -u):$(id -g) -e GOPATH=/go -v $(go env GOPATH):/go -v $HOME:$HOME -w $(pwd) quay.io/goswagger/swagger'
-          swagger version
+          ${SWAGGER_CMD} version
       - name: Generate swagger spec
         run: make generate-swagger
       - name: Generate Go Client Lib

--- a/.github/workflows/gen-swagger.yaml
+++ b/.github/workflows/gen-swagger.yaml
@@ -8,7 +8,7 @@ on:
 # concurrency: commits-to-mainline
 
 env:
-  SWAGGER_CMD: 'docker run --rm -it -e GOPATH=/go -v $(go env GOPATH):/go -v $HOME:$HOME -w $(pwd) quay.io/goswagger/swagger'
+  SWAGGER_CMD: 'docker run --rm -e GOPATH=/go -v $(go env GOPATH):/go -v $HOME:$HOME -w $(pwd) quay.io/goswagger/swagger'
 
 jobs:
   gen-swagger:

--- a/.github/workflows/gen-swagger.yaml
+++ b/.github/workflows/gen-swagger.yaml
@@ -25,10 +25,18 @@ jobs:
           go-version-file: 'go.mod'
       - name: Install swaggo
         run: go install github.com/swaggo/swag/cmd/swag@latest
+      - name: Install go-swagger
+        shell: bash
+        run: |
+          apt update
+          apt install -y apt-transport-https gnupg curl
+          curl -1sLf 'https://dl.cloudsmith.io/public/go-swagger/go-swagger/gpg.2F8CB673971B5C9E.key' | apt-key add -
+          curl -1sLf 'https://dl.cloudsmith.io/public/go-swagger/go-swagger/config.deb.txt?distro=debian&codename=any-version' > /etc/apt/sources.list.d/go-swagger-go-swagger.list
+          apt update 
+          apt install swagger
       - name: Generate swagger spec
         run: make generate-swagger
       - name: Generate Go Client Lib
-        container: quay.io/go-swaggeer/swagger
         run: |
           swagger generate client -f docs/swagger.json -A sherlock --default-scheme=https -m clients/go/client/models -c clients/go/client
       # - name: Set up Git

--- a/.github/workflows/gen-swagger.yaml
+++ b/.github/workflows/gen-swagger.yaml
@@ -28,13 +28,6 @@ jobs:
           go-version-file: 'go.mod'
       - name: Install swaggo
         run: go install github.com/swaggo/swag/cmd/swag@latest
-      - name: Install go-swagger
-        shell: bash
-        run: |
-          docker run --rm -e GOPATH=/go \
-            -v $(go env GOPATH):/go \
-            -v $HOME:$HOME -w "$(pwd)" \
-            quay.io/goswagger/swagger version
       - name: Generate swagger spec
         run: make generate-swagger
       - name: Generate Go Client Lib

--- a/.github/workflows/gen-swagger.yaml
+++ b/.github/workflows/gen-swagger.yaml
@@ -31,7 +31,10 @@ jobs:
       - name: Install go-swagger
         shell: bash
         run: |
-          "${SWAGGER_CMD}" version
+          docker run --rm -e GOPATH=/go \
+            -v$(go env GOPATH):/go \
+            -v $HOME:$HOME -w $(pwd)\ 
+            quay.io/goswagger/swagger version
       - name: Generate swagger spec
         run: make generate-swagger
       - name: Generate Go Client Lib

--- a/.github/workflows/gen-swagger.yaml
+++ b/.github/workflows/gen-swagger.yaml
@@ -5,7 +5,7 @@ on:
     #   - main
     # types:
     #   - closed
-concurrency: commits-to-mainline
+# concurrency: commits-to-mainline
 
 jobs:
   gen-swagger:

--- a/.github/workflows/gen-swagger.yaml
+++ b/.github/workflows/gen-swagger.yaml
@@ -8,7 +8,7 @@ on:
 # concurrency: commits-to-mainline
 
 env:
-  SWAGGER_CMD: "docker run --rm -e GOPATH=/go -v $(go env GOPATH):/go -v $HOME:$HOME -w $(pwd) quay.io/goswagger/swagger"
+  GO_SWAGGER_VERSION: v0.29.0
 
 jobs:
   gen-swagger:
@@ -42,7 +42,7 @@ jobs:
           docker run --rm -e GOPATH=/go \
             -v $(go env GOPATH):/go \
             -v $HOME:$HOME -w "$(pwd)" \
-            quay.io/goswagger/swagger \
+            quay.io/goswagger/swagger:${GO_SWAGGER_VERSION} \
             generate client -f docs/swagger.json -A sherlock --default-scheme=https -m clients/go/client/models -c clients/go/client
       # - name: Set up Git
       #   shell: bash

--- a/.github/workflows/gen-swagger.yaml
+++ b/.github/workflows/gen-swagger.yaml
@@ -8,7 +8,7 @@ on:
 # concurrency: commits-to-mainline
 
 env:
-  SWAGGER_CMD: docker run --rm -it  --user $(id -u):$(id -g) -e GOPATH=/go -v $(go env GOPATH):/go -v $HOME:$HOME -w $(pwd) quay.io/goswagger/swagger
+  SWAGGER_CMD: 'docker run --rm -it  --user $(id -u):$(id -g) -e GOPATH=/go -v $(go env GOPATH):/go -v $HOME:$HOME -w $(pwd) quay.io/goswagger/swagger'
 
 jobs:
   gen-swagger:

--- a/.github/workflows/gen-swagger.yaml
+++ b/.github/workflows/gen-swagger.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Install go-swagger
         shell: bash
         run: |
-          ${SWAGGER_CMD} version
+          docker run --rm -e GOPATH=/go -v $(go env GOPATH):/go -v $HOME:$HOME -w $(pwd) quay.io/goswagger/swagger version
       - name: Generate swagger spec
         run: make generate-swagger
       - name: Generate Go Client Lib

--- a/.github/workflows/gen-swagger.yaml
+++ b/.github/workflows/gen-swagger.yaml
@@ -30,8 +30,8 @@ jobs:
         run: |
           sudo apt update
           sudo apt install -y apt-transport-https gnupg curl
-          curl -1sLf 'https://dl.cloudsmith.io/public/go-swagger/go-swagger/gpg.2F8CB673971B5C9E.key' | apt-key add -
-          curl -1sLf 'https://dl.cloudsmith.io/public/go-swagger/go-swagger/config.deb.txt?distro=debian&codename=any-version' > /etc/apt/sources.list.d/go-swagger-go-swagger.list
+          curl -1sLf 'https://dl.cloudsmith.io/public/go-swagger/go-swagger/gpg.2F8CB673971B5C9E.key' | sudo apt-key add -
+          curl -1sLf 'https://dl.cloudsmith.io/public/go-swagger/go-swagger/config.deb.txt?distro=debian&codename=any-version' | sudo tee /etc/apt/sources.list.d/go-swagger-go-swagger.list
           sudo apt update 
           sudo apt install swagger
       - name: Generate swagger spec

--- a/.github/workflows/gen-swagger.yaml
+++ b/.github/workflows/gen-swagger.yaml
@@ -32,7 +32,7 @@ jobs:
         shell: bash
         run: |
           docker run --rm -e GOPATH=/go \
-            -v$(go env GOPATH):/go \
+            -v $(go env GOPATH):/go \
             -v $HOME:$HOME -w $(pwd) \ 
             quay.io/goswagger/swagger version
       - name: Generate swagger spec

--- a/.github/workflows/gen-swagger.yaml
+++ b/.github/workflows/gen-swagger.yaml
@@ -8,7 +8,7 @@ on:
 # concurrency: commits-to-mainline
 
 env:
-  SWAGGER_CMD: 'docker run --rm -e GOPATH=/go -v $(go env GOPATH):/go -v $HOME:$HOME -w $(pwd) quay.io/goswagger/swagger'
+  SWAGGER_CMD: "docker run --rm -e GOPATH=/go -v $(go env GOPATH):/go -v $HOME:$HOME -w $(pwd) quay.io/goswagger/swagger"
 
 jobs:
   gen-swagger:
@@ -31,7 +31,7 @@ jobs:
       - name: Install go-swagger
         shell: bash
         run: |
-          docker run --rm -e GOPATH=/go -v $(go env GOPATH):/go -v $HOME:$HOME -w $(pwd) quay.io/goswagger/swagger version
+          "${SWAGGER_CMD}" version
       - name: Generate swagger spec
         run: make generate-swagger
       - name: Generate Go Client Lib

--- a/.github/workflows/gen-swagger.yaml
+++ b/.github/workflows/gen-swagger.yaml
@@ -28,12 +28,8 @@ jobs:
       - name: Install go-swagger
         shell: bash
         run: |
-          sudo apt update
-          sudo apt install -y apt-transport-https gnupg curl
-          curl -1sLf 'https://dl.cloudsmith.io/public/go-swagger/go-swagger/gpg.2F8CB673971B5C9E.key' | sudo apt-key add -
-          curl -1sLf 'https://dl.cloudsmith.io/public/go-swagger/go-swagger/config.deb.txt?distro=debian&codename=any-version' | sudo tee /etc/apt/sources.list.d/go-swagger-go-swagger.list
-          sudo apt update 
-          sudo apt install swagger
+          alias swagger='docker run --rm -it  --user $(id -u):$(id -g) -e GOPATH=/go -v $(go env GOPATH):/go -v $HOME:$HOME -w $(pwd) quay.io/goswagger/swagger'
+          swagger version
       - name: Generate swagger spec
         run: make generate-swagger
       - name: Generate Go Client Lib

--- a/.github/workflows/gen-swagger.yaml
+++ b/.github/workflows/gen-swagger.yaml
@@ -8,7 +8,7 @@ on:
 # concurrency: commits-to-mainline
 
 env:
-  SWAGGER_CMD: 'docker run --rm -it  --user $(id -u):$(id -g) -e GOPATH=/go -v $(go env GOPATH):/go -v $HOME:$HOME -w $(pwd) quay.io/goswagger/swagger'
+  SWAGGER_CMD: 'docker run --rm -it -e GOPATH=/go -v $(go env GOPATH):/go -v $HOME:$HOME -w $(pwd) quay.io/goswagger/swagger'
 
 jobs:
   gen-swagger:

--- a/.github/workflows/gen-swagger.yaml
+++ b/.github/workflows/gen-swagger.yaml
@@ -33,7 +33,7 @@ jobs:
         run: |
           docker run --rm -e GOPATH=/go \
             -v$(go env GOPATH):/go \
-            -v $HOME:$HOME -w $(pwd)\ 
+            -v $HOME:$HOME -w $(pwd) \ 
             quay.io/goswagger/swagger version
       - name: Generate swagger spec
         run: make generate-swagger

--- a/.github/workflows/gen-swagger.yaml
+++ b/.github/workflows/gen-swagger.yaml
@@ -39,7 +39,11 @@ jobs:
         run: make generate-swagger
       - name: Generate Go Client Lib
         run: |
-          swagger generate client -f docs/swagger.json -A sherlock --default-scheme=https -m clients/go/client/models -c clients/go/client
+          docker run --rm -e GOPATH=/go \
+            -v $(go env GOPATH):/go \
+            -v $HOME:$HOME -w "$(pwd)" \
+            quay.io/goswagger/swagger \
+            generate client -f docs/swagger.json -A sherlock --default-scheme=https -m clients/go/client/models -c clients/go/client
       # - name: Set up Git
       #   shell: bash
       #   run: |

--- a/.github/workflows/gen-swagger.yaml
+++ b/.github/workflows/gen-swagger.yaml
@@ -1,10 +1,10 @@
 name: generate-swagger-spec
 on:
   pull_request:
-    branches:
-      - main
-    types:
-      - closed
+    # branches:
+    #   - main
+    # types:
+    #   - closed
 concurrency: commits-to-mainline
 
 jobs:
@@ -27,15 +27,19 @@ jobs:
         run: go install github.com/swaggo/swag/cmd/swag@latest
       - name: Generate swagger spec
         run: make generate-swagger
-      - name: Set up Git
-        shell: bash
+      - name: Generate Go Client Lib
+        container: quay.io/go-swaggeer/swagger
         run: |
-          git config --global user.name 'broadbot'
-          git config --global user.email 'broadbot@broadinstitute.org'
-      - name: Add and commit swagger spec
-        shell: bash
-        run: |
-          git add .
-          git commit --allow-empty --message "[gen-swagger] update swagger spec"
-      - name: Push to main with retry
-        uses: ./.github/actions/push-with-retry
+          swagger generate client -f docs/swagger.json -A sherlock --default-scheme=https -m clients/go/client/models -c clients/go/client
+      # - name: Set up Git
+      #   shell: bash
+      #   run: |
+      #     git config --global user.name 'broadbot'
+      #     git config --global user.email 'broadbot@broadinstitute.org'
+      # - name: Add and commit swagger spec
+      #   shell: bash
+      #   run: |
+      #     git add .
+      #     git commit --allow-empty --message "[gen-swagger] update swagger spec"
+      # - name: Push to main with retry
+      #   uses: ./.github/actions/push-with-retry

--- a/.github/workflows/gen-swagger.yaml
+++ b/.github/workflows/gen-swagger.yaml
@@ -1,18 +1,18 @@
-name: generate-swagger-spec
+name: generate-swagger-spec-and-client-libs
 on:
   pull_request:
-    # branches:
-    #   - main
-    # types:
-    #   - closed
-# concurrency: commits-to-mainline
+    branches:
+      - main
+    types:
+      - closed
+concurrency: commits-to-mainline
 
 env:
   GO_SWAGGER_VERSION: v0.29.0
 
 jobs:
   gen-swagger:
-    name: generate-swagger-spec
+    name: generate-swagger-spec-and-client-libs
     runs-on: ubuntu-latest
     steps:
       - name: Checkout current code
@@ -38,21 +38,22 @@ jobs:
       - name: Generate swagger spec
         run: make generate-swagger
       - name: Generate Go Client Lib
+        # Running this tool via docker because go-swagger's local install procedures are a huge pain to perform from within a github action
         run: |
           docker run --rm -e GOPATH=/go \
             -v $(go env GOPATH):/go \
             -v $HOME:$HOME -w "$(pwd)" \
             quay.io/goswagger/swagger:${GO_SWAGGER_VERSION} \
             generate client -f docs/swagger.json -A sherlock --default-scheme=https -m clients/go/client/models -c clients/go/client
-      # - name: Set up Git
-      #   shell: bash
-      #   run: |
-      #     git config --global user.name 'broadbot'
-      #     git config --global user.email 'broadbot@broadinstitute.org'
-      # - name: Add and commit swagger spec
-      #   shell: bash
-      #   run: |
-      #     git add .
-      #     git commit --allow-empty --message "[gen-swagger] update swagger spec"
-      # - name: Push to main with retry
-      #   uses: ./.github/actions/push-with-retry
+      - name: Set up Git
+        shell: bash
+        run: |
+          git config --global user.name 'broadbot'
+          git config --global user.email 'broadbot@broadinstitute.org'
+      - name: Add and commit swagger spec
+        shell: bash
+        run: |
+          git add .
+          git commit --allow-empty --message "[gen-swagger-and-clients] update swagger spec"
+      - name: Push to main with retry
+        uses: ./.github/actions/push-with-retry

--- a/.github/workflows/gen-swagger.yaml
+++ b/.github/workflows/gen-swagger.yaml
@@ -33,7 +33,7 @@ jobs:
         run: |
           docker run --rm -e GOPATH=/go \
             -v $(go env GOPATH):/go \
-            -v $HOME:$HOME -w "$(pwd)"" \ 
+            -v $HOME:$HOME -w "$(pwd)" \
             quay.io/goswagger/swagger version
       - name: Generate swagger spec
         run: make generate-swagger

--- a/.github/workflows/gen-swagger.yaml
+++ b/.github/workflows/gen-swagger.yaml
@@ -28,12 +28,12 @@ jobs:
       - name: Install go-swagger
         shell: bash
         run: |
-          apt update
-          apt install -y apt-transport-https gnupg curl
+          sudo apt update
+          sudo apt install -y apt-transport-https gnupg curl
           curl -1sLf 'https://dl.cloudsmith.io/public/go-swagger/go-swagger/gpg.2F8CB673971B5C9E.key' | apt-key add -
           curl -1sLf 'https://dl.cloudsmith.io/public/go-swagger/go-swagger/config.deb.txt?distro=debian&codename=any-version' > /etc/apt/sources.list.d/go-swagger-go-swagger.list
-          apt update 
-          apt install swagger
+          sudo apt update 
+          sudo apt install swagger
       - name: Generate swagger spec
         run: make generate-swagger
       - name: Generate Go Client Lib

--- a/.github/workflows/gen-swagger.yaml
+++ b/.github/workflows/gen-swagger.yaml
@@ -33,7 +33,7 @@ jobs:
         run: |
           docker run --rm -e GOPATH=/go \
             -v $(go env GOPATH):/go \
-            -v $HOME:$HOME -w $(pwd) \ 
+            -v $HOME:$HOME -w "$(pwd)"" \ 
             quay.io/goswagger/swagger version
       - name: Generate swagger spec
         run: make generate-swagger

--- a/internal/handlers/v2handlers/app_version.go
+++ b/internal/handlers/v2handlers/app_version.go
@@ -19,7 +19,7 @@ func RegisterAppVersionHandlers(routerGroup *gin.RouterGroup, controller *v2cont
 // @accept      json
 // @produce     json
 // @param       app-version             body     v2controllers.CreatableAppVersion true "The AppVersion to create"
-// @success     200                     {object} v2controllers.AppVersion
+// @success     201                     {object} v2controllers.AppVersion
 // @failure     400,403,404,407,409,500 {object} errors.ErrorResponse
 // @router      /api/v2/app-versions [post]
 func createAppVersion(controller *v2controllers.AppVersionController) func(ctx *gin.Context) {

--- a/internal/handlers/v2handlers/chart.go
+++ b/internal/handlers/v2handlers/chart.go
@@ -21,7 +21,7 @@ func RegisterChartHandlers(routerGroup *gin.RouterGroup, controller *v2controlle
 // @accept      json
 // @produce     json
 // @param       chart                   body     v2controllers.CreatableChart true "The Chart to create"
-// @success     200                     {object} v2controllers.Chart
+// @success     201                     {object} v2controllers.Chart
 // @failure     400,403,404,407,409,500 {object} errors.ErrorResponse
 // @router      /api/v2/charts [post]
 func createChart(controller *v2controllers.ChartController) func(ctx *gin.Context) {

--- a/internal/handlers/v2handlers/chart_deploy_record.go
+++ b/internal/handlers/v2handlers/chart_deploy_record.go
@@ -19,7 +19,7 @@ func RegisterChartDeployRecordHandlers(routerGroup *gin.RouterGroup, controller 
 // @accept      json
 // @produce     json
 // @param       chart-deploy-record     body     v2controllers.CreatableChartDeployRecord true "The ChartDeployRecord to create"
-// @success     200                     {object} v2controllers.ChartDeployRecord
+// @success     201                   {object} v2controllers.ChartDeployRecord
 // @failure     400,403,404,407,409,500 {object} errors.ErrorResponse
 // @router      /api/v2/chart-deploy-records [post]
 func createChartDeployRecord(controller *v2controllers.ChartDeployRecordController) func(ctx *gin.Context) {

--- a/internal/handlers/v2handlers/chart_release.go
+++ b/internal/handlers/v2handlers/chart_release.go
@@ -21,7 +21,7 @@ func RegisterChartReleaseHandlers(routerGroup *gin.RouterGroup, controller *v2co
 // @accept      json
 // @produce     json
 // @param       chart-release           body     v2controllers.CreatableChartRelease true "The ChartRelease to create"
-// @success     200                     {object} v2controllers.ChartRelease
+// @success     201                     {object} v2controllers.ChartRelease
 // @failure     400,403,404,407,409,500 {object} errors.ErrorResponse
 // @router      /api/v2/chart-releases [post]
 func createChartRelease(controller *v2controllers.ChartReleaseController) func(ctx *gin.Context) {

--- a/internal/handlers/v2handlers/chart_version.go
+++ b/internal/handlers/v2handlers/chart_version.go
@@ -19,7 +19,7 @@ func RegisterChartVersionHandlers(routerGroup *gin.RouterGroup, controller *v2co
 // @accept      json
 // @produce     json
 // @param       chart-version           body     v2controllers.CreatableChartVersion true "The ChartVersion to create"
-// @success     200                     {object} v2controllers.ChartVersion
+// @success     201                     {object} v2controllers.ChartVersion
 // @failure     400,403,404,407,409,500 {object} errors.ErrorResponse
 // @router      /api/v2/chart-versions [post]
 func createChartVersion(controller *v2controllers.ChartVersionController) func(ctx *gin.Context) {

--- a/internal/handlers/v2handlers/cluster.go
+++ b/internal/handlers/v2handlers/cluster.go
@@ -21,7 +21,7 @@ func RegisterClusterHandlers(routerGroup *gin.RouterGroup, controller *v2control
 // @accept      json
 // @produce     json
 // @param       cluster                 body     v2controllers.CreatableCluster true "The Cluster to create"
-// @success     200                     {object} v2controllers.Cluster
+// @success     201                     {object} v2controllers.Cluster
 // @failure     400,403,404,407,409,500 {object} errors.ErrorResponse
 // @router      /api/v2/clusters [post]
 func createCluster(controller *v2controllers.ClusterController) func(ctx *gin.Context) {

--- a/internal/handlers/v2handlers/environment.go
+++ b/internal/handlers/v2handlers/environment.go
@@ -22,7 +22,7 @@ func RegisterEnvironmentHandlers(routerGroup *gin.RouterGroup, controller *v2con
 // @accept      json
 // @produce     json
 // @param       environment             body     v2controllers.CreatableEnvironment true "The Environment to create"
-// @success     200                     {object} v2controllers.Environment
+// @success     201                     {object} v2controllers.Environment
 // @failure     400,403,404,407,409,500 {object} errors.ErrorResponse
 // @router      /api/v2/environments [post]
 func createEnvironment(controller *v2controllers.EnvironmentController) func(ctx *gin.Context) {


### PR DESCRIPTION
Updates the swagger spec so that the fact that successful POST requests to v2 endpoints return status `201` rather than `200`.

Also adds CI support for building and publishing the go client library based on the generated swagger spec upon merge to main.