### PR TITLE
[DDO-2593] Fix PagerdutyIntegration handling in Environment and ChartRelease

### DIFF
--- a/internal/controllers/v2controllers/chart_release.go
+++ b/internal/controllers/v2controllers/chart_release.go
@@ -110,7 +110,7 @@ func (c ChartRelease) toModel(storeSet *v2models.StoreSet) (v2models.ChartReleas
 		chartVersionFollowChartReleaseID = &followChartRelease.ID
 	}
 	var pagerdutyIntegrationID *uint
-	if c.PagerdutyIntegration != nil {
+	if c.PagerdutyIntegration != nil && *c.PagerdutyIntegration != "" {
 		pagerdutyIntegration, err := storeSet.PagerdutyIntegration.Get(*c.PagerdutyIntegration)
 		if err != nil {
 			return v2models.ChartRelease{}, err
@@ -230,6 +230,8 @@ func modelChartReleaseToChartRelease(model *v2models.ChartRelease) *ChartRelease
 	pagerdutyIntegration := modelPagerdutyIntegrationToPagerdutyIntegration(model.PagerdutyIntegration)
 	if pagerdutyIntegration != nil {
 		pagerdutyIntegrationID = strconv.FormatUint(uint64(pagerdutyIntegration.ID), 10)
+	} else if model.PagerdutyIntegrationID != nil {
+		pagerdutyIntegrationID = strconv.FormatUint(uint64(*model.PagerdutyIntegrationID), 10)
 	}
 
 	return &ChartRelease{

--- a/internal/controllers/v2controllers/environment.go
+++ b/internal/controllers/v2controllers/environment.go
@@ -69,7 +69,7 @@ func (e Environment) toModel(storeSet *v2models.StoreSet) (v2models.Environment,
 		defaultClusterID = &defaultCluster.ID
 	}
 	var pagerdutyIntegrationID *uint
-	if e.PagerdutyIntegration != nil {
+	if e.PagerdutyIntegration != nil && *e.PagerdutyIntegration != "" {
 		pagerdutyIntegration, err := storeSet.PagerdutyIntegration.Get(*e.PagerdutyIntegration)
 		if err != nil {
 			return v2models.Environment{}, err
@@ -149,6 +149,8 @@ func modelEnvironmentToEnvironment(model *v2models.Environment) *Environment {
 	pagerdutyIntegration := modelPagerdutyIntegrationToPagerdutyIntegration(model.PagerdutyIntegration)
 	if pagerdutyIntegration != nil {
 		pagerdutyIntegrationID = strconv.FormatUint(uint64(pagerdutyIntegration.ID), 10)
+	} else if model.PagerdutyIntegrationID != nil {
+		pagerdutyIntegrationID = strconv.FormatUint(uint64(*model.PagerdutyIntegrationID), 10)
 	}
 
 	return &Environment{


### PR DESCRIPTION
- When returning an Environment or ChartRelease, if the associated PagerdutyIntegration wasn't loaded, still include its ID in the response (since the ID is in the Environment or ChartRelease's own database row, we might have it)
- When mutating an Environment or ChartRelease, at least handle the case where someone set the PagerdutyIntegration to ""
  - There's not a good way to zero out the field. For string fields, we can just store the "" in the database because "" isn't nil, so it's detected by Go as an actual value. At the database level, though, this field is a numeric ID. Not just that, it's a foreign key. We can't just set it to 0 because that's actually semantically different, and I think SQL would reject the bad association. We want to explicitly set it to nil, but because of Go's god-forsaken empty-handling in structs there is _zero_ generic way to do that with Gorm. Gorm only sets to nil if you do something non-generic.
  - If it becomes an issue I guess we can write a custom non-generic API method to handle this case, but frankly I don't think people are going to want to disconnect Environments or ChartReleases from the manual PagerDuty button that often. If they do, it's easy enough to wipe in the DB. Rather than spending a day on this problem I think the right call is to move fast, merge this, get people using it, and if it becomes so popular that people notice this edge case, then we can prioritize sorting this out.
- Also I attempted another fix for the stupid race condition thing. It'll make changeset apply take marginally longer but I don't think it's bad and the requests out to pd themselves still happen in goroutines.