### PR TITLE
[DDO-2346] Error faster on Changeset Chart mismatches

### DIFF
--- a/internal/controllers/v2controllers/changeset_procedures.go
+++ b/internal/controllers/v2controllers/changeset_procedures.go
@@ -39,6 +39,11 @@ func (c ChangesetController) changesetPlanRequestToModelChangesets(request Chang
 			if err != nil {
 				return nil, fmt.Errorf("error getting referenced other chart release '%s' for chart release entry %d, '%s': %v", *chartReleaseRequestEntry.UseExactVersionsFromOtherChartRelease, index+1, fullChangesetRequest.ChartRelease, err)
 			}
+			if chartRelease, err := c.allStores.ChartReleaseStore.Get(fullChangesetRequest.ChartRelease); err != nil {
+				return nil, fmt.Errorf("error getting referenced chart release '%s' for chart release entry %d: %v", fullChangesetRequest.ChartRelease, index+1, err)
+			} else if chartRelease.ChartID != otherChartRelease.ChartID {
+				return nil, fmt.Errorf("validation error on chart release entry %d: chart release has chart '%s' but referenced other chart release has mismatched chart '%s'", index+1, chartRelease.Chart.Name, otherChartRelease.Chart.Name)
+			}
 			if otherChartRelease.AppVersionResolver != nil && *otherChartRelease.AppVersionResolver == "none" {
 				fullChangesetRequest.ToAppVersionResolver = otherChartRelease.AppVersionResolver
 			} else {

--- a/internal/controllers/v2controllers/changeset_test.go
+++ b/internal/controllers/v2controllers/changeset_test.go
@@ -329,4 +329,15 @@ func (suite *changesetControllerSuite) TestChangesetFlow() {
 	samInProd, err = suite.ChartReleaseController.Get("terra-prod/sam")
 	assert.NoError(suite.T(), err)
 	assert.Equal(suite.T(), "0.0.3", *samInProd.ChartVersionExact)
+
+	// Plans can't get created if there's chart mismatches:
+	_, err = suite.ChangesetController.Plan(ChangesetPlanRequest{
+		ChartReleases: []ChangesetPlanRequestChartReleaseEntry{
+			{
+				CreatableChangeset:                    CreatableChangeset{ChartRelease: "terra-dev/sam"},
+				UseExactVersionsFromOtherChartRelease: testutils.PointerTo("terra-staging/leonardo"),
+			},
+		},
+	}, auth.GenerateUser(suite.T(), true))
+	assert.ErrorContains(suite.T(), err, "mismatched chart")
 }


### PR DESCRIPTION
This would error out elsewhere but we can fail-fast and give a good error message by catching this case.

I’ve actually had this code locally forever, just forgot to push it.