### PR TITLE
[DDO-2382] Version description fields

### DIFF
--- a/db/migrations/000019_add_version_descriptions.down.sql
+++ b/db/migrations/000019_add_version_descriptions.down.sql
@@ -1,0 +1,5 @@
+alter table v2_app_versions
+    drop column if exists description;
+
+alter table v2_chart_versions
+    drop column  if exists description;

--- a/db/migrations/000019_add_version_descriptions.up.sql
+++ b/db/migrations/000019_add_version_descriptions.up.sql
@@ -1,0 +1,5 @@
+alter table v2_app_versions
+    add if not exists description text;
+
+alter table v2_chart_versions
+    add if not exists description text;

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -59,6 +59,12 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
+                        "description": "Generally the Git commit message",
+                        "name": "description",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
                         "name": "gitBranch",
                         "in": "query"
                     },
@@ -229,6 +235,81 @@ const docTemplate = `{
                         "name": "selector",
                         "in": "path",
                         "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/v2controllers.AppVersion"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "407": {
+                        "description": "Proxy Authentication Required",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "patch": {
+                "description": "Edit an existing AppVersion entry via one its \"selectors\": chart/version or numeric ID. Note that only mutable fields are available here, immutable fields can only be set using /create.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "AppVersions"
+                ],
+                "summary": "Edit a AppVersion entry",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "The AppVersion to edit's selector: chart/version or numeric ID",
+                        "name": "selector",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "The edits to make to the AppVersion",
+                        "name": "app-version",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/v2controllers.EditableAppVersion"
+                        }
                     }
                 ],
                 "responses": {
@@ -1114,6 +1195,12 @@ const docTemplate = `{
                         "in": "query"
                     },
                     {
+                        "type": "string",
+                        "description": "Generally the Git commit message",
+                        "name": "description",
+                        "in": "query"
+                    },
+                    {
                         "type": "integer",
                         "name": "id",
                         "in": "query"
@@ -1275,6 +1362,81 @@ const docTemplate = `{
                         "name": "selector",
                         "in": "path",
                         "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/v2controllers.ChartVersion"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "407": {
+                        "description": "Proxy Authentication Required",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "patch": {
+                "description": "Edit an existing ChartVersion entry via one its \"selectors\": chart/version or numeric ID. Note that only mutable fields are available here, immutable fields can only be set using /create.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ChartVersions"
+                ],
+                "summary": "Edit a ChartVersion entry",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "The ChartVersion to edit's selector: chart/version or numeric ID",
+                        "name": "selector",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "The edits to make to the ChartVersion",
+                        "name": "chart-version",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/v2controllers.EditableChartVersion"
+                        }
                     }
                 ],
                 "responses": {
@@ -3482,6 +3644,10 @@ const docTemplate = `{
                 "createdAt": {
                     "type": "string"
                 },
+                "description": {
+                    "description": "Generally the Git commit message",
+                    "type": "string"
+                },
                 "gitBranch": {
                     "type": "string"
                 },
@@ -3853,6 +4019,10 @@ const docTemplate = `{
                 "createdAt": {
                     "type": "string"
                 },
+                "description": {
+                    "description": "Generally the Git commit message",
+                    "type": "string"
+                },
                 "id": {
                     "type": "integer"
                 },
@@ -3923,6 +4093,10 @@ const docTemplate = `{
                 },
                 "chart": {
                     "description": "Required when creating",
+                    "type": "string"
+                },
+                "description": {
+                    "description": "Generally the Git commit message",
                     "type": "string"
                 },
                 "gitBranch": {
@@ -4084,6 +4258,10 @@ const docTemplate = `{
                     "description": "Required when creating",
                     "type": "string"
                 },
+                "description": {
+                    "description": "Generally the Git commit message",
+                    "type": "string"
+                },
                 "parentChartVersion": {
                     "type": "string"
                 }
@@ -4175,6 +4353,15 @@ const docTemplate = `{
                 }
             }
         },
+        "v2controllers.EditableAppVersion": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "description": "Generally the Git commit message",
+                    "type": "string"
+                }
+            }
+        },
         "v2controllers.EditableChart": {
             "type": "object",
             "properties": {
@@ -4220,6 +4407,15 @@ const docTemplate = `{
                 },
                 "subdomain": {
                     "description": "When creating, will use the chart's default if left empty",
+                    "type": "string"
+                }
+            }
+        },
+        "v2controllers.EditableChartVersion": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "description": "Generally the Git commit message",
                     "type": "string"
                 }
             }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -53,6 +53,12 @@
                     },
                     {
                         "type": "string",
+                        "description": "Generally the Git commit message",
+                        "name": "description",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
                         "name": "gitBranch",
                         "in": "query"
                     },
@@ -223,6 +229,81 @@
                         "name": "selector",
                         "in": "path",
                         "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/v2controllers.AppVersion"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "407": {
+                        "description": "Proxy Authentication Required",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "patch": {
+                "description": "Edit an existing AppVersion entry via one its \"selectors\": chart/version or numeric ID. Note that only mutable fields are available here, immutable fields can only be set using /create.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "AppVersions"
+                ],
+                "summary": "Edit a AppVersion entry",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "The AppVersion to edit's selector: chart/version or numeric ID",
+                        "name": "selector",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "The edits to make to the AppVersion",
+                        "name": "app-version",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/v2controllers.EditableAppVersion"
+                        }
                     }
                 ],
                 "responses": {
@@ -1108,6 +1189,12 @@
                         "in": "query"
                     },
                     {
+                        "type": "string",
+                        "description": "Generally the Git commit message",
+                        "name": "description",
+                        "in": "query"
+                    },
+                    {
                         "type": "integer",
                         "name": "id",
                         "in": "query"
@@ -1269,6 +1356,81 @@
                         "name": "selector",
                         "in": "path",
                         "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/v2controllers.ChartVersion"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "407": {
+                        "description": "Proxy Authentication Required",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "patch": {
+                "description": "Edit an existing ChartVersion entry via one its \"selectors\": chart/version or numeric ID. Note that only mutable fields are available here, immutable fields can only be set using /create.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ChartVersions"
+                ],
+                "summary": "Edit a ChartVersion entry",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "The ChartVersion to edit's selector: chart/version or numeric ID",
+                        "name": "selector",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "The edits to make to the ChartVersion",
+                        "name": "chart-version",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/v2controllers.EditableChartVersion"
+                        }
                     }
                 ],
                 "responses": {
@@ -3476,6 +3638,10 @@
                 "createdAt": {
                     "type": "string"
                 },
+                "description": {
+                    "description": "Generally the Git commit message",
+                    "type": "string"
+                },
                 "gitBranch": {
                     "type": "string"
                 },
@@ -3847,6 +4013,10 @@
                 "createdAt": {
                     "type": "string"
                 },
+                "description": {
+                    "description": "Generally the Git commit message",
+                    "type": "string"
+                },
                 "id": {
                     "type": "integer"
                 },
@@ -3917,6 +4087,10 @@
                 },
                 "chart": {
                     "description": "Required when creating",
+                    "type": "string"
+                },
+                "description": {
+                    "description": "Generally the Git commit message",
                     "type": "string"
                 },
                 "gitBranch": {
@@ -4078,6 +4252,10 @@
                     "description": "Required when creating",
                     "type": "string"
                 },
+                "description": {
+                    "description": "Generally the Git commit message",
+                    "type": "string"
+                },
                 "parentChartVersion": {
                     "type": "string"
                 }
@@ -4169,6 +4347,15 @@
                 }
             }
         },
+        "v2controllers.EditableAppVersion": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "description": "Generally the Git commit message",
+                    "type": "string"
+                }
+            }
+        },
         "v2controllers.EditableChart": {
             "type": "object",
             "properties": {
@@ -4214,6 +4401,15 @@
                 },
                 "subdomain": {
                     "description": "When creating, will use the chart's default if left empty",
+                    "type": "string"
+                }
+            }
+        },
+        "v2controllers.EditableChartVersion": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "description": "Generally the Git commit message",
                     "type": "string"
                 }
             }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -85,6 +85,9 @@ definitions:
         $ref: '#/definitions/v2controllers.Chart'
       createdAt:
         type: string
+      description:
+        description: Generally the Git commit message
+        type: string
       gitBranch:
         type: string
       gitCommit:
@@ -345,6 +348,9 @@ definitions:
         type: string
       createdAt:
         type: string
+      description:
+        description: Generally the Git commit message
+        type: string
       id:
         type: integer
       parentChartVersion:
@@ -396,6 +402,9 @@ definitions:
         type: string
       chart:
         description: Required when creating
+        type: string
+      description:
+        description: Generally the Git commit message
         type: string
       gitBranch:
         type: string
@@ -516,6 +525,9 @@ definitions:
       chartVersion:
         description: Required when creating
         type: string
+      description:
+        description: Generally the Git commit message
+        type: string
       parentChartVersion:
         type: string
     type: object
@@ -583,6 +595,12 @@ definitions:
         description: Required for dynamic environments
         type: string
     type: object
+  v2controllers.EditableAppVersion:
+    properties:
+      description:
+        description: Generally the Git commit message
+        type: string
+    type: object
   v2controllers.EditableChart:
     properties:
       appImageGitMainBranch:
@@ -617,6 +635,12 @@ definitions:
         type: string
       subdomain:
         description: When creating, will use the chart's default if left empty
+        type: string
+    type: object
+  v2controllers.EditableChartVersion:
+    properties:
+      description:
+        description: Generally the Git commit message
         type: string
     type: object
   v2controllers.EditableCluster:
@@ -728,6 +752,10 @@ paths:
         type: string
       - in: query
         name: createdAt
+        type: string
+      - description: Generally the Git commit message
+        in: query
+        name: description
         type: string
       - in: query
         name: gitBranch
@@ -878,6 +906,59 @@ paths:
           schema:
             $ref: '#/definitions/errors.ErrorResponse'
       summary: Get a AppVersion entry
+      tags:
+      - AppVersions
+    patch:
+      consumes:
+      - application/json
+      description: 'Edit an existing AppVersion entry via one its "selectors": chart/version
+        or numeric ID. Note that only mutable fields are available here, immutable
+        fields can only be set using /create.'
+      parameters:
+      - description: 'The AppVersion to edit''s selector: chart/version or numeric
+          ID'
+        in: path
+        name: selector
+        required: true
+        type: string
+      - description: The edits to make to the AppVersion
+        in: body
+        name: app-version
+        required: true
+        schema:
+          $ref: '#/definitions/v2controllers.EditableAppVersion'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/v2controllers.AppVersion'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/errors.ErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/errors.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/errors.ErrorResponse'
+        "407":
+          description: Proxy Authentication Required
+          schema:
+            $ref: '#/definitions/errors.ErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/errors.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/errors.ErrorResponse'
+      summary: Edit a AppVersion entry
       tags:
       - AppVersions
   /api/v2/changesets:
@@ -1435,6 +1516,10 @@ paths:
       - in: query
         name: createdAt
         type: string
+      - description: Generally the Git commit message
+        in: query
+        name: description
+        type: string
       - in: query
         name: id
         type: integer
@@ -1578,6 +1663,59 @@ paths:
           schema:
             $ref: '#/definitions/errors.ErrorResponse'
       summary: Get a ChartVersion entry
+      tags:
+      - ChartVersions
+    patch:
+      consumes:
+      - application/json
+      description: 'Edit an existing ChartVersion entry via one its "selectors": chart/version
+        or numeric ID. Note that only mutable fields are available here, immutable
+        fields can only be set using /create.'
+      parameters:
+      - description: 'The ChartVersion to edit''s selector: chart/version or numeric
+          ID'
+        in: path
+        name: selector
+        required: true
+        type: string
+      - description: The edits to make to the ChartVersion
+        in: body
+        name: chart-version
+        required: true
+        schema:
+          $ref: '#/definitions/v2controllers.EditableChartVersion'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/v2controllers.ChartVersion'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/errors.ErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/errors.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/errors.ErrorResponse'
+        "407":
+          description: Proxy Authentication Required
+          schema:
+            $ref: '#/definitions/errors.ErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/errors.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/errors.ErrorResponse'
+      summary: Edit a ChartVersion entry
       tags:
       - ChartVersions
   /api/v2/charts:

--- a/internal/controllers/v2controllers/app_version.go
+++ b/internal/controllers/v2controllers/app_version.go
@@ -24,7 +24,9 @@ type CreatableAppVersion struct {
 	EditableAppVersion
 }
 
-type EditableAppVersion struct{}
+type EditableAppVersion struct {
+	Description string `json:"description" form:"description"` // Generally the Git commit message
+}
 
 //nolint:unused
 func (c CreatableAppVersion) toReadable() AppVersion {
@@ -75,11 +77,12 @@ func modelAppVersionToAppVersion(model *v2models.AppVersion) *AppVersion {
 		ChartInfo:            chart,
 		ParentAppVersionInfo: parentAppVersion,
 		CreatableAppVersion: CreatableAppVersion{
-			Chart:            chartName,
-			AppVersion:       model.AppVersion,
-			GitCommit:        model.GitCommit,
-			GitBranch:        model.GitBranch,
-			ParentAppVersion: parentAppVersionSelector,
+			Chart:              chartName,
+			AppVersion:         model.AppVersion,
+			GitCommit:          model.GitCommit,
+			GitBranch:          model.GitBranch,
+			ParentAppVersion:   parentAppVersionSelector,
+			EditableAppVersion: EditableAppVersion{Description: model.Description},
 		},
 	}
 }
@@ -116,5 +119,6 @@ func appVersionToModelAppVersion(appVersion AppVersion, stores *v2models.StoreSe
 		GitCommit:          appVersion.GitCommit,
 		GitBranch:          appVersion.GitBranch,
 		ParentAppVersionID: parentAppVersionID,
+		Description:        appVersion.Description,
 	}, nil
 }

--- a/internal/controllers/v2controllers/app_version_test.go
+++ b/internal/controllers/v2controllers/app_version_test.go
@@ -292,15 +292,16 @@ func (suite *appVersionControllerSuite) TestAppVersionGetOtherValidSelectors() {
 }
 
 func (suite *appVersionControllerSuite) TestAppVersionEdit() {
-	suite.Run("'successfully' but there's no fields", func() {
+	suite.Run("successfully", func() {
 		db.Truncate(suite.T(), suite.db)
 		suite.seedCharts(suite.T())
 		suite.seedAppVersions(suite.T())
 		appVersions, _ := suite.AppVersionController.ListAllMatching(AppVersion{}, 1)
 		anID := fmt.Sprintf("%d", appVersions[0].ID)
 
-		_, err := suite.AppVersionController.Edit(anID, EditableAppVersion{}, auth.GenerateUser(suite.T(), false))
+		response, err := suite.AppVersionController.Edit(anID, EditableAppVersion{Description: "blah"}, auth.GenerateUser(suite.T(), false))
 		assert.NoError(suite.T(), err)
+		assert.Equal(suite.T(), "blah", response.Description)
 	})
 }
 

--- a/internal/controllers/v2controllers/chart_version.go
+++ b/internal/controllers/v2controllers/chart_version.go
@@ -22,7 +22,9 @@ type CreatableChartVersion struct {
 	EditableChartVersion
 }
 
-type EditableChartVersion struct{}
+type EditableChartVersion struct {
+	Description string `json:"description" form:"description"` // Generally the Git commit message
+}
 
 //nolint:unused
 func (c CreatableChartVersion) toReadable() ChartVersion {
@@ -73,9 +75,10 @@ func modelChartVersionToChartVersion(model *v2models.ChartVersion) *ChartVersion
 		ChartInfo:              chart,
 		ParentChartVersionInfo: parentChartVersion,
 		CreatableChartVersion: CreatableChartVersion{
-			Chart:              chartName,
-			ChartVersion:       model.ChartVersion,
-			ParentChartVersion: parentChartVersionSelector,
+			Chart:                chartName,
+			ChartVersion:         model.ChartVersion,
+			ParentChartVersion:   parentChartVersionSelector,
+			EditableChartVersion: EditableChartVersion{Description: model.Description},
 		},
 	}
 }
@@ -110,5 +113,6 @@ func chartVersionToModelChartVersion(chartVersion ChartVersion, stores *v2models
 		ChartID:              chartID,
 		ChartVersion:         chartVersion.ChartVersion,
 		ParentChartVersionID: parentChartVersionID,
+		Description:          chartVersion.Description,
 	}, nil
 }

--- a/internal/controllers/v2controllers/chart_version_test.go
+++ b/internal/controllers/v2controllers/chart_version_test.go
@@ -262,15 +262,16 @@ func (suite *chartVersionControllerSuite) TestChartVersionGetOtherValidSelectors
 }
 
 func (suite *chartVersionControllerSuite) TestChartVersionEdit() {
-	suite.Run("'successfully' but there's no fields", func() {
+	suite.Run("successfully", func() {
 		db.Truncate(suite.T(), suite.db)
 		suite.seedCharts(suite.T())
 		suite.seedChartVersions(suite.T())
 		chartVersions, _ := suite.ChartVersionController.ListAllMatching(ChartVersion{}, 1)
 		anID := fmt.Sprintf("%d", chartVersions[0].ID)
 
-		_, err := suite.ChartVersionController.Edit(anID, EditableChartVersion{}, auth.GenerateUser(suite.T(), false))
+		response, err := suite.ChartVersionController.Edit(anID, EditableChartVersion{Description: "blah"}, auth.GenerateUser(suite.T(), false))
 		assert.NoError(suite.T(), err)
+		assert.Equal(suite.T(), "blah", response.Description)
 	})
 }
 

--- a/internal/handlers/v2handlers/app_version.go
+++ b/internal/handlers/v2handlers/app_version.go
@@ -9,6 +9,7 @@ func RegisterAppVersionHandlers(routerGroup *gin.RouterGroup, controller *v2cont
 	routerGroup.POST("/app-versions", createAppVersion(controller))
 	routerGroup.GET("/app-versions", listAppVersion(controller))
 	routerGroup.GET("/app-versions/*selector", getAppVersion(controller))
+	routerGroup.PATCH("/app-versions/*selector", editAppVersion(controller))
 	routerGroup.GET("/selectors/app-versions/*selector", listAppVersionSelectors(controller))
 }
 
@@ -52,6 +53,21 @@ func listAppVersion(controller *v2controllers.AppVersionController) func(ctx *gi
 // @router      /api/v2/app-versions/{selector} [get]
 func getAppVersion(controller *v2controllers.AppVersionController) func(ctx *gin.Context) {
 	return handleGet(controller)
+}
+
+// editAppVersion godoc
+// @summary     Edit a AppVersion entry
+// @description Edit an existing AppVersion entry via one its "selectors": chart/version or numeric ID. Note that only mutable fields are available here, immutable fields can only be set using /create.
+// @tags        AppVersions
+// @accept      json
+// @produce     json
+// @param       selector                path     string                           true "The AppVersion to edit's selector: chart/version or numeric ID"
+// @param       app-version             body     v2controllers.EditableAppVersion true "The edits to make to the AppVersion"
+// @success     200                     {object} v2controllers.AppVersion
+// @failure     400,403,404,407,409,500 {object} errors.ErrorResponse
+// @router      /api/v2/app-versions/{selector} [patch]
+func editAppVersion(controller *v2controllers.AppVersionController) func(ctx *gin.Context) {
+	return handleEdit(controller)
 }
 
 // listAppVersionSelectors godoc

--- a/internal/handlers/v2handlers/chart_version.go
+++ b/internal/handlers/v2handlers/chart_version.go
@@ -9,6 +9,7 @@ func RegisterChartVersionHandlers(routerGroup *gin.RouterGroup, controller *v2co
 	routerGroup.POST("/chart-versions", createChartVersion(controller))
 	routerGroup.GET("/chart-versions", listChartVersion(controller))
 	routerGroup.GET("/chart-versions/*selector", getChartVersion(controller))
+	routerGroup.PATCH("/chart-versions/*selector", editChartVersion(controller))
 	routerGroup.GET("/selectors/chart-versions/*selector", listChartVersionSelectors(controller))
 }
 
@@ -52,6 +53,21 @@ func listChartVersion(controller *v2controllers.ChartVersionController) func(ctx
 // @router      /api/v2/chart-versions/{selector} [get]
 func getChartVersion(controller *v2controllers.ChartVersionController) func(ctx *gin.Context) {
 	return handleGet(controller)
+}
+
+// editChartVersion godoc
+// @summary     Edit a ChartVersion entry
+// @description Edit an existing ChartVersion entry via one its "selectors": chart/version or numeric ID. Note that only mutable fields are available here, immutable fields can only be set using /create.
+// @tags        ChartVersions
+// @accept      json
+// @produce     json
+// @param       selector                path     string                             true "The ChartVersion to edit's selector: chart/version or numeric ID"
+// @param       chart-version           body     v2controllers.EditableChartVersion true "The edits to make to the ChartVersion"
+// @success     200                     {object} v2controllers.ChartVersion
+// @failure     400,403,404,407,409,500 {object} errors.ErrorResponse
+// @router      /api/v2/chart-versions/{selector} [patch]
+func editChartVersion(controller *v2controllers.ChartVersionController) func(ctx *gin.Context) {
+	return handleEdit(controller)
 }
 
 // listChartVersionSelectors godoc

--- a/internal/models/v2models/app_version.go
+++ b/internal/models/v2models/app_version.go
@@ -15,6 +15,7 @@ type AppVersion struct {
 	AppVersion         string `gorm:"not null: default:null"`
 	GitCommit          string
 	GitBranch          string
+	Description        string
 	ParentAppVersion   *AppVersion
 	ParentAppVersionID *uint
 }

--- a/internal/models/v2models/chart_version.go
+++ b/internal/models/v2models/chart_version.go
@@ -13,6 +13,7 @@ type ChartVersion struct {
 	Chart                *Chart
 	ChartID              uint   `gorm:"not null: default:null"`
 	ChartVersion         string `gorm:"not null: default:null"`
+	Description          string
 	ParentChartVersion   *ChartVersion
 	ParentChartVersionID *uint
 }


### PR DESCRIPTION
- Easy enough to add when calling the API from GitHub Actions or whatever
- Saves me from DDOSing GitHub’s API from Beehive
  - Also chart versions don’t have git info stored because they’re git-agnostic, so this is important for having the info there
- Lets us make this info editable in Beehive, which might be useful. Not like that’s hard to do in Beehive anyway

In other words, I think allowing storage of git commit messages or some other equivalent string inside Sherlock makes sense so I'm going to do it now because it is faster this way than trying to engineer a hacky temporary solution in Beehive. This took like 15 minutes.