### PR TITLE
DDO-2522 Fix missing input to workflow dispatch

### DIFF
--- a/.github/workflows/client-set-environment-app-version.yaml
+++ b/.github/workflows/client-set-environment-app-version.yaml
@@ -234,4 +234,4 @@ jobs:
           workflow: sync-release
           ref: refs/heads/main
           token: ${{ secrets.sync-git-token }}
-          inputs: '{ "chart-release-names": "${{ inputs.environment-name }}/${{ inputs.chart-name }}" }'
+          inputs: '{ "chart-release-names": "${{ inputs.environment-name }}/${{ inputs.chart-name }}", "refresh-only": "${{ needs.should-sync.outputs.should-sync }}" }'

--- a/.github/workflows/client-set-environment-app-version.yaml
+++ b/.github/workflows/client-set-environment-app-version.yaml
@@ -234,4 +234,4 @@ jobs:
           workflow: sync-release
           ref: refs/heads/main
           token: ${{ secrets.sync-git-token }}
-          inputs: '{ "chart-release-names": "${{ inputs.environment-name }}/${{ inputs.chart-name }}", "refresh-only": "${{ needs.should-sync.outputs.should-sync }}" }'
+          inputs: '{ "chart-release-names": "${{ inputs.environment-name }}/${{ inputs.chart-name }}", "refresh-only": "false" }'


### PR DESCRIPTION
It seems like the the `sync-release` workflow in terra-github-workflows requires a boolean input of `refresh-only` that wasn't being passed here.