### PR TITLE
[DDO-2395] Truncate version change logs if we weren't able to assemble a fully correct one

### DIFF
--- a/internal/controllers/v2controllers/changeset_test.go
+++ b/internal/controllers/v2controllers/changeset_test.go
@@ -342,7 +342,7 @@ func (suite *changesetControllerSuite) TestChangesetFlow() {
 	assert.ErrorContains(suite.T(), err, "mismatched chart")
 
 	// We can go to arbitrary chart and app versions too:
-	_, err = suite.ChangesetController.PlanAndApply(ChangesetPlanRequest{
+	applied, err = suite.ChangesetController.PlanAndApply(ChangesetPlanRequest{
 		ChartReleases: []ChangesetPlanRequestChartReleaseEntry{
 			{CreatableChangeset: CreatableChangeset{
 				ChartRelease:        fmt.Sprintf("%s/%s", newBee.Name, "sam"),
@@ -352,4 +352,7 @@ func (suite *changesetControllerSuite) TestChangesetFlow() {
 		},
 	}, auth.GenerateUser(suite.T(), true))
 	assert.NoError(suite.T(), err)
+	// And the changelogs don't balloon in size:
+	assert.Len(suite.T(), applied[0].NewAppVersions, 1)
+	assert.Len(suite.T(), applied[0].NewChartVersions, 1)
 }

--- a/internal/models/v2models/changeset.go
+++ b/internal/models/v2models/changeset.go
@@ -116,7 +116,10 @@ func preCreateChangeset(db *gorm.DB, toCreate *Changeset, _ *auth.User) error {
 					break
 				}
 			}
-			if len(observedVersions) > 0 && observedVersions[len(observedVersions)] != nil && observedVersions[len(observedVersions)].ID == *toCreate.From.AppVersionID {
+			if len(observedVersions) > 0 &&
+				observedVersions[len(observedVersions)-1] != nil &&
+				observedVersions[len(observedVersions)-1].ParentAppVersionID != nil &&
+				*observedVersions[len(observedVersions)-1].ParentAppVersionID == *toCreate.From.AppVersionID {
 				toCreate.NewAppVersions = observedVersions
 			} else {
 				// If we didn't end up connecting the tree, just include the most recent rather than literally every version.
@@ -146,7 +149,10 @@ func preCreateChangeset(db *gorm.DB, toCreate *Changeset, _ *auth.User) error {
 					break
 				}
 			}
-			if len(observedVersions) > 0 && observedVersions[len(observedVersions)] != nil && observedVersions[len(observedVersions)].ID == *toCreate.From.ChartVersionID {
+			if len(observedVersions) > 0 &&
+				observedVersions[len(observedVersions)-1] != nil &&
+				observedVersions[len(observedVersions)-1].ParentChartVersionID != nil &&
+				*observedVersions[len(observedVersions)-1].ParentChartVersionID == *toCreate.From.ChartVersionID {
 				toCreate.NewChartVersions = observedVersions
 			} else {
 				// If we didn't end up connecting the tree, just include the most recent rather than literally every version.

--- a/internal/models/v2models/changeset.go
+++ b/internal/models/v2models/changeset.go
@@ -96,62 +96,61 @@ func preCreateChangeset(db *gorm.DB, toCreate *Changeset, _ *auth.User) error {
 
 		// List new app versions
 		if toCreate.From.AppVersionID != nil && toCreate.To.AppVersionID != nil && *toCreate.From.AppVersionID != *toCreate.To.AppVersionID {
+			var observedVersions []*AppVersion
 			newVersion := toCreate.To.AppVersion
-			for *toCreate.From.AppVersionID != newVersion.ID {
-				if newVersion != nil {
-					isActuallyNew := true
-					for _, listedVersion := range toCreate.NewAppVersions {
-						if listedVersion.ID == newVersion.ID {
-							isActuallyNew = false
-						}
-					}
-					if isActuallyNew {
-						toCreate.NewAppVersions = append(toCreate.NewAppVersions, newVersion)
-						if newVersion.ParentAppVersionID != nil {
-							potentialNewVersion, err := appVersionStore.get(db, AppVersion{Model: gorm.Model{ID: *newVersion.ParentAppVersionID}})
-							if err == nil {
-								newVersion = &potentialNewVersion
-							} else {
-								break
-							}
-						} else {
-							break
-						}
-					} else {
+			for newVersion != nil && *toCreate.From.AppVersionID != newVersion.ID {
+				for _, observedVersion := range observedVersions {
+					if observedVersion.ID == newVersion.ID {
 						break
 					}
 				}
+				observedVersions = append(observedVersions, newVersion)
+				if newVersion.ParentAppVersionID != nil {
+					potentialNewVersion, err := appVersionStore.get(db, AppVersion{Model: gorm.Model{ID: *newVersion.ParentAppVersionID}})
+					if err == nil {
+						newVersion = &potentialNewVersion
+					} else {
+						break
+					}
+				} else {
+					break
+				}
+			}
+			if len(observedVersions) > 0 && observedVersions[len(observedVersions)] != nil && observedVersions[len(observedVersions)].ID == *toCreate.From.AppVersionID {
+				toCreate.NewAppVersions = observedVersions
+			} else {
+				// If we didn't end up connecting the tree, just include the most recent rather than literally every version.
+				toCreate.NewAppVersions = []*AppVersion{toCreate.To.AppVersion}
 			}
 		}
 
 		// List new chart versions
 		if toCreate.From.ChartVersionID != nil && toCreate.To.ChartVersionID != nil && *toCreate.From.ChartVersionID != *toCreate.To.ChartVersionID {
+			var observedVersions []*ChartVersion
 			newVersion := toCreate.To.ChartVersion
-			for *toCreate.From.ChartVersionID != newVersion.ID {
-				if newVersion != nil {
-					isActuallyNew := true
-					for _, listedVersion := range toCreate.NewChartVersions {
-						if listedVersion.ID == newVersion.ID {
-							isActuallyNew = false
-						}
-					}
-					if isActuallyNew {
-						toCreate.NewChartVersions = append(toCreate.NewChartVersions, newVersion)
-						if newVersion.ParentChartVersionID != nil {
-							potentialNewVersion, err := chartVersionStore.get(db, ChartVersion{Model: gorm.Model{ID: *newVersion.ParentChartVersionID}})
-							if err == nil {
-								newVersion = &potentialNewVersion
-							} else {
-								break
-							}
-						} else {
-							break
-						}
-					} else {
+			for newVersion != nil && *toCreate.From.ChartVersionID != newVersion.ID {
+				for _, observedVersion := range observedVersions {
+					if observedVersion.ID == newVersion.ID {
 						break
 					}
 				}
-
+				observedVersions = append(observedVersions, newVersion)
+				if newVersion.ParentChartVersionID != nil {
+					potentialNewVersion, err := chartVersionStore.get(db, ChartVersion{Model: gorm.Model{ID: *newVersion.ParentChartVersionID}})
+					if err == nil {
+						newVersion = &potentialNewVersion
+					} else {
+						break
+					}
+				} else {
+					break
+				}
+			}
+			if len(observedVersions) > 0 && observedVersions[len(observedVersions)] != nil && observedVersions[len(observedVersions)].ID == *toCreate.From.ChartVersionID {
+				toCreate.NewChartVersions = observedVersions
+			} else {
+				// If we didn't end up connecting the tree, just include the most recent rather than literally every version.
+				toCreate.NewChartVersions = []*ChartVersion{toCreate.To.ChartVersion}
 			}
 		}
 	}


### PR DESCRIPTION
[Lots more context in the ticket.](https://broadworkbench.atlassian.net/browse/DDO-2395) I might eventually add logic here to assemble a correct one more often, but I kinda don't want to do that now because it's hard and regardless we'll want this better failure mode behavior.