### PR TITLE
[DDO-2669] Have Sherlock ignore passed zero times

### DIFF
--- a/internal/controllers/v2controllers/environment.go
+++ b/internal/controllers/v2controllers/environment.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/broadinstitute/sherlock/internal/config"
 	"github.com/broadinstitute/sherlock/internal/models/v2models/environment"
+	"github.com/broadinstitute/sherlock/internal/utils"
 	"math/rand"
 	"strconv"
 	"strings"
@@ -110,9 +111,9 @@ func (e Environment) toModel(storeSet *v2models.StoreSet) (v2models.Environment,
 		PagerdutyIntegrationID:      pagerdutyIntegrationID,
 		Offline:                     e.Offline,
 		OfflineScheduleBeginEnabled: e.OfflineScheduleBeginEnabled,
-		OfflineScheduleBeginTime:    e.OfflineScheduleBeginTime,
+		OfflineScheduleBeginTime:    utils.NilOrNonZeroTime(e.OfflineScheduleBeginTime),
 		OfflineScheduleEndEnabled:   e.OfflineScheduleEndEnabled,
-		OfflineScheduleEndTime:      e.OfflineScheduleEndTime,
+		OfflineScheduleEndTime:      utils.NilOrNonZeroTime(e.OfflineScheduleEndTime),
 		OfflineScheduleEndWeekends:  e.OfflineScheduleEndWeekends,
 	}, nil
 }
@@ -164,7 +165,6 @@ func modelEnvironmentToEnvironment(model *v2models.Environment) *Environment {
 	} else if model.PagerdutyIntegrationID != nil {
 		pagerdutyIntegrationID = strconv.FormatUint(uint64(*model.PagerdutyIntegrationID), 10)
 	}
-
 	return &Environment{
 		ReadableBaseType: ReadableBaseType{
 			ID:        model.ID,
@@ -198,9 +198,9 @@ func modelEnvironmentToEnvironment(model *v2models.Environment) *Environment {
 				PagerdutyIntegration:        &pagerdutyIntegrationID,
 				Offline:                     model.Offline,
 				OfflineScheduleBeginEnabled: model.OfflineScheduleBeginEnabled,
-				OfflineScheduleBeginTime:    model.OfflineScheduleBeginTime,
+				OfflineScheduleBeginTime:    utils.NilOrNonZeroTime(model.OfflineScheduleBeginTime),
 				OfflineScheduleEndEnabled:   model.OfflineScheduleEndEnabled,
-				OfflineScheduleEndTime:      model.OfflineScheduleEndTime,
+				OfflineScheduleEndTime:      utils.NilOrNonZeroTime(model.OfflineScheduleEndTime),
 				OfflineScheduleEndWeekends:  model.OfflineScheduleEndWeekends,
 			},
 		},

--- a/internal/utils/time.go
+++ b/internal/utils/time.go
@@ -1,0 +1,11 @@
+package utils
+
+import "time"
+
+func NilOrNonZeroTime(t *time.Time) *time.Time {
+	if t == nil || t.IsZero() {
+		return nil
+	} else {
+		return t
+	}
+}

--- a/internal/utils/time_test.go
+++ b/internal/utils/time_test.go
@@ -1,0 +1,42 @@
+package utils
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestNilOrNonZeroTime(t *testing.T) {
+	now := time.Now()
+	type args struct {
+		t *time.Time
+	}
+	tests := []struct {
+		name string
+		args args
+		want *time.Time
+	}{
+		{
+			name: "nil",
+			args: args{t: nil},
+			want: nil,
+		},
+		{
+			name: "zero to nil",
+			args: args{t: &time.Time{}},
+			want: nil,
+		},
+		{
+			name: "nonzero stays",
+			args: args{t: &now},
+			want: &now,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NilOrNonZeroTime(tt.args.t); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("NilOrNonZeroTime() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
GO POINTER LOGIC STRIKES AGAIN

so you know how go structs initialize every field

and we use pointers a bunch so that we have nil in all those fields so that we don't accidentally overwrite stuff with zero values?

well the openapi library for golang doesn't bother with that. It's _smarter_, and uses a mix of pointer and non-pointer fields plus some `json:",omitempty"`. Except this doesn't work for their homebrew strfmt.DateTime type, which gets initialized to an empty time.Time{} internally but then never gets omitted from the JSON. So every time Thelma mutates an environment, it'll overwrite the schedule with zero, which is literally just wrong.

I can't control them but I can control me, so I wrote the stupidest little function ever:

```golang
func NilOrNonZeroTime(t *time.Time) *time.Time {
	if t == nil || t.IsZero() {
		return nil
	} else {
		return t
	}
}
```

and I just shoved it into Sherlock's environment controller, so it'll keep garbage from going in and prevent any current garbage that the client library has added from going back out. Goodness.