### PR TITLE
[DDO-2413] Make Sherlock's Changeset#equalTo() include the new firecloudDevelopRef field

### DIFF
--- a/internal/handlers/v2handlers/generic_handlers.go
+++ b/internal/handlers/v2handlers/generic_handlers.go
@@ -51,7 +51,7 @@ func handleList[M v2models.Model, R v2controllers.Readable, C v2controllers.Crea
 			ctx.JSON(errors.ErrorToApiResponse(fmt.Errorf("(%s) error parsing a filtering %T from the query parameters: %v", errors.BadRequest, filter, err)))
 			return
 		} else {
-			log.Debug().Msgf("parsing query params to %T: '%s' => %+v", filter, ctx.Request.URL.RawQuery, filter)
+			log.Trace().Msgf("parsing query params to %T: '%s' => %+v", filter, ctx.Request.URL.RawQuery, filter)
 		}
 		limitString := ctx.DefaultQuery("limit", "0")
 		limit, err := strconv.Atoi(limitString)

--- a/internal/models/v2models/chart_release_version.go
+++ b/internal/models/v2models/chart_release_version.go
@@ -228,5 +228,6 @@ func (chartReleaseVersion *ChartReleaseVersion) equalTo(other ChartReleaseVersio
 		((chartReleaseVersion.ChartVersionResolver == nil && other.ChartVersionResolver == nil) || (*chartReleaseVersion.ChartVersionResolver == *other.ChartVersionResolver)) &&
 		((chartReleaseVersion.ChartVersionExact == nil && other.ChartVersionExact == nil) || (*chartReleaseVersion.ChartVersionExact == *other.ChartVersionExact)) &&
 		((chartReleaseVersion.ChartVersionID == nil && other.ChartVersionID == nil) || (*chartReleaseVersion.ChartVersionID == *other.ChartVersionID)) &&
-		((chartReleaseVersion.HelmfileRef == nil && other.HelmfileRef == nil) || (*chartReleaseVersion.HelmfileRef == *other.HelmfileRef))
+		((chartReleaseVersion.HelmfileRef == nil && other.HelmfileRef == nil) || (*chartReleaseVersion.HelmfileRef == *other.HelmfileRef)) &&
+		((chartReleaseVersion.FirecloudDevelopRef == nil && other.FirecloudDevelopRef == nil) || (*chartReleaseVersion.FirecloudDevelopRef == *other.FirecloudDevelopRef))
 }

--- a/internal/models/v2models/chart_release_version_test.go
+++ b/internal/models/v2models/chart_release_version_test.go
@@ -1389,6 +1389,62 @@ func TestChartReleaseVersion_equalTo(t *testing.T) {
 			}},
 			want: false,
 		},
+		{
+			name: "checks firecloud develop ref",
+			fields: fields{
+				ResolvedAt: testutils.PointerTo(time.Now()),
+
+				AppVersionResolver: testutils.PointerTo("branch"),
+				AppVersionExact:    testutils.PointerTo("v1.2.3"),
+				AppVersionCommit:   testutils.PointerTo("a1b2c3d4"),
+				AppVersionBranch:   testutils.PointerTo("main"),
+				AppVersion: &AppVersion{
+					Model:      gorm.Model{ID: 1},
+					AppVersion: "v1.2.3",
+					GitCommit:  "a1b2c3d4",
+					GitBranch:  "main",
+				},
+				AppVersionID: testutils.PointerTo[uint](1),
+
+				ChartVersionResolver: testutils.PointerTo("latest"),
+				ChartVersionExact:    testutils.PointerTo("v0.0.100"),
+				ChartVersion: &ChartVersion{
+					Model:        gorm.Model{ID: 2},
+					ChartVersion: "v0.0.100",
+				},
+				ChartVersionID: testutils.PointerTo[uint](2),
+
+				HelmfileRef:         testutils.PointerTo("e5f6g7h8"),
+				FirecloudDevelopRef: testutils.PointerTo("dev"),
+			},
+			args: args{other: ChartReleaseVersion{
+				ResolvedAt: testutils.PointerTo(time.Now()),
+
+				AppVersionResolver: testutils.PointerTo("branch"),
+				AppVersionExact:    testutils.PointerTo("v1.2.3"),
+				AppVersionCommit:   testutils.PointerTo("a1b2c3d4"),
+				AppVersionBranch:   testutils.PointerTo("main"),
+				AppVersion: &AppVersion{
+					Model:      gorm.Model{ID: 1},
+					AppVersion: "v1.2.3",
+					GitCommit:  "a1b2c3d4",
+					GitBranch:  "main",
+				},
+				AppVersionID: testutils.PointerTo[uint](1),
+
+				ChartVersionResolver: testutils.PointerTo("latest"),
+				ChartVersionExact:    testutils.PointerTo("v0.0.100"),
+				ChartVersion: &ChartVersion{
+					Model:        gorm.Model{ID: 2},
+					ChartVersion: "v0.0.100",
+				},
+				ChartVersionID: testutils.PointerTo[uint](2),
+
+				HelmfileRef:         testutils.PointerTo("e5f6g7h8"),
+				FirecloudDevelopRef: testutils.PointerTo("prod"),
+			}},
+			want: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Also, make query parameter parse logs at the trace level, since debug is noisy.