### PR TITLE
[DDO-2520] New client actions

### DIFF
--- a/.github/workflows/client-get-environment.yaml
+++ b/.github/workflows/client-get-environment.yaml
@@ -1,0 +1,90 @@
+name: Get Environment
+
+on:
+  workflow_call:
+
+    inputs:
+
+      ##
+      ## Required configuration:
+      ##
+
+      environment-name:
+        required: true
+        type: string
+        description: "The name of the environment to get"
+
+      ##
+      ## Sherlock configuration:
+      ##
+
+      use-sherlock-dev:
+        required: false
+        type: boolean
+        default: false
+        description: "If the environment should be gotten from the DevOps-use development Sherlock instance instead of the general-use production instance"
+
+    outputs:
+      lifecycle:
+        description: "The lifecycle of the environment"
+        value: ${{ steps.get.outputs.lifecycle }}
+      owner:
+        description: "The owner of the environment"
+        value: ${{ steps.get.outputs.owner }}
+
+env:
+  SHERLOCK_PROD_URL: 'https://sherlock.dsp-devops.broadinstitute.org'
+  SHERLOCK_DEV_URL: 'https://sherlock-dev.dsp-devops.broadinstitute.org'
+  BEEHIVE_PROD_URL: 'https://beehive.dsp-devops.broadinsitute.org'
+  BEEHIVE_DEV_URL: 'https://beehive-dev.dsp-devops.broadinstitute.org'
+  BEEHIVE_PROD_VANITY_URL: 'https://broad.io/beehive'
+  BEEHIVE_DEV_VANITY_URL: 'https://broad.io/beehive-dev'
+
+jobs:
+  get:
+    runs-on: ubuntu-22.04
+    permissions:
+      id-token: 'write'
+    outputs:
+      lifecycle: ${{ steps.parse.outputs.lifecycle }}
+      owner: ${{ steps.parse.outputs.owner }}
+    steps:
+      - name: "Authenticate to GCP"
+        id: 'auth'
+        uses: google-github-actions/auth@v0
+        with:
+          workload_identity_provider: 'projects/1038484894585/locations/global/workloadIdentityPools/github-wi-pool/providers/github-wi-provider'
+          service_account: 'dsp-tools-iap-access@dsp-tools-k8s.iam.gserviceaccount.com'
+          token_format: 'id_token'
+          id_token_audience: '1038484894585-k8qvf7l876733laev0lm8kenfa2lj6bn.apps.googleusercontent.com'
+          id_token_include_email: true
+          create_credentials_file: false
+          export_environment_variables: false
+
+      - name: "Get from Sherlock Dev"
+        if: ${{ inputs.use-sherlock-dev == true }}
+        shell: bash
+        run: |
+          set -ex
+          curl --fail-with-body \
+            "$SHERLOCK_DEV_URL/api/v2/environments/${{ inputs.environment-name }}" \
+            -H 'Content-Type: application/json' \
+            -H 'Authorization: Bearer ${{ steps.auth.outputs.id_token }}' \
+            -o "$RUNNER_TEMP/response.json"
+
+      - name: "Get from Sherlock Prod"
+        if: ${{ inputs.use-sherlock-dev == false }}
+        shell: bash
+        run: |
+          set -ex
+          curl --fail-with-body \
+            "$SHERLOCK_PROD_URL/api/v2/environments/${{ inputs.environment-name }}" \
+            -H 'Content-Type: application/json' \
+            -H 'Authorization: Bearer ${{ steps.auth.outputs.id_token }}' \
+            -o "$RUNNER_TEMP/response.json"
+      
+      - name: "Parse Outputs"
+        id: 'parse'
+        shell: bash
+        run: |
+          jq -r 'to_entries | map("\(.key)=\(.value|tostring)") | .[]' $RUNNER_TEMP/response.json >> $GITHUB_OUTPUT

--- a/.github/workflows/client-get-environment.yaml
+++ b/.github/workflows/client-get-environment.yaml
@@ -1,5 +1,26 @@
 name: Get Environment
 
+# This workflow provides GitHub Actions native access to information about Sherlock environments.
+#
+# The caller repository must have Workload Identity Federation configured to allow impersonation of the
+# "dsp-tools-iap-access@dsp-tools-k8s.iam.gserviceaccount.com" service account; steps 1 and 2 of the documentation:
+# https://docs.google.com/document/d/1bnhDmWQHAMat_Saoa_z28FHwXmGWw6kywjdbKf208h4/edit
+#
+# With that configured, here's how you can call this workflow:
+# ```yaml
+# jobs:
+#
+#   get-environment:
+#     uses: broadinstitute/sherlock/.github/workflows/client-get-environment.yaml@main
+#     with:
+#       environment-name: '<the-environment-to-get>'
+#     permissions:
+#       id-token: 'write'
+# ```
+#
+# For more information on using called workflow outputs, see 
+# https://docs.github.com/en/actions/using-workflows/reusing-workflows#using-outputs-from-a-reusable-workflow
+
 on:
   workflow_call:
 

--- a/.github/workflows/client-get-environment.yaml
+++ b/.github/workflows/client-get-environment.yaml
@@ -27,10 +27,10 @@ on:
     outputs:
       lifecycle:
         description: "The lifecycle of the environment"
-        value: ${{ steps.get.outputs.lifecycle }}
+        value: ${{ jobs.get.outputs.lifecycle }}
       owner:
         description: "The owner of the environment"
-        value: ${{ steps.get.outputs.owner }}
+        value: ${{ jobs.get.outputs.owner }}
 
 env:
   SHERLOCK_PROD_URL: 'https://sherlock.dsp-devops.broadinstitute.org'

--- a/.github/workflows/client-set-environment-app-version.yaml
+++ b/.github/workflows/client-set-environment-app-version.yaml
@@ -194,10 +194,19 @@ jobs:
             -d "@$RUNNER_TEMP/body.json" | jq
           echo "Available in Beehive's dev instance at $BEEHIVE_DEV_VANITY_URL/r/chart-release/${{ inputs.environment-name }}/${{ inputs.chart-name }}" >> $GITHUB_STEP_SUMMARY
 
-  sync:
+  get-environment:
+    # We do this so that we don't accidentally try to have Thelma sync something that's just a template instance. Runs in parallel and super quick so why not.
     if: ${{ secrets.sync-github-token != '' }}
+    uses: ./github/workflows/client-get-environment.yaml
+    permissions:
+      id-token: 'write'
+    with:
+      environment-name: ${{ inputs.environment-name }}
+
+  sync:
+    needs: [report, get-environment]
+    if: ${{ secrets.sync-github-token != '' && needs.get-environment.outputs.lifecycle != 'template' }}
     runs-on: ubuntu-latest
-    needs: report
     steps:
 
       ##

--- a/.github/workflows/client-set-environment-app-version.yaml
+++ b/.github/workflows/client-set-environment-app-version.yaml
@@ -30,9 +30,44 @@ name: Set Environment App Version
 #     permissions:
 #       id-token: 'write'
 # ```
+#
+# If you'd like to automatically sync the environment--meaning deploy whatever changes were made--you can provide
+# a custom GitHub token to the workflow. It cannot be default one in the workflow as default tokens cannot use
+# the workflow dispatch API.
+#
+# An example, assuming your repo has the BROADBOT_TOKEN available:
+# ```yaml
+# jobs:
+#
+#   <your-existing-job-id>:
+#     # Output the version from your existing job's tag/bump step, something like this:
+#     outputs:
+#       tag: ${{ steps.tag.outputs.tag }}
+#     steps:
+#       # ... (The rest of your existing job can stay the same)
+#
+#   set-app-version-in-environment:
+#     uses: broadinstitute/sherlock/.github/workflows/client-set-environment-app-version.yaml@main
+#     needs: <your-existing-job-id>
+#     with:
+#       new-version: ${{ needs.<your-existing-job-id>.outputs.tag }}
+#       chart-name: '<your-app-helm-chart-name>'
+#       environment-name: '<the-environment-to-update>'
+#     secrets:
+#       sync-git-token: ${{ secrets.BROADBOT_TOKEN }}
+#     permissions:
+#       id-token: 'write'
+# ```
+
 
 on:
   workflow_call:
+
+    secrets:
+      sync-git-token:
+        required: false
+        description: "When provided, finish by calling out to terra-github-workflows to sync the affected chart release"
+
     inputs:
 
       ##
@@ -87,7 +122,7 @@ env:
   BEEHIVE_DEV_VANITY_URL: 'https://broad.io/beehive-dev'
 
 jobs:
-  report:
+  set:
     runs-on: ubuntu-22.04
     permissions:
       id-token: 'write'
@@ -158,3 +193,22 @@ jobs:
             -H 'Authorization: Bearer ${{ steps.auth.outputs.id_token }}' \
             -d "@$RUNNER_TEMP/body.json" | jq
           echo "Available in Beehive's dev instance at $BEEHIVE_DEV_VANITY_URL/r/chart-release/${{ inputs.environment-name }}/${{ inputs.chart-name }}" >> $GITHUB_STEP_SUMMARY
+
+  sync:
+    if: ${{ secrets.sync-github-token != '' }}
+    runs-on: ubuntu-latest
+    needs: report
+    steps:
+
+      ##
+      ## Handle syncing:
+      ##
+
+      - name: "Dispatch to terra-github-workflows"
+        uses: aurelien-baudet/workflow-dispatch@v2
+        with: 
+          repo: broadinstitute/terra-github-workflows
+          workflow: sync-release
+          ref: refs/heads/main
+          token: ${{ secrets.sync-github-token }}
+          inputs: '{ "chart-release-names": "${{ inputs.environment-name }}/${{ inputs.chart-name }}" }'


### PR DESCRIPTION
- Adds client-get-environment, which is a GHA-native mechanism to grab some info about an environment. Can easily extend it over time--just means we don't need to write curls and bash everywhere.
- Extends client-set-environment-app-version, so if you pass a GH token it'll call terra-github-workflows to sync whatever got updated. It uses client-get-environment to be smart about how it treats templates just to avoid the user gotcha.
  - client-set-environment-app-version already had parity with terra-helmfile's update-service, but now it actually has full parity with fc-jenkins's gke-update-service, which is neat.