### PR TITLE
[DDO-2664] Autopopulate templates with honeycomb

### DIFF
--- a/config/default_config.yaml
+++ b/config/default_config.yaml
@@ -55,6 +55,13 @@ metrics:
 pagerduty:
   enable: false
 
+model:
+  environments:
+    templates:
+      # Uses appVersionResolver = "none", chartVersionResolver = "latest", and helmfileRef = "HEAD"
+      autoPopulateCharts:
+        - name: honeycomb
+
 beehive:
     chartReleaseUrlFormatString: https://beehive.dsp-devops.broadinstitute.org/r/chart-release/%s
     environmentUrlFormatString: https://beehive.dsp-devops.broadinstitute.org/r/environment/%s

--- a/config/test_config.yaml
+++ b/config/test_config.yaml
@@ -25,3 +25,9 @@ auth:
 
 pagerduty:
   enable: false
+
+model:
+  environments:
+    templates:
+      autoPopulateCharts:
+        - name: honeycomb

--- a/db/migrations/000030_rename_autopopulate.down.sql
+++ b/db/migrations/000030_rename_autopopulate.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE v2_environments
+    RENAME COLUMN auto_populate_chart_releases TO chart_releases_from_template;

--- a/db/migrations/000030_rename_autopopulate.up.sql
+++ b/db/migrations/000030_rename_autopopulate.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE v2_environments
+    RENAME COLUMN chart_releases_from_template TO auto_populate_chart_releases;

--- a/internal/controllers/v2controllers/environment.go
+++ b/internal/controllers/v2controllers/environment.go
@@ -25,7 +25,8 @@ type Environment struct {
 
 type CreatableEnvironment struct {
 	Base                      string `json:"base" form:"base"`                                                          // Required when creating
-	ChartReleasesFromTemplate *bool  `json:"chartReleasesFromTemplate" form:"chartReleasesFromTemplate" default:"true"` // Upon creation of a dynamic environment, if this is true the template's chart releases will be copied to the new environment
+	ChartReleasesFromTemplate *bool  `json:"chartReleasesFromTemplate" form:"chartReleasesFromTemplate" default:"true"` // Deprecated, use AutoPopulateChartReleases
+	AutoPopulateChartReleases *bool  `json:"autoPopulateChartReleases" form:"autoPopulateChartReleases" default:"true"` // If true when creating, dynamic environments copy from template and template environments get the honeycomb chart
 	Lifecycle                 string `json:"lifecycle" form:"lifecycle" default:"dynamic"`
 	Name                      string `json:"name" form:"name"`                                 // When creating, will be calculated if dynamic, required otherwise
 	TemplateEnvironment       string `json:"templateEnvironment" form:"templateEnvironment"`   // Required for dynamic environments
@@ -77,6 +78,10 @@ func (e Environment) toModel(storeSet *v2models.StoreSet) (v2models.Environment,
 		}
 		pagerdutyIntegrationID = &pagerdutyIntegration.ID
 	}
+	autoPopulateChartReleases := e.ChartReleasesFromTemplate
+	if e.AutoPopulateChartReleases != nil {
+		autoPopulateChartReleases = e.AutoPopulateChartReleases
+	}
 	return v2models.Environment{
 		Model: gorm.Model{
 			ID:        e.ID,
@@ -84,7 +89,7 @@ func (e Environment) toModel(storeSet *v2models.StoreSet) (v2models.Environment,
 			UpdatedAt: e.UpdatedAt,
 		},
 		Base:                       e.Base,
-		ChartReleasesFromTemplate:  e.ChartReleasesFromTemplate,
+		AutoPopulateChartReleases:  autoPopulateChartReleases,
 		Lifecycle:                  e.Lifecycle,
 		Name:                       e.Name,
 		TemplateEnvironmentID:      templateEnvironmentID,
@@ -166,7 +171,8 @@ func modelEnvironmentToEnvironment(model *v2models.Environment) *Environment {
 		PagerdutyIntegrationInfo: pagerdutyIntegration,
 		CreatableEnvironment: CreatableEnvironment{
 			Base:                      model.Base,
-			ChartReleasesFromTemplate: model.ChartReleasesFromTemplate,
+			ChartReleasesFromTemplate: model.AutoPopulateChartReleases,
+			AutoPopulateChartReleases: model.AutoPopulateChartReleases,
 			Lifecycle:                 model.Lifecycle,
 			Name:                      model.Name,
 			TemplateEnvironment:       templateEnvironmentName,


### PR DESCRIPTION
Renames ChartReleasesFromTemplate to AutoPopulateChartReleases, keeps old field at the controller level for backwards-compatibility (I'll need to update Beehive). For templates, when the flag is true it'll grab a list of chart names from the config file and try to insert them all with no app version and latest chart version. When I tweak the field name in Beehive I'll also tweak it to show the toggle for both dynamic and template lifecycles instead of just dynamic.