### PR TITLE
[DDO-2581] Have Sherlock host a static self-closing page

### DIFF
--- a/html/close.html
+++ b/html/close.html
@@ -1,6 +1,8 @@
 <!doctype html>
 <html lang="en">
-<title>Sherlock</title>
+<head>
+    <title>Sherlock</title>
+</head>
 <!-- Attempt to window.close so that another apps can direct users here with window.open for a clean experience -->
 <script>
     window.close();

--- a/html/close.html
+++ b/html/close.html
@@ -1,0 +1,9 @@
+<html lang="en">
+<!-- Attempt to window.close so that another apps can direct users here with window.open for a clean experience -->
+<script>
+    window.close();
+</script>
+<h1>
+    You may close this window.
+</h1>
+</html>

--- a/html/close.html
+++ b/html/close.html
@@ -1,4 +1,6 @@
+<!doctype html>
 <html lang="en">
+<title>Sherlock</title>
 <!-- Attempt to window.close so that another apps can direct users here with window.open for a clean experience -->
 <script>
     window.close();

--- a/html/html.go
+++ b/html/html.go
@@ -1,0 +1,6 @@
+package html
+
+import "embed"
+
+//go:embed *.html
+var StaticHtmlFiles embed.FS

--- a/internal/sherlock/routes.go
+++ b/internal/sherlock/routes.go
@@ -2,6 +2,7 @@ package sherlock
 
 import (
 	"github.com/broadinstitute/sherlock/docs"
+	"github.com/broadinstitute/sherlock/html"
 	"github.com/broadinstitute/sherlock/internal/auth"
 	"github.com/broadinstitute/sherlock/internal/config"
 	"github.com/broadinstitute/sherlock/internal/handlers/misc"
@@ -53,6 +54,9 @@ func (a *Application) buildRouter() {
 	router.Use(func(c *gin.Context) {
 		c.Writer.Header().Set("Cache-Control", "no-store")
 	})
+
+	// serve static files
+	router.StaticFS("/static", http.FS(html.StaticHtmlFiles))
 
 	// swagger
 	router.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler))


### PR DESCRIPTION
Allows frontend Javascript on other origins to initiate user IAP sessions with Sherlock without landing the user at the Swagger page or an IAP intercept.