### PR TITLE
[DDO-2428] Unique Resource Prefix

### DIFF
--- a/db/migrations/000021_add_resource_prefix.down.sql
+++ b/db/migrations/000021_add_resource_prefix.down.sql
@@ -1,0 +1,2 @@
+alter table v2_environments
+    drop column if exists unique_resource_prefix;

--- a/db/migrations/000021_add_resource_prefix.up.sql
+++ b/db/migrations/000021_add_resource_prefix.up.sql
@@ -1,0 +1,9 @@
+-- No, this isn't unique, but older environments would've been created
+-- without this value so it is meaningless anyway. Sherlock can handle
+-- selector conflicts without completely blowing up, and prod is empty
+-- right now.
+alter table v2_environments
+    add if not exists unique_resource_prefix text DEFAULT 'aaaa' NOT NULL;
+
+alter table v2_environments
+    alter column unique_resource_prefix DROP DEFAULT;

--- a/internal/controllers/v2controllers/chart_release_test.go
+++ b/internal/controllers/v2controllers/chart_release_test.go
@@ -523,7 +523,7 @@ func (suite *chartReleaseControllerSuite) TestChartReleaseGetOtherValidSelectors
 	suite.Run("successfully", func() {
 		selectors, err := suite.ChartReleaseController.GetOtherValidSelectors(datarepoDevChartRelease.Name)
 		assert.NoError(suite.T(), err)
-		assert.Equal(suite.T(), 10, len(selectors))
+		assert.Equal(suite.T(), 12, len(selectors))
 		assert.Contains(suite.T(), selectors, datarepoDevChartRelease.Name)
 	})
 	suite.Run("unsuccessfully for non-present", func() {

--- a/internal/controllers/v2controllers/environment.go
+++ b/internal/controllers/v2controllers/environment.go
@@ -25,8 +25,9 @@ type CreatableEnvironment struct {
 	Base                      string `json:"base" form:"base"`                                                          // Required when creating
 	ChartReleasesFromTemplate *bool  `json:"chartReleasesFromTemplate" form:"chartReleasesFromTemplate" default:"true"` // Upon creation of a dynamic environment, if this is true the template's chart releases will be copied to the new environment
 	Lifecycle                 string `json:"lifecycle" form:"lifecycle" default:"dynamic"`
-	Name                      string `json:"name" form:"name"`                               // When creating, will be calculated if dynamic, required otherwise
-	TemplateEnvironment       string `json:"templateEnvironment" form:"templateEnvironment"` // Required for dynamic environments
+	Name                      string `json:"name" form:"name"`                                 // When creating, will be calculated if dynamic, required otherwise
+	TemplateEnvironment       string `json:"templateEnvironment" form:"templateEnvironment"`   // Required for dynamic environments
+	UniqueResourcePrefix      string `json:"uniqueResourcePrefix" form:"uniqueResourcePrefix"` // When creating, will be calculated if left empty
 	EditableEnvironment
 }
 
@@ -95,6 +96,7 @@ func modelEnvironmentToEnvironment(model *v2models.Environment) *Environment {
 			Lifecycle:                 model.Lifecycle,
 			Name:                      model.Name,
 			TemplateEnvironment:       templateEnvironmentName,
+			UniqueResourcePrefix:      model.UniqueResourcePrefix,
 			EditableEnvironment: EditableEnvironment{
 				DefaultCluster:             &defaultClusterName,
 				DefaultNamespace:           model.DefaultNamespace,
@@ -138,6 +140,7 @@ func environmentToModelEnvironment(environment Environment, stores *v2models.Sto
 		Name:                       environment.Name,
 		TemplateEnvironmentID:      templateEnvironmentID,
 		ValuesName:                 environment.ValuesName,
+		UniqueResourcePrefix:       environment.UniqueResourcePrefix,
 		DefaultClusterID:           defaultClusterID,
 		DefaultNamespace:           environment.DefaultNamespace,
 		DefaultFirecloudDevelopRef: environment.DefaultFirecloudDevelopRef,

--- a/internal/controllers/v2controllers/environment_test.go
+++ b/internal/controllers/v2controllers/environment_test.go
@@ -427,7 +427,7 @@ func (suite *environmentControllerSuite) TestEnvironmentGetOtherValidSelectors()
 	suite.Run("successfully", func() {
 		selectors, err := suite.EnvironmentController.GetOtherValidSelectors(terraDevEnvironment.Name)
 		assert.NoError(suite.T(), err)
-		assert.Equal(suite.T(), 2, len(selectors))
+		assert.Equal(suite.T(), 3, len(selectors))
 		assert.Equal(suite.T(), terraDevEnvironment.Name, selectors[0])
 	})
 	suite.Run("unsuccessfully for not found", func() {

--- a/internal/handlers/v2handlers/environment.go
+++ b/internal/handlers/v2handlers/environment.go
@@ -45,10 +45,10 @@ func listEnvironment(controller *v2controllers.EnvironmentController) func(ctx *
 
 // getEnvironment godoc
 // @summary     Get a Environment entry
-// @description Get an existing Environment entry via one of its "selectors": name or numeric ID.
+// @description Get an existing Environment entry via one of its "selectors": name, numeric ID, or "resource-prefix/" + the unique resource prefix.
 // @tags        Environments
 // @produce     json
-// @param       selector                path     string true "The Environment to get's selector: name or numeric ID"
+// @param       selector                path     string true "The Environment to get's selector: name, numeric ID, or "resource-prefix/" + the unique resource prefix"
 // @success     200                     {object} v2controllers.Environment
 // @failure     400,403,404,407,409,500 {object} errors.ErrorResponse
 // @router      /api/v2/environments/{selector} [get]
@@ -58,11 +58,11 @@ func getEnvironment(controller *v2controllers.EnvironmentController) func(ctx *g
 
 // editEnvironment godoc
 // @summary     Edit a Environment entry
-// @description Edit an existing Environment entry via one of its "selectors": name or numeric ID. Note that only mutable fields are available here, immutable fields can only be set using /create.
+// @description Edit an existing Environment entry via one of its "selectors": name, numeric ID. Note that only mutable fields are available here, immutable fields can only be set using /create, or "resource-prefix/" + the unique resource prefix.
 // @tags        Environments
 // @accept      json
 // @produce     json
-// @param       selector                path     string                            true "The Environment to edit's selector: name or numeric ID"
+// @param       selector                path     string                            true "The Environment to edit's selector: name, numeric ID, or "resource-prefix/" + the unique resource prefix"
 // @param       environment             body     v2controllers.EditableEnvironment true "The edits to make to the Environment"
 // @success     200                     {object} v2controllers.Environment
 // @failure     400,403,404,407,409,500 {object} errors.ErrorResponse
@@ -73,10 +73,10 @@ func editEnvironment(controller *v2controllers.EnvironmentController) func(ctx *
 
 // deleteEnvironment godoc
 // @summary     Delete a Environment entry
-// @description Delete an existing Environment entry via one of its "selectors": name or numeric ID.
+// @description Delete an existing Environment entry via one of its "selectors": name, numeric ID, or "resource-prefix/" + the unique resource prefix.
 // @tags        Environments
 // @produce     json
-// @param       selector                path     string true "The Environment to delete's selector: name or numeric ID"
+// @param       selector                path     string true "The Environment to delete's selector: name, numeric ID, or "resource-prefix/" + the unique resource prefix"
 // @success     200                     {object} v2controllers.Environment
 // @failure     400,403,404,407,409,500 {object} errors.ErrorResponse
 // @router      /api/v2/environments/{selector} [delete]

--- a/internal/models/v2models/environment.go
+++ b/internal/models/v2models/environment.go
@@ -2,11 +2,13 @@ package v2models
 
 import (
 	"fmt"
-	"strconv"
-
 	"github.com/broadinstitute/sherlock/internal/auth"
 	"github.com/broadinstitute/sherlock/internal/errors"
 	"gorm.io/gorm"
+	"math/bits"
+	"strconv"
+	"strings"
+	"time"
 )
 
 type Environment struct {
@@ -18,6 +20,7 @@ type Environment struct {
 	TemplateEnvironmentID     *uint
 	ValuesName                string
 	ChartReleasesFromTemplate *bool
+	UniqueResourcePrefix      string `gorm:"not null; default:null"`
 	// Mutable
 	DefaultCluster             *Cluster
 	DefaultClusterID           *uint
@@ -42,6 +45,7 @@ func init() {
 		modelToSelectors:         environmentToSelectors,
 		modelRequiresSuitability: environmentRequiresSuitability,
 		validateModel:            validateEnvironment,
+		preCreate:                preCreateEnvironment,
 		postCreate:               postCreateEnvironment,
 	}
 }
@@ -66,6 +70,30 @@ func environmentSelectorToQuery(_ *gorm.DB, selector string) (Environment, error
 		}
 		query.Name = selector
 		return query, nil
+	} else if strings.Count(selector, "/") == 1 { // "resource-prefix" + unique resource prefix
+		parts := strings.Split(selector, "/")
+
+		// "resource-prefix"
+		// The reason we have this at all is so that we can differentiate resource prefix selectors from name selectors.
+		// In other words, a name can't have the slash that "resource-prefix/<blah>" has, so that's our hack to tell
+		// incoming selectors apart. I expect this selector will be super rarely used but internally it'll be a
+		// safeguard against duplicates and if a human ever uses it, it'll be some weird edge case that'll be super
+		// nice to have a solution for.
+		selectorLabel := parts[0]
+		if selectorLabel != "resource-prefix" {
+			return Environment{}, fmt.Errorf("(%s) invalid environment selector %s, unique resource prefix selector needed to start with 'resource-prefix/' but was '%s/'", errors.BadRequest, selector, selectorLabel)
+		}
+
+		// unique resource prefix
+		uniqueResourcePrefix := parts[1]
+		if !(isLowerAlphaNumeric(uniqueResourcePrefix) &&
+			isStartingWithLetter(uniqueResourcePrefix) &&
+			isEndingWithAlphaNumeric(uniqueResourcePrefix) &&
+			len(uniqueResourcePrefix) == 4) {
+			return Environment{}, fmt.Errorf("(%s) invalid environment selector %s, unique resource prefix sub-selector %s was invalid", errors.BadRequest, selector, uniqueResourcePrefix)
+		}
+		query.UniqueResourcePrefix = uniqueResourcePrefix
+		return query, nil
 	}
 	return Environment{}, fmt.Errorf("(%s) invalid environment selector '%s'", errors.BadRequest, selector)
 }
@@ -78,6 +106,9 @@ func environmentToSelectors(environment *Environment) []string {
 		}
 		if environment.ID != 0 {
 			selectors = append(selectors, fmt.Sprintf("%d", environment.ID))
+		}
+		if environment.UniqueResourcePrefix != "" {
+			selectors = append(selectors, fmt.Sprintf("resource-prefix/%s", environment.UniqueResourcePrefix))
 		}
 	}
 	return selectors
@@ -132,7 +163,116 @@ func validateEnvironment(environment *Environment) error {
 	if environment.DefaultFirecloudDevelopRef == nil || *environment.DefaultFirecloudDevelopRef == "" {
 		return fmt.Errorf("a %T must have a non-empty default firecloud-develop ref", environment)
 	}
+
+	if environment.UniqueResourcePrefix == "" {
+		return fmt.Errorf("a %T must have a non-empty unique resource prefix", environment)
+	}
 	return nil
+}
+
+func preCreateEnvironment(db *gorm.DB, environment *Environment, _ *auth.User) error {
+	if environment.UniqueResourcePrefix == "" {
+		// Time to derive a unique resource prefix. /^[a-z][a-z0-9]{3}$/ and unique among
+		// all non-deleted environments. The tricky part is that environments *can* specify
+		// a custom prefix, for Thelma state-provider migration or debugging purposes.
+		//
+		// That means this algorithm needs to make sure it works before continuing. In
+		// theory, collisions should be rare.
+		//
+		// The fact that we need to verify and retry at all, though, means that the worst-
+		// case runtime behavior here is... potentially really bad. So we set a timeout,
+		// add some error messages pointing to the problem, and make an attempt at a
+		// vaguely memory-allocation-efficient solution to help lower the constant runtime
+		// factor to buy the algorithm time to run.
+		//
+		// The goal is that even if we get into a worst-case of somehow needing to iterate
+		// through a few hundred environments to find a match, we can do so fast enough
+		// that no one will care, and eventually the environments that conflict with this
+		// algorithm will get deleted and the runtime will recover.
+		var countOfAllEnvironmentsEver, candidateOccurrencesInDatabase int64
+		var unsignedCountOfAllEnvironmentsEver, iterations uint64
+		var candidate Environment
+		// First, we take advantage of the domain size as much as we can. We offset by
+		// how many environments have ever existed, knowing we'll modulo down. This
+		// ends up being like a ring buffer, where we can assume that the resulting
+		// "index" is either empty or very old (and most likely soft-deleted).
+		// Note that we use Unscoped here to include even soft-deleted environments.
+		db.Unscoped().Model(&Environment{}).Count(&countOfAllEnvironmentsEver)
+		unsignedCountOfAllEnvironmentsEver = uint64(countOfAllEnvironmentsEver)
+		// We use a strings.Builder because it offers a typed way to assemble the
+		// string while also giving us a performance boost in the form of a zero-copy
+		// method to get the resulting string.
+		sb := strings.Builder{}
+		sb.Grow(4)
+		// We set a deadline here three seconds into the future. This is purely a
+		// guess based on what we can probably get away with in proxies and UIs without
+		// needing to add additional handling.
+		for end := time.Now().Add(3 * time.Second); ; {
+			// Every 16th iteration via bitmask (faster than modulo), check if we're past the deadline
+			if iterations&15 == 0 && time.Now().After(end) {
+				return fmt.Errorf("(%s) could not derive a unique environment resource prefix, used %d iterations based on an initial lifetime environment count of %d",
+					errors.InternalServerError, iterations, countOfAllEnvironmentsEver)
+			}
+			// Write the letter bytes into the strings.Builder, from our starting count plus
+			// however many iterations we've already used. We modulo that down inside the
+			// function to encapsulate the part that cares about the string.
+			generateUniqueResourcePrefix(&sb, unsignedCountOfAllEnvironmentsEver+iterations)
+			candidate.UniqueResourcePrefix = sb.String()
+			// Check the database for this candidate prefix existing. Note that we do not use
+			// Unscoped here like we did above, because now we don't care if there is a
+			// conflict in the soft-deleted environments.
+			db.Where(&candidate).Count(&candidateOccurrencesInDatabase)
+			if candidateOccurrencesInDatabase == 0 {
+				// If the candidate prefix we just generated isn't already in a non-deleted
+				// Environment, we're good to bail
+				break
+			} else {
+				// Otherwise, reset the string builder and let's try incrementing.
+				// That there was a conflict wasn't a huge issue because eventually the
+				// environment will get deleted, but all we care about right now is
+				// finding a valid prefix ASAP so we can complete the user's transaction.
+				sb.Reset()
+				iterations++
+			}
+		}
+		if candidate.UniqueResourcePrefix == "" {
+			return fmt.Errorf("(%s) could not derive a unique environment resource prefix, used %d iterations based on an initial lifetime environment count of %d (loop exited but prefix was still empty)",
+				errors.InternalServerError, iterations, countOfAllEnvironmentsEver)
+		} else {
+			environment.UniqueResourcePrefix = candidate.UniqueResourcePrefix
+		}
+	}
+	return nil
+}
+
+// Go strings are UTF-8, and these characters all map to single bytes, so this is like a `const`
+// slice of bytes for the possible characters (a normal slice can't be a constant).
+const (
+	characterBytes       = "abcdefghijklmnopqrstuvwxyz0123456789"
+	possibleCombinations = uint64(26 * 36 * 36 * 36)
+)
+
+func generateUniqueResourcePrefix(sb *strings.Builder, number uint64) {
+	// We're assembling a string like `[r3][r2][r1][r0]`. r0 through r2 are in
+	// base 36, while r3 is in base 26 so the string always starts with a letter.
+	// r0 is the "lowest" digit, and the string is a bit similar to a hexadecimal
+	// number with letters taking on numeral values. The result is a string-y
+	// modulo representation of the input number that achieves full coverage of
+	// the domain to minimize conflicts.
+	// Example (remember that input is always modulo possibleCombinations):
+	// possibleCombinations-2 => z998
+	// possibleCombinations-1 => z999
+	// possibleCombinations   => aaaa
+	// possibleCombinations+1 => aaab
+	// possibleCombinations+2 => aaac
+	number, r0 := bits.Div64(0, number%possibleCombinations, 36)
+	number, r1 := bits.Div64(0, number, 36)
+	number, r2 := bits.Div64(0, number, 36)
+	_, r3 := bits.Div64(0, number, 26)
+	sb.WriteByte(characterBytes[r3])
+	sb.WriteByte(characterBytes[r2])
+	sb.WriteByte(characterBytes[r1])
+	sb.WriteByte(characterBytes[r0])
 }
 
 func postCreateEnvironment(db *gorm.DB, environment *Environment, user *auth.User) error {

--- a/internal/models/v2models/selector_helpers.go
+++ b/internal/models/v2models/selector_helpers.go
@@ -23,6 +23,15 @@ func isAlphaNumeric(selector string) bool {
 	return true
 }
 
+func isLowerAlphaNumeric(selector string) bool {
+	for _, r := range selector {
+		if !unicode.IsDigit(r) && !(unicode.IsLetter(r) && unicode.IsLower(r)) {
+			return false
+		}
+	}
+	return true
+}
+
 func isAlphaNumericWithHyphens(selector string) bool {
 	for _, r := range selector {
 		if !unicode.IsDigit(r) && !unicode.IsLetter(r) && r != '-' {


### PR DESCRIPTION
A resource prefix can be given during creation, in which case it will be uniqueness checked. If you don't provide one, [Sherlock will derive one guaranteed to be unique](https://github.com/broadinstitute/sherlock/pull/83/files#diff-5c8215f59953ce46e01ca7acd0dacd8abf806c7ae0607df135592bd8501f4d1fR173). We allow it to be specified on creation mainly for the state transition where we need to import existing prefixes generated with another algorithm.

The algorithm works based on a count of all environments that have ever existed. That count is converted to a "number," where `0` would become `aaaa`, `1` would become `aaab`, etc. The count is modulo the number of possibilities, keeping in mind the restriction that it lead with a letter.

```
z    9    9    9

^^   ^^   ^^   ^^
26 * 36 * 36 * 36 = 1213056
```

Sherlock checks for conflicts among environments that _currently_ exist (even though the starting number is based on all environments). If there's a conflict, it increments and tries again. Conflicts shouldn't accumulate over time, since environments will get deleted and fall out of the conflict space. The algorithm uses some tricks to be memory efficient and it has a timeout. It tries to optimistic and intentionally doesn't load all prefixes in from the database because that would be a constant-time hit when I really very rarely expect we'll have conflicts.

This prefix is added to all environment types because that's easier for me to implement. We can just ignore it when we don't care about it.

This prefix is also added as a "selector" for Environments with the form `resource-prefix/$`, so Sherlock will enforce the uniqueness constraint upon entry for a custom user-specified prefix. This means that something like [broad.io/beehive/r/environment/resource-prefix/aaaa](https://broad.io/beehive/r/environment/resource-prefix/aaaa) would redirect you to the environment with that prefix, since Beehive delegates to Sherlock for selector resolution.