### PR TITLE
DDO-2451

### DIFF
--- a/config/default_config.yaml
+++ b/config/default_config.yaml
@@ -25,7 +25,7 @@ db:
   # SQL migration files.
   autoMigrateV1: false
   autoMigrateV2: false
-  maxOpenConnections: 150
+  maxOpenConnections: 75
 
 metrics:
   accelerate:

--- a/config/default_config.yaml
+++ b/config/default_config.yaml
@@ -25,6 +25,7 @@ db:
   # SQL migration files.
   autoMigrateV1: false
   autoMigrateV2: false
+  maxOpenConnections: 150
 
 metrics:
   accelerate:


### PR DESCRIPTION
Setting a defensive upper limit on the number of open DB connections to avoid contention issues under high traffic. Max number of connections is set to 200 on the CloudSQL side.