### PR TITLE
Generate Typescript (and Go) from openapi-generator

### DIFF
--- a/.github/workflows/gen-swagger.yaml
+++ b/.github/workflows/gen-swagger.yaml
@@ -46,7 +46,7 @@ jobs:
             -o /local/clients/typescript-fetch \
             --additional-properties=disallowAdditionalPropertiesIfNotPresent=false \
             --additional-properties=supportsES6=true \
-            --additional-properties=npmName=sherlock-client \
+            --additional-properties=npmName=sherlock \
             --additional-properties=npmVersion=$(git tag --points-at HEAD)
       - name: Generate Go (openapi-generator) Client Lib
         run: |
@@ -55,7 +55,7 @@ jobs:
             -g go \
             -o /local/clients/go-openapi-generator \
             --additional-properties=disallowAdditionalPropertiesIfNotPresent=false \
-            --additional-properties=packageName=sherlockclient \
+            --additional-properties=packageName=sherlock \
             --additional-properties=packageVersion=$(git tag --points-at HEAD)
       - name: Set up Git
         shell: bash

--- a/.github/workflows/gen-swagger.yaml
+++ b/.github/workflows/gen-swagger.yaml
@@ -38,6 +38,25 @@ jobs:
             -v $HOME:$HOME -w "$(pwd)" \
             quay.io/goswagger/swagger:${GO_SWAGGER_VERSION} \
             generate client -f docs/swagger.json -A sherlock --default-scheme=https -m clients/go/client/models -c clients/go/client
+      - name: Generate Typescript Client Lib
+        run: |
+          docker run --rm -v "${PWD}:/local" openapitools/openapi-generator-cli generate \
+            -i /local/docs/swagger.json \
+            -g typescript-fetch \
+            -o /local/clients/typescript-fetch \
+            --additional-properties=disallowAdditionalPropertiesIfNotPresent=false \
+            --additional-properties=supportsES6=true \
+            --additional-properties=npmName=sherlock \
+            --additional-properties=npmVersion=$(git tag --points-at HEAD)
+      - name: Generate Go (openapi-generator) Client Lib
+        run: |
+          docker run --rm -v "${PWD}:/local" openapitools/openapi-generator-cli generate \
+            -i /local/docs/swagger.json \
+            -g go \
+            -o /local/clients/go-openapi-generator \
+            --additional-properties=disallowAdditionalPropertiesIfNotPresent=false \
+            --additional-properties=packageName=sherlock \
+            --additional-properties=packageVersion=$(git tag --points-at HEAD)
       - name: Set up Git
         shell: bash
         run: |

--- a/.github/workflows/gen-swagger.yaml
+++ b/.github/workflows/gen-swagger.yaml
@@ -46,7 +46,7 @@ jobs:
             -o /local/clients/typescript-fetch \
             --additional-properties=disallowAdditionalPropertiesIfNotPresent=false \
             --additional-properties=supportsES6=true \
-            --additional-properties=npmName=sherlock \
+            --additional-properties=npmName=sherlock-client \
             --additional-properties=npmVersion=$(git tag --points-at HEAD)
       - name: Generate Go (openapi-generator) Client Lib
         run: |
@@ -55,7 +55,7 @@ jobs:
             -g go \
             -o /local/clients/go-openapi-generator \
             --additional-properties=disallowAdditionalPropertiesIfNotPresent=false \
-            --additional-properties=packageName=sherlock \
+            --additional-properties=packageName=sherlockclient \
             --additional-properties=packageVersion=$(git tag --points-at HEAD)
       - name: Set up Git
         shell: bash


### PR DESCRIPTION
I'm really not too concerned about trying to standardize on a tool here.

It makes the TypeScript library at `clients/typescript-fetch` and the Go library at `go-openapi-generator` just for now so we can compare.