### PR TITLE
[DDO-2564] Allow API users to query applied Changesets for a given Chart Release

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -3083,6 +3083,86 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/v2/procedures/changesets/query-applied-for-chart-release/{selector}": {
+            "get": {
+                "description": "List existing applied Changesets for a particular Chart Release, ordered by most recently applied.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Changesets"
+                ],
+                "summary": "List applied Changesets for a Chart Release",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Selector the Chart Release to find applied Changesets for",
+                        "name": "selector",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "An optional offset to skip a number of latest Changesets",
+                        "name": "offset",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "An optional limit to the number of entries returned",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/v2controllers.Changeset"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "407": {
+                        "description": "Proxy Authentication Required",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v2/selectors/app-versions/{selector}": {
             "get": {
                 "description": "Validate a given AppVersion selector and provide any other selectors that would match the same AppVersion.",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -3077,6 +3077,86 @@
                 }
             }
         },
+        "/api/v2/procedures/changesets/query-applied-for-chart-release/{selector}": {
+            "get": {
+                "description": "List existing applied Changesets for a particular Chart Release, ordered by most recently applied.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Changesets"
+                ],
+                "summary": "List applied Changesets for a Chart Release",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Selector the Chart Release to find applied Changesets for",
+                        "name": "selector",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "An optional offset to skip a number of latest Changesets",
+                        "name": "offset",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "An optional limit to the number of entries returned",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/v2controllers.Changeset"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "407": {
+                        "description": "Proxy Authentication Required",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v2/selectors/app-versions/{selector}": {
             "get": {
                 "description": "Validate a given AppVersion selector and provide any other selectors that would match the same AppVersion.",

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -2952,6 +2952,60 @@ paths:
       summary: Plan and apply version changes in one step
       tags:
       - Changesets
+  /api/v2/procedures/changesets/query-applied-for-chart-release/{selector}:
+    get:
+      description: List existing applied Changesets for a particular Chart Release,
+        ordered by most recently applied.
+      parameters:
+      - description: Selector the Chart Release to find applied Changesets for
+        in: path
+        name: selector
+        required: true
+        type: string
+      - description: An optional offset to skip a number of latest Changesets
+        in: query
+        name: offset
+        type: integer
+      - description: An optional limit to the number of entries returned
+        in: query
+        name: limit
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/v2controllers.Changeset'
+            type: array
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/errors.ErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/errors.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/errors.ErrorResponse'
+        "407":
+          description: Proxy Authentication Required
+          schema:
+            $ref: '#/definitions/errors.ErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/errors.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/errors.ErrorResponse'
+      summary: List applied Changesets for a Chart Release
+      tags:
+      - Changesets
   /api/v2/selectors/app-versions/{selector}:
     get:
       description: Validate a given AppVersion selector and provide any other selectors

--- a/internal/controllers/v2controllers/changeset_procedures.go
+++ b/internal/controllers/v2controllers/changeset_procedures.go
@@ -216,3 +216,16 @@ func (c ChangesetController) Apply(selectors []string, user *auth.User) ([]Chang
 	}
 	return ret, nil
 }
+
+func (c ChangesetController) QueryApplied(chartReleaseSelector string, offset int, limit int) ([]Changeset, error) {
+	modelChangesets, err := c.ChangesetEventStore.QueryApplied(chartReleaseSelector, offset, limit)
+	if err != nil {
+		return nil, err
+	}
+	//golang:noinspection GoPreferNilSlice
+	ret := []Changeset{}
+	for _, modelChangeset := range modelChangesets {
+		ret = append(ret, *modelChangesetToChangeset(&modelChangeset))
+	}
+	return ret, nil
+}

--- a/internal/controllers/v2controllers/changeset_test.go
+++ b/internal/controllers/v2controllers/changeset_test.go
@@ -426,4 +426,21 @@ func (suite *changesetControllerSuite) TestChangesetFlow() {
 	assert.NoError(suite.T(), err)
 	assert.Equal(suite.T(), "my-new-version", *samInBee.AppVersionExact)
 
+	// We can also query things that were applied!
+	unapplied, err := suite.ChangesetController.Plan(ChangesetPlanRequest{
+		ChartReleases: []ChangesetPlanRequestChartReleaseEntry{
+			{CreatableChangeset: CreatableChangeset{
+				ChartRelease:         "terra-dev/sam",
+				ToAppVersionResolver: testutils.PointerTo("exact"),
+				ToAppVersionExact:    testutils.PointerTo("some fake version"),
+			}},
+		},
+	}, auth.GenerateUser(suite.T(), true))
+	assert.NoError(suite.T(), err)
+	assert.Len(suite.T(), applied, 1)
+	queried, err := suite.ChangesetController.QueryApplied("terra-dev/sam", 0, 100)
+	assert.NoError(suite.T(), err)
+	for _, result := range queried {
+		assert.NotEqual(suite.T(), unapplied[0].ID, result.ID)
+	}
 }


### PR DESCRIPTION
Supports an offset and limit which I'll have to use if I put this in Beehive because querying like this can get heavy.