### PR TITLE
[DDO-2339] Add "chartExposesEndpoint" field to Charts

### DIFF
--- a/db/migrations/000018_add_exposes_endpoint.down.sql
+++ b/db/migrations/000018_add_exposes_endpoint.down.sql
@@ -1,0 +1,2 @@
+alter table v2_charts
+    drop column if exists chart_exposes_endpoint;

--- a/db/migrations/000018_add_exposes_endpoint.up.sql
+++ b/db/migrations/000018_add_exposes_endpoint.up.sql
@@ -1,0 +1,2 @@
+alter table v2_charts
+    add if not exists chart_exposes_endpoint boolean;

--- a/internal/controllers/v2controllers/chart.go
+++ b/internal/controllers/v2controllers/chart.go
@@ -20,7 +20,8 @@ type EditableChart struct {
 	ChartRepo             *string `json:"chartRepo" form:"chartRepo" default:"terra-helm"`
 	AppImageGitRepo       *string `json:"appImageGitRepo" form:"appImageGitRepo"`
 	AppImageGitMainBranch *string `json:"appImageGitMainBranch" form:"appImageGitMainBranch"`
-	DefaultSubdomain      *string `json:"defaultSubdomain" form:"defaultSubdomain"` // When creating, will default to the name of the chart
+	ChartExposesEndpoint  *bool   `json:"chartExposesEndpoint" form:"chartExposesEndpoint" default:"false"` // Indicates if the default subdomain, protocol, and port fields are relevant for this chart
+	DefaultSubdomain      *string `json:"defaultSubdomain" form:"defaultSubdomain"`                         // When creating, will default to the name of the chart
 	DefaultProtocol       *string `json:"defaultProtocol" form:"defaultProtocol" default:"https"`
 	DefaultPort           *uint   `json:"defaultPort" form:"defaultPort" default:"443"`
 }
@@ -64,6 +65,7 @@ func modelChartToChart(model *v2models.Chart) *Chart {
 				ChartRepo:             model.ChartRepo,
 				AppImageGitRepo:       model.AppImageGitRepo,
 				AppImageGitMainBranch: model.AppImageGitMainBranch,
+				ChartExposesEndpoint:  model.ChartExposesEndpoint,
 				DefaultSubdomain:      model.DefaultSubdomain,
 				DefaultProtocol:       model.DefaultProtocol,
 				DefaultPort:           model.DefaultPort,
@@ -83,6 +85,7 @@ func chartToModelChart(chart Chart, _ *v2models.StoreSet) (v2models.Chart, error
 		ChartRepo:             chart.ChartRepo,
 		AppImageGitRepo:       chart.AppImageGitRepo,
 		AppImageGitMainBranch: chart.AppImageGitMainBranch,
+		ChartExposesEndpoint:  chart.ChartExposesEndpoint,
 		DefaultSubdomain:      chart.DefaultSubdomain,
 		DefaultProtocol:       chart.DefaultProtocol,
 		DefaultPort:           chart.DefaultPort,

--- a/internal/controllers/v2controllers/chart_release.go
+++ b/internal/controllers/v2controllers/chart_release.go
@@ -219,14 +219,16 @@ func setChartReleaseDynamicDefaults(chartRelease *ChartRelease, stores *v2models
 	if chart.AppImageGitMainBranch != nil && *chart.AppImageGitMainBranch != "" && chartRelease.AppVersionBranch == nil {
 		chartRelease.AppVersionBranch = chart.AppImageGitMainBranch
 	}
-	if chartRelease.Subdomain == nil {
-		chartRelease.Subdomain = chart.DefaultSubdomain
-	}
-	if chartRelease.Protocol == nil {
-		chartRelease.Protocol = chart.DefaultProtocol
-	}
-	if chartRelease.Port == nil {
-		chartRelease.Port = chart.DefaultPort
+	if chart.ChartExposesEndpoint != nil && *chart.ChartExposesEndpoint {
+		if chartRelease.Subdomain == nil {
+			chartRelease.Subdomain = chart.DefaultSubdomain
+		}
+		if chartRelease.Protocol == nil {
+			chartRelease.Protocol = chart.DefaultProtocol
+		}
+		if chartRelease.Port == nil {
+			chartRelease.Port = chart.DefaultPort
+		}
 	}
 
 	if chartRelease.AppVersionResolver == nil {

--- a/internal/controllers/v2controllers/chart_release_test.go
+++ b/internal/controllers/v2controllers/chart_release_test.go
@@ -295,6 +295,11 @@ func (suite *chartReleaseControllerSuite) TestChartReleaseCreate() {
 			suite.Run("sets destination type to cluster", func() {
 				assert.Equal(suite.T(), "cluster", release.DestinationType)
 			})
+			suite.Run("chart without an endpoint doesn't fill endpoint fields in chart release", func() {
+				assert.Empty(suite.T(), release.Subdomain)
+				assert.Empty(suite.T(), release.Protocol)
+				assert.Empty(suite.T(), release.Port)
+			})
 		})
 		suite.Run("won't create duplicates", func() {
 			db.Truncate(suite.T(), suite.db)

--- a/internal/controllers/v2controllers/chart_test.go
+++ b/internal/controllers/v2controllers/chart_test.go
@@ -53,6 +53,7 @@ var (
 		EditableChart: EditableChart{
 			AppImageGitRepo:       testutils.PointerTo("DataBiosphere/leonardo"),
 			AppImageGitMainBranch: testutils.PointerTo("main"),
+			ChartExposesEndpoint:  testutils.PointerTo(true),
 		},
 	}
 	samChart = CreatableChart{
@@ -60,6 +61,7 @@ var (
 		EditableChart: EditableChart{
 			AppImageGitRepo:       testutils.PointerTo("broadinstitute/sam"),
 			AppImageGitMainBranch: testutils.PointerTo("develop"),
+			ChartExposesEndpoint:  testutils.PointerTo(true),
 		},
 	}
 	datarepoChart = CreatableChart{
@@ -68,6 +70,7 @@ var (
 			ChartRepo:             testutils.PointerTo("datarepo-helm"),
 			AppImageGitRepo:       testutils.PointerTo("DataBiosphere/jade-data-repo"),
 			AppImageGitMainBranch: testutils.PointerTo("develop"),
+			ChartExposesEndpoint:  testutils.PointerTo(true),
 		},
 	}
 	// "app release" (per environment), but doesn't actually have an application

--- a/internal/controllers/v2controllers/environment_test.go
+++ b/internal/controllers/v2controllers/environment_test.go
@@ -261,7 +261,7 @@ func (suite *environmentControllerSuite) TestEnvironmentCreate() {
 					// The template gets this field set based on the Chart's app main branch, dynamic should copy
 					assert.Equal(suite.T(), swatRelease.AppVersionBranch, envRelease.AppVersionBranch)
 					assert.True(suite.T(), envRelease.ID > 0)
-					assert.Equal(suite.T(), *swatRelease.Subdomain, *envRelease.Subdomain)
+					assert.Equal(suite.T(), swatRelease.Subdomain, envRelease.Subdomain)
 				}
 			}
 			assert.True(suite.T(), found)

--- a/internal/models/v2models/chart.go
+++ b/internal/models/v2models/chart.go
@@ -14,6 +14,7 @@ type Chart struct {
 	ChartRepo             *string `gorm:"not null; default:null"`
 	AppImageGitRepo       *string
 	AppImageGitMainBranch *string
+	ChartExposesEndpoint  *bool
 	DefaultSubdomain      *string
 	DefaultProtocol       *string
 	DefaultPort           *uint


### PR DESCRIPTION
Just a little default-false field to indicate whether the "defaultSubdomain" etc fields actually matter. This gets passed down to influence chart release creation, so if this is false then the defaultSubdomain etc won't get put into the chart release's subdomain etc field. This gives Beehive enough information to know whether to show the URL in the UI.