### PR TITLE
[DDO-2420] Fix "latest" bug introduced by App and Chart Versions now being editable

### DIFF
--- a/internal/controllers/v2controllers/changeset_procedures.go
+++ b/internal/controllers/v2controllers/changeset_procedures.go
@@ -89,7 +89,7 @@ func (c ChangesetController) changesetPlanRequestToModelChangesets(request Chang
 			}
 			chartsToExclude[chart.ID] = struct{}{}
 		}
-		environmentChartReleases, err := c.allStores.ChartReleaseStore.ListAllMatching(v2models.ChartRelease{EnvironmentID: &environment.ID}, 0)
+		environmentChartReleases, err := c.allStores.ChartReleaseStore.ListAllMatchingByUpdated(v2models.ChartRelease{EnvironmentID: &environment.ID}, 0)
 		if err != nil {
 			return nil, fmt.Errorf("error getting chart releases in environment '%s' for environment entry %d: %v", environmentRequestEntry.Environment, index+1, err)
 		}
@@ -109,7 +109,7 @@ func (c ChangesetController) changesetPlanRequestToModelChangesets(request Chang
 			if err != nil {
 				return nil, fmt.Errorf("error getting referenced other environment '%s' for environment entry %d, '%s': %v", *environmentRequestEntry.UseExactVersionsFromOtherEnvironment, index+1, environmentRequestEntry.Environment, err)
 			}
-			otherChartReleases, err := c.allStores.ChartReleaseStore.ListAllMatching(v2models.ChartRelease{EnvironmentID: &otherEnvironment.ID}, 0)
+			otherChartReleases, err := c.allStores.ChartReleaseStore.ListAllMatchingByUpdated(v2models.ChartRelease{EnvironmentID: &otherEnvironment.ID}, 0)
 			if err != nil {
 				return nil, fmt.Errorf("error getting chart releases in referenced other environment '%s' for environment entry %d, '%s': %v", *environmentRequestEntry.UseExactVersionsFromOtherEnvironment, index+1, environmentRequestEntry.Environment, err)
 			}

--- a/internal/controllers/v2controllers/changeset_test.go
+++ b/internal/controllers/v2controllers/changeset_test.go
@@ -194,7 +194,15 @@ func (suite *changesetControllerSuite) TestChangesetFlow() {
 	assert.NoError(suite.T(), err)
 	assert.True(suite.T(), created)
 
-	// terra-dev tracks Sam mainline, so upon next refresh it would get updated:
+	// Maybe someone else happens to be editing the description of an earlier version at the same time,
+	// making that earlier version suddenly the most recently edited version:
+	_, err = suite.AppVersionController.Edit("sam/0.2.0", EditableAppVersion{
+		Description: "some random edit",
+	}, auth.GenerateUser(suite.T(), true))
+	assert.NoError(suite.T(), err)
+
+	// terra-dev tracks Sam mainline, so upon next refresh it would get updated to the most recently created version,
+	// even though an older version was just edited above:
 	applied, err = suite.ChangesetController.PlanAndApply(ChangesetPlanRequest{
 		Environments: []ChangesetPlanRequestEnvironmentEntry{
 			// Here we refresh all of terra-dev, but we could just do Sam too

--- a/internal/controllers/v2controllers/model_controller.go
+++ b/internal/controllers/v2controllers/model_controller.go
@@ -109,7 +109,7 @@ func (c ModelController[M, R, C, E]) ListAllMatching(filter R, limit int) ([]R, 
 	if err != nil {
 		return []R{}, fmt.Errorf("error parsing filter to a %T that can be queried against the database: %v", model, err)
 	}
-	results, err := c.primaryStore.ListAllMatching(model, limit)
+	results, err := c.primaryStore.ListAllMatchingByUpdated(model, limit)
 	readables := make([]R, 0)
 	for _, result := range results {
 		readables = append(readables, *c.modelToReadable(&result))

--- a/internal/models/v2models/changeset_event_store.go
+++ b/internal/models/v2models/changeset_event_store.go
@@ -128,7 +128,7 @@ func (s *internalChangesetEventStore) apply(db *gorm.DB, changesets []Changeset,
 			}
 			// Forcibly include AppliedAt and SupersededAt in the match criteria so we only find things where both of those
 			// fields are empty.
-			consumedChangesets, err := s.listAllMatching(tx, 0, Changeset{ChartReleaseID: toApply.ChartReleaseID}, "ChartReleaseID", "AppliedAt", "SupersededAt")
+			consumedChangesets, err := s.listAllMatchingByUpdated(tx, 0, Changeset{ChartReleaseID: toApply.ChartReleaseID}, "ChartReleaseID", "AppliedAt", "SupersededAt")
 			if err != nil {
 				return fmt.Errorf("post-apply error on %T %d (ID: %d): couldn't query consumed %T: %v", changeset, index+1, toApply.ID, changeset, err)
 			}

--- a/internal/models/v2models/chart_release_version.go
+++ b/internal/models/v2models/chart_release_version.go
@@ -39,7 +39,7 @@ func (chartReleaseVersion *ChartReleaseVersion) resolve(db *gorm.DB, chartQuery 
 		switch *chartReleaseVersion.AppVersionResolver {
 		case "branch":
 			if chartReleaseVersion.AppVersionBranch != nil {
-				appVersions, err := appVersionStore.listAllMatching(db, 1, AppVersion{ChartID: chart.ID, GitBranch: *chartReleaseVersion.AppVersionBranch})
+				appVersions, err := appVersionStore.listAllMatchingByCreated(db, 1, AppVersion{ChartID: chart.ID, GitBranch: *chartReleaseVersion.AppVersionBranch})
 				if err != nil {
 					return fmt.Errorf("(%s) failed to get matching app versions for branch '%s': %v", errors.InternalServerError, *chartReleaseVersion.AppVersionBranch, err)
 				} else if len(appVersions) == 0 {
@@ -57,7 +57,7 @@ func (chartReleaseVersion *ChartReleaseVersion) resolve(db *gorm.DB, chartQuery 
 				}
 				// It's ugly but we go down to basically raw SQL here so we can handle the fact that people are definitely going
 				// to specify commits with less than the full hash.
-				appVersions, err := appVersionStore.listAllMatching(db, 1, "chart_id = ? and git_commit LIKE ?", chart.ID, fmt.Sprintf("%s%%", *chartReleaseVersion.AppVersionCommit))
+				appVersions, err := appVersionStore.listAllMatchingByCreated(db, 1, "chart_id = ? and git_commit LIKE ?", chart.ID, fmt.Sprintf("%s%%", *chartReleaseVersion.AppVersionCommit))
 				if err != nil {
 					return fmt.Errorf("(%s) failed to get matching app versions for commit '%s': %v", errors.InternalServerError, *chartReleaseVersion.AppVersionCommit, err)
 				} else if len(appVersions) == 0 {
@@ -72,7 +72,7 @@ func (chartReleaseVersion *ChartReleaseVersion) resolve(db *gorm.DB, chartQuery 
 			}
 		case "exact":
 			if chartReleaseVersion.AppVersionExact != nil {
-				appVersions, err := appVersionStore.listAllMatching(db, 1, AppVersion{ChartID: chart.ID, AppVersion: *chartReleaseVersion.AppVersionExact})
+				appVersions, err := appVersionStore.listAllMatchingByCreated(db, 1, AppVersion{ChartID: chart.ID, AppVersion: *chartReleaseVersion.AppVersionExact})
 				if err == nil && len(appVersions) > 0 {
 					chartReleaseVersion.AppVersion = &appVersions[0]
 					chartReleaseVersion.AppVersionID = &appVersions[0].ID
@@ -96,7 +96,7 @@ func (chartReleaseVersion *ChartReleaseVersion) resolve(db *gorm.DB, chartQuery 
 	if chartReleaseVersion.ChartVersionResolver != nil {
 		switch *chartReleaseVersion.ChartVersionResolver {
 		case "latest":
-			chartVersions, err := chartVersionStore.listAllMatching(db, 1, ChartVersion{ChartID: chart.ID})
+			chartVersions, err := chartVersionStore.listAllMatchingByCreated(db, 1, ChartVersion{ChartID: chart.ID})
 			if err != nil {
 				return fmt.Errorf("(%s) failed to get latest chart versions for %s", errors.InternalServerError, chart.Name)
 			} else if len(chartVersions) == 0 {
@@ -107,7 +107,7 @@ func (chartReleaseVersion *ChartReleaseVersion) resolve(db *gorm.DB, chartQuery 
 			chartReleaseVersion.ChartVersionExact = &chartVersions[0].ChartVersion
 		case "exact":
 			if chartReleaseVersion.ChartVersionExact != nil {
-				chartVersions, err := chartVersionStore.listAllMatching(db, 1, ChartVersion{ChartID: chart.ID, ChartVersion: *chartReleaseVersion.ChartVersionExact})
+				chartVersions, err := chartVersionStore.listAllMatchingByCreated(db, 1, ChartVersion{ChartID: chart.ID, ChartVersion: *chartReleaseVersion.ChartVersionExact})
 				if err == nil && len(chartVersions) > 0 {
 					chartReleaseVersion.ChartVersion = &chartVersions[0]
 					chartReleaseVersion.ChartVersionID = &chartVersions[0].ID

--- a/internal/models/v2models/environment.go
+++ b/internal/models/v2models/environment.go
@@ -141,7 +141,7 @@ func postCreateEnvironment(db *gorm.DB, environment *Environment, user *auth.Use
 		*environment.ChartReleasesFromTemplate &&
 		environment.TemplateEnvironmentID != nil {
 		// This is a dynamic environment that is getting created right now, let's copy the chart releases from the template too
-		chartReleases, err := chartReleaseStore.listAllMatching(db, 0, ChartRelease{EnvironmentID: environment.TemplateEnvironmentID})
+		chartReleases, err := chartReleaseStore.listAllMatchingByUpdated(db, 0, ChartRelease{EnvironmentID: environment.TemplateEnvironmentID})
 		if err != nil {
 			return fmt.Errorf("wasn't able to list chart releases of template %s: %v", environment.TemplateEnvironment.Name, err)
 		}

--- a/internal/models/v2models/internal_model_store.go
+++ b/internal/models/v2models/internal_model_store.go
@@ -126,11 +126,19 @@ func (s internalModelStore[M]) create(db *gorm.DB, model M, user *auth.User) (M,
 }
 
 // The signature here is really loose so we don't need to go down to the raw db's Where method. The signature exposed
-// outside this package by ModelStore's ListAllMatching is more restrictive.
-func (s internalModelStore[M]) listAllMatching(db *gorm.DB, limit int, query interface{}, args ...interface{}) ([]M, error) {
+// outside this package by ModelStore's ListAllMatchingByUpdated is more restrictive.
+func (s internalModelStore[M]) listAllMatchingByUpdated(db *gorm.DB, limit int, query interface{}, args ...interface{}) ([]M, error) {
+	return s.listAllMatchingOrdered(db, limit, "updated_at desc", query, args...)
+}
+
+func (s internalModelStore[M]) listAllMatchingByCreated(db *gorm.DB, limit int, query interface{}, args ...interface{}) ([]M, error) {
+	return s.listAllMatchingOrdered(db, limit, "created_at desc", query, args...)
+}
+
+func (s internalModelStore[M]) listAllMatchingOrdered(db *gorm.DB, limit int, order string, query interface{}, args ...interface{}) ([]M, error) {
 	var modelRef M
 	var matching []M
-	tx := db.Model(&modelRef).Where(query, args...).Preload(clause.Associations).Order("updated_at desc")
+	tx := db.Model(&modelRef).Where(query, args...).Preload(clause.Associations).Order(order)
 	if limit > 0 {
 		tx = tx.Limit(limit)
 	}

--- a/internal/models/v2models/model_store.go
+++ b/internal/models/v2models/model_store.go
@@ -19,8 +19,12 @@ func (s ModelStore[M]) Create(model M, user *auth.User) (M, bool, error) {
 	return s.create(s.db, model, user)
 }
 
-func (s ModelStore[M]) ListAllMatching(filter M, limit int) ([]M, error) {
-	return s.listAllMatching(s.db, limit, &filter)
+func (s ModelStore[M]) ListAllMatchingByUpdated(filter M, limit int) ([]M, error) {
+	return s.listAllMatchingByUpdated(s.db, limit, &filter)
+}
+
+func (s ModelStore[M]) ListAllMatchingByCreated(filter M, limit int) ([]M, error) {
+	return s.listAllMatchingByCreated(s.db, limit, &filter)
 }
 
 func (s ModelStore[M]) Get(selector string) (M, error) {

--- a/internal/sherlock/sherlock.go
+++ b/internal/sherlock/sherlock.go
@@ -115,13 +115,13 @@ func (a *Application) initializeMetrics() error {
 	ctx := context.Background()
 
 	if config.Config.String("metrics.accelerate.fromAPI") == "v2" {
-		//staticEnvironments, err := a.v2controllers.EnvironmentController.ListAllMatching(
+		//staticEnvironments, err := a.v2controllers.EnvironmentController.ListAllMatchingByUpdated(
 		//	v2controllers.Environment{CreatableEnvironment: v2controllers.CreatableEnvironment{Lifecycle: "static"}}, 0)
 		//if err != nil {
 		//	return err
 		//}
 		//for _, staticEnvironment := range staticEnvironments {
-		//	chartReleases, err := a.v2controllers.ChartReleaseController.ListAllMatching(
+		//	chartReleases, err := a.v2controllers.ChartReleaseController.ListAllMatchingByUpdated(
 		//		v2controllers.ChartRelease{CreatableChartRelease: v2controllers.CreatableChartRelease{Environment: staticEnvironment.Name}}, 0)
 		//	if err != nil {
 		//		return err
@@ -130,7 +130,7 @@ func (a *Application) initializeMetrics() error {
 		//		metrics.RecordDeployFrequency(ctx, chartRelease.Environment, chartRelease.Chart)
 		//
 		//		// Maybe we should allow sorting by AppliedAt? That might accomplish this the easiest
-		//		mostRecentDeploy, err := a.v2controllers.ChangesetController.ListAllMatching(
+		//		mostRecentDeploy, err := a.v2controllers.ChangesetController.ListAllMatchingByUpdated(
 		//			v2controllers.Changeset{CreatableChangeset: v2controllers.CreatableChangeset{ChartRelease: chartRelease.Name}, IsApplied: true}, 1) // We'd need to actually add IsApplied to the database for this to work, or add extra handling
 		//		if err != nil {
 		//			return err


### PR DESCRIPTION
Now that they're editable, updated_at != created_at, so we gotta order by the right thing when we care (which is only internally right now)