### PR TITLE
[DDO-2530] Tweak internal GHA naming

### DIFF
--- a/.github/workflows/client-get-chart-release.yaml
+++ b/.github/workflows/client-get-chart-release.yaml
@@ -48,13 +48,13 @@ on:
     outputs:
       name:
         description: "The name of the chart release"
-        value: ${{ jobs.get.outputs.name }}
+        value: ${{ jobs.get-chart-release.outputs.name }}
       environment:
         description: "The environment of the chart release"
-        value: ${{ jobs.get.outputs.environment }}
+        value: ${{ jobs.get-chart-release.outputs.environment }}
       cluster:
         description: "The cluster of the chart release"
-        value: ${{ jobs.get.outputs.cluster }}
+        value: ${{ jobs.get-chart-release.outputs.cluster }}
 
 env:
   SHERLOCK_PROD_URL: 'https://sherlock.dsp-devops.broadinstitute.org'

--- a/.github/workflows/client-get-chart-release.yaml
+++ b/.github/workflows/client-get-chart-release.yaml
@@ -65,7 +65,7 @@ env:
   BEEHIVE_DEV_VANITY_URL: 'https://broad.io/beehive-dev'
 
 jobs:
-  get:
+  get-chart-release:
     runs-on: ubuntu-22.04
     permissions:
       id-token: 'write'

--- a/.github/workflows/client-get-environment.yaml
+++ b/.github/workflows/client-get-environment.yaml
@@ -48,10 +48,10 @@ on:
     outputs:
       lifecycle:
         description: "The lifecycle of the environment"
-        value: ${{ jobs.get.outputs.lifecycle }}
+        value: ${{ jobs.get-environment.outputs.lifecycle }}
       owner:
         description: "The owner of the environment"
-        value: ${{ jobs.get.outputs.owner }}
+        value: ${{ jobs.get-environment.outputs.owner }}
 
 env:
   SHERLOCK_PROD_URL: 'https://sherlock.dsp-devops.broadinstitute.org'

--- a/.github/workflows/client-get-environment.yaml
+++ b/.github/workflows/client-get-environment.yaml
@@ -62,7 +62,7 @@ env:
   BEEHIVE_DEV_VANITY_URL: 'https://broad.io/beehive-dev'
 
 jobs:
-  get:
+  get-environment:
     runs-on: ubuntu-22.04
     permissions:
       id-token: 'write'

--- a/.github/workflows/client-refresh-environment.yaml
+++ b/.github/workflows/client-refresh-environment.yaml
@@ -103,7 +103,7 @@ env:
   BEEHIVE_DEV_VANITY_URL: 'https://broad.io/beehive-dev'
 
 jobs:
-  set:
+  refresh:
     runs-on: ubuntu-22.04
     permissions:
       id-token: 'write'
@@ -171,10 +171,10 @@ jobs:
             -H 'Authorization: Bearer ${{ steps.auth.outputs.id_token }}' \
             -d "@$RUNNER_TEMP/body.json" | jq
 
-  should-sync:
+  can-sync:
     runs-on: ubuntu-22.04
     outputs:
-      should-sync: ${{ steps.check.outputs.should-sync }}
+      can-sync: ${{ steps.check.outputs.can-sync }}
     steps:
     - name: "Check Token"
       id: check
@@ -182,12 +182,14 @@ jobs:
       run: |
         if [ -z "${{ secrets.sync-git-token }}" ]
         then
-          echo "should-sync=false" >> $GITHUB_OUTPUT
+          echo "can-sync=false" >> $GITHUB_OUTPUT
         else
-          echo "should-sync=true" >> $GITHUB_OUTPUT
+          echo "can-sync=true" >> $GITHUB_OUTPUT
         fi
   
   get-environment:
+    needs: can-sync
+    if: ${{ needs.can-sync.outputs.can-sync == 'true' }}
     uses: ./.github/workflows/client-get-environment.yaml
     permissions:
       id-token: 'write'
@@ -195,8 +197,8 @@ jobs:
       environment-name: ${{ inputs.environment-name }}
 
   sync:
-    needs: [set, get-environment, should-sync]
-    if: ${{ needs.should-sync.outputs.should-sync == 'true' && needs.get-environment.outputs.lifecycle != 'template' }}
+    needs: [refresh, get-environment, can-sync]
+    if: ${{ needs.can-sync.outputs.can-sync == 'true' && needs.get-environment.outputs.lifecycle != 'template' }}
     runs-on: ubuntu-latest
     steps:
 

--- a/.github/workflows/client-report-app-version.yaml
+++ b/.github/workflows/client-report-app-version.yaml
@@ -124,7 +124,7 @@ env:
   BEEHIVE_DEV_VANITY_URL: 'https://broad.io/beehive-dev'
 
 jobs:
-  report:
+  report-new-version:
     runs-on: ubuntu-22.04
     permissions:
       contents: 'read'
@@ -287,4 +287,3 @@ jobs:
             -H 'Content-Type: application/json' \
             -H 'Authorization: Bearer ${{ steps.auth.outputs.id_token }}' \
             -d "@$RUNNER_TEMP/body.json" | jq
-          echo "Available in Beehive's dev instance at $BEEHIVE_DEV_VANITY_URL/r/app-version/${{ inputs.chart-name }}/${{ inputs.new-version }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/client-set-environment-app-version.yaml
+++ b/.github/workflows/client-set-environment-app-version.yaml
@@ -129,7 +129,7 @@ jobs:
     with:
       chart-release-name: ${{ inputs.environment-name }}/${{ inputs.chart-name }}
 
-  set:
+  set-version:
     needs: get-chart-release
     runs-on: ubuntu-22.04
     permissions:
@@ -162,7 +162,7 @@ jobs:
         shell: bash
         run: |
           cat "$RUNNER_TEMP/body.json"
-          echo "## Set ${{ inputs.environment-name }}/${{ inputs.chart-name }} to ${{ inputs.new-version }} Sherlock" >> $GITHUB_STEP_SUMMARY
+          echo "## Set ${{ inputs.environment-name }}/${{ inputs.chart-name }} to ${{ inputs.chart-name }}/${{ inputs.new-version }} in Sherlock" >> $GITHUB_STEP_SUMMARY
 
       - name: "Authenticate to GCP"
         id: 'auth'
@@ -200,12 +200,11 @@ jobs:
             -H 'Content-Type: application/json' \
             -H 'Authorization: Bearer ${{ steps.auth.outputs.id_token }}' \
             -d "@$RUNNER_TEMP/body.json" | jq
-          echo "Available in Beehive's dev instance at $BEEHIVE_DEV_VANITY_URL/r/chart-release/${{ inputs.environment-name }}/${{ inputs.chart-name }}" >> $GITHUB_STEP_SUMMARY
 
-  should-sync:
+  can-sync:
     runs-on: ubuntu-22.04
     outputs:
-      should-sync: ${{ steps.check.outputs.should-sync }}
+      can-sync: ${{ steps.check.outputs.can-sync }}
     steps:
     - name: "Check Token"
       id: check
@@ -213,14 +212,14 @@ jobs:
       run: |
         if [ -z "${{ secrets.sync-git-token }}" ]
         then
-          echo "should-sync=false" >> $GITHUB_OUTPUT
+          echo "can-sync=false" >> $GITHUB_OUTPUT
         else
-          echo "should-sync=true" >> $GITHUB_OUTPUT
+          echo "can-sync=true" >> $GITHUB_OUTPUT
         fi
 
   get-environment:
-    needs: should-sync
-    if: needs.should-sync.outputs.should-sync == 'true'
+    needs: can-sync
+    if: ${{ needs.can-sync.outputs.can-sync == 'true' }}
     uses: ./.github/workflows/client-get-environment.yaml
     permissions:
       id-token: 'write'
@@ -228,8 +227,8 @@ jobs:
       environment-name: ${{ inputs.environment-name }}
 
   sync:
-    needs: [set, get-environment, get-chart-release, should-sync]
-    if: ${{ needs.should-sync.outputs.should-sync == 'true' && needs.get-environment.outputs.lifecycle != 'template' }}
+    needs: [set-version, get-environment, get-chart-release, can-sync]
+    if: ${{ needs.can-sync.outputs.can-sync == 'true' && needs.get-environment.outputs.lifecycle != 'template' }}
     runs-on: ubuntu-latest
     steps:
 


### PR DESCRIPTION
Turns out that some of the internal naming gets exposed at the top level in the workflow graph that GHA helpfully shows. I'm changing some internal stuff here to make it look prettier; here's an example of what it looks like now https://github.com/DataBiosphere/terra-workspace-manager/actions/runs/3688913109 (notice the "get" and "set" nonsense)