### PR TITLE
[DDO-2308] Don't recursively parse query parameters

### DIFF
--- a/internal/controllers/v2controllers/README.md
+++ b/internal/controllers/v2controllers/README.md
@@ -11,6 +11,7 @@ For naming, for a model type called `v2models.X`, the three types would be `X`, 
 #### Do use:
 - `json` controls the field name when parsing to/from json (always add)
 - `form` controls the field name when parsing from query parameters (always add)
+  - Struct types can't ever be parsed from query parameters, so `form:"-"` should be used [to skip them during parsing](https://github.com/gin-gonic/gin/pull/1733)
 - `swaggertype` can override the type of the field documented on Swagger, useful for anything recursive (only add when Swaggo is parsing the type incorrectly)
 - `enums` controls possible values for the field as documented on Swagger (add when reasonable)
 - `default` controls (add when reasonable):

--- a/internal/controllers/v2controllers/app_version.go
+++ b/internal/controllers/v2controllers/app_version.go
@@ -7,7 +7,7 @@ import (
 
 type AppVersion struct {
 	ReadableBaseType
-	ChartInfo Chart `json:"chartInfo" form:"chartInfo"`
+	ChartInfo Chart `json:"chartInfo" form:"-"`
 	CreatableAppVersion
 }
 

--- a/internal/controllers/v2controllers/chart_deploy_record.go
+++ b/internal/controllers/v2controllers/chart_deploy_record.go
@@ -8,7 +8,7 @@ import (
 
 type ChartDeployRecord struct {
 	ReadableBaseType
-	ChartReleaseInfo ChartRelease `json:"chartReleaseInfo" form:"chartReleaseInfo"`
+	ChartReleaseInfo ChartRelease `json:"chartReleaseInfo" form:"-"`
 	CreatableChartDeployRecord
 }
 

--- a/internal/controllers/v2controllers/chart_deploy_record_test.go
+++ b/internal/controllers/v2controllers/chart_deploy_record_test.go
@@ -194,8 +194,6 @@ func (suite *chartDeployRecordControllerSuite) TestChartDeployRecordGet() {
 	suite.seedCharts(suite.T())
 	suite.seedChartReleases(suite.T())
 	suite.seedChartDeployRecords(suite.T())
-	suite.seedAppVersions(suite.T())
-	suite.seedChartVersions(suite.T())
 	chartDeployRecords, _ := suite.ChartDeployRecordController.ListAllMatching(ChartDeployRecord{
 		CreatableChartDeployRecord: CreatableChartDeployRecord{
 			ChartRelease: datarepoDevChartRelease.Name,

--- a/internal/controllers/v2controllers/chart_deploy_record_test.go
+++ b/internal/controllers/v2controllers/chart_deploy_record_test.go
@@ -194,6 +194,8 @@ func (suite *chartDeployRecordControllerSuite) TestChartDeployRecordGet() {
 	suite.seedCharts(suite.T())
 	suite.seedChartReleases(suite.T())
 	suite.seedChartDeployRecords(suite.T())
+	suite.seedAppVersions(suite.T())
+	suite.seedChartVersions(suite.T())
 	chartDeployRecords, _ := suite.ChartDeployRecordController.ListAllMatching(ChartDeployRecord{
 		CreatableChartDeployRecord: CreatableChartDeployRecord{
 			ChartRelease: datarepoDevChartRelease.Name,

--- a/internal/controllers/v2controllers/chart_release.go
+++ b/internal/controllers/v2controllers/chart_release.go
@@ -9,9 +9,9 @@ import (
 
 type ChartRelease struct {
 	ReadableBaseType
-	ChartInfo       Chart        `json:"chartInfo" form:"chartInfo"`
-	ClusterInfo     *Cluster     `json:"clusterInfo,omitempty" form:"clusterInfo"`
-	EnvironmentInfo *Environment `json:"environmentInfo,omitempty" form:"environmentInfo"`
+	ChartInfo       Chart        `json:"chartInfo" form:"-"`
+	ClusterInfo     *Cluster     `json:"clusterInfo,omitempty" form:"-"`
+	EnvironmentInfo *Environment `json:"environmentInfo,omitempty" form:"-"`
 	DestinationType string       `json:"destinationType" form:"destinationType" enum:"environment,cluster"` // Calculated field
 	CreatableChartRelease
 }

--- a/internal/controllers/v2controllers/chart_version.go
+++ b/internal/controllers/v2controllers/chart_version.go
@@ -7,7 +7,7 @@ import (
 
 type ChartVersion struct {
 	ReadableBaseType
-	ChartInfo Chart `json:"chartInfo" form:"chartInfo"`
+	ChartInfo Chart `json:"chartInfo" form:"-"`
 	CreatableChartVersion
 }
 

--- a/internal/controllers/v2controllers/environment.go
+++ b/internal/controllers/v2controllers/environment.go
@@ -15,8 +15,8 @@ import (
 
 type Environment struct {
 	ReadableBaseType
-	TemplateEnvironmentInfo *Environment `json:"templateEnvironmentInfo,omitempty" swaggertype:"object" form:"templateEnvironmentInfo"` // Single-layer recursive; provides info of the template environment if this environment has one
-	DefaultClusterInfo      *Cluster     `json:"defaultClusterInfo,omitempty" form:"defaultClusterInfo"`
+	TemplateEnvironmentInfo *Environment `json:"templateEnvironmentInfo,omitempty" swaggertype:"object" form:"-"` // Single-layer recursive; provides info of the template environment if this environment has one
+	DefaultClusterInfo      *Cluster     `json:"defaultClusterInfo,omitempty" form:"-"`
 	ValuesName              string       `json:"valuesName" form:"valuesName"`
 	CreatableEnvironment
 }


### PR DESCRIPTION
(Actually, just don't try to parse nested info structs from query parameters at all).

H/T to https://github.com/gin-gonic/gin/pull/1733 for an absolute life-saver here. The struct tags like this will ignore even _trying_ to bind nested structs out of query parameters so we won't hit that fun stack-overflow issue.

Granted I'm, uh, not super sure how on earth to test this. The stack overflow comes up in Gin, from binding in handlers, in a way that the current v2 test infra doesn't really let us check. We'd have to spin up a very full Sherlock server and hit it for tests and I think that's not worth it here.