### PR TITLE
[DDO-2396] Use distroless/static for Sherlock server

### DIFF
--- a/build/server/Dockerfile
+++ b/build/server/Dockerfile
@@ -16,6 +16,7 @@ RUN go mod download && go mod verify
 COPY . .
 RUN go build -ldflags="-X 'main.BuildVersion=${SHERLOCK_BUILD_VERSION}'" -o /bin/sherlock ./cmd/server/...
 
-FROM alpine:${ALPINE_VERSION} as runtime
+# FROM alpine:${ALPINE_VERSION} as runtime <-- use this if you hit issues
+FROM gcr.io/distroless/static as runtime
 COPY --from=build /bin/sherlock /bin/sherlock
 ENTRYPOINT [ "/bin/sherlock" ]


### PR DESCRIPTION
1. New service checklist says to use a blessed image
2. Denis says we should just use a distroless image directly

If we need to shell into sherlock's pod we'd need to use `kubectl debug` but in my testing the image seemed to run a very tiny bit faster? I dunno, distroless means that nothing is ever gonna flag for Trivy so 🤷‍♂️ 