### PR TITLE
[DDO-2295] Cluster name presence accidentally enforced by Swagger

### DIFF
--- a/internal/controllers/v2controllers/cluster.go
+++ b/internal/controllers/v2controllers/cluster.go
@@ -15,7 +15,7 @@ type Cluster struct {
 // CreatableCluster
 // @description The subset of Cluster fields that can be set upon creation
 type CreatableCluster struct {
-	Name              string `json:"name" validate:"required" form:"name"` // Required when creating
+	Name              string `json:"name" form:"name"` // Required when creating
 	Provider          string `json:"provider" form:"provider" enums:"google,azure" default:"google"`
 	GoogleProject     string `json:"googleProject" form:"googleProject"`         // Required when creating if provider is 'google'
 	AzureSubscription string `json:"azureSubscription" form:"azureSubscription"` // Required when creating if providers is 'azure'


### PR DESCRIPTION
This is enforced (there's a test for it) internally, and at the Swagger level it's actually bad because it prevents us from listing all clusters. At one point I'd tried to remove all the validate struct tags and must have just missed one.