### PR TITLE
[DDO-2496] Use PR branch itself, unmerged, when collecting app version metadata

### DIFF
--- a/.github/workflows/client-report-app-version.yaml
+++ b/.github/workflows/client-report-app-version.yaml
@@ -159,6 +159,11 @@ jobs:
 
       # Branch:
 
+      - name: "If a PR, Use the Target Branch"
+        if: ${{ inputs.use-git == true && inputs.override-branch == '' && github.head_ref != '' }}
+        shell: bash
+        run: |
+          git checkout ${{ github.head_ref }}
       - name: "Parse Branch From Git"
         if: ${{ inputs.use-git == true && inputs.override-branch == '' }}
         shell: bash


### PR DESCRIPTION
By default, the checked out branch on a run from a PR will be a merge commit. That makes the contents correct, but not the metadata, which is what we actually want.