### PR TITLE
[DDO-2709] Users in Sherlock

### DIFF
--- a/db/migrations/000035_add_user_table.down.sql
+++ b/db/migrations/000035_add_user_table.down.sql
@@ -1,0 +1,1 @@
+drop table if exists v2_users;

--- a/db/migrations/000035_add_user_table.up.sql
+++ b/db/migrations/000035_add_user_table.up.sql
@@ -1,0 +1,15 @@
+create table if not exists v2_users
+(
+    id         bigserial
+        primary key,
+    created_at timestamp with time zone,
+    updated_at timestamp with time zone,
+    deleted_at timestamp with time zone,
+    email      text not null
+        unique,
+    google_id  text not null
+        unique
+);
+
+create index if not exists idx_v2_users_deleted_at
+    on v2_users (deleted_at);

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,8 @@ require (
 	github.com/go-resty/resty/v2 v2.7.0
 	github.com/golang-migrate/migrate/v4 v4.15.2
 	github.com/google/go-cmp v0.5.9
+	github.com/jackc/pgconn v1.13.0
+	github.com/jackc/pgerrcode v0.0.0-20220416144525-469b46aa5efa
 	github.com/jackc/pgx/v4 v4.17.2
 	github.com/knadh/koanf v1.4.4
 	github.com/rs/zerolog v1.28.0
@@ -70,8 +72,6 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jackc/chunkreader/v2 v2.0.1 // indirect
-	github.com/jackc/pgconn v1.13.0 // indirect
-	github.com/jackc/pgerrcode v0.0.0-20220416144525-469b46aa5efa // indirect
 	github.com/jackc/pgio v1.0.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgproto3/v2 v2.3.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -71,6 +71,7 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jackc/chunkreader/v2 v2.0.1 // indirect
 	github.com/jackc/pgconn v1.13.0 // indirect
+	github.com/jackc/pgerrcode v0.0.0-20220416144525-469b46aa5efa // indirect
 	github.com/jackc/pgio v1.0.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgproto3/v2 v2.3.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -809,6 +809,8 @@ github.com/jackc/pgconn v1.9.1-0.20210724152538-d89c8390a530/go.mod h1:4z2w8XhRb
 github.com/jackc/pgconn v1.13.0 h1:3L1XMNV2Zvca/8BYhzcRFS70Lr0WlDg16Di6SFGAbys=
 github.com/jackc/pgconn v1.13.0/go.mod h1:AnowpAqO4CMIIJNZl2VJp+KrkAZciAkhEl0W0JIobpI=
 github.com/jackc/pgerrcode v0.0.0-20201024163028-a0d42d470451/go.mod h1:a/s9Lp5W7n/DD0VrVoyJ00FbP2ytTPDVOivvn2bMlds=
+github.com/jackc/pgerrcode v0.0.0-20220416144525-469b46aa5efa h1:s+4MhCQ6YrzisK6hFJUX53drDT4UsSW3DEhKn0ifuHw=
+github.com/jackc/pgerrcode v0.0.0-20220416144525-469b46aa5efa/go.mod h1:a/s9Lp5W7n/DD0VrVoyJ00FbP2ytTPDVOivvn2bMlds=
 github.com/jackc/pgio v1.0.0 h1:g12B9UwVnzGhueNavwioyEEpAmqMe1E/BN9ES+8ovkE=
 github.com/jackc/pgio v1.0.0/go.mod h1:oP+2QK2wFfUWgr+gxjoBH9KGBb31Eio69xUb0w5bYf8=
 github.com/jackc/pgmock v0.0.0-20190831213851-13a1b77aafa2/go.mod h1:fGZlG77KXmcq05nJLRkk0+p82V8B8Dw8KN2/V9c/OAE=

--- a/internal/auth/cache_extra.go
+++ b/internal/auth/cache_extra.go
@@ -1,18 +1,19 @@
 package auth
 
 import (
+	"github.com/broadinstitute/sherlock/internal/auth/auth_models"
 	"github.com/broadinstitute/sherlock/internal/config"
 	"github.com/rs/zerolog/log"
 )
 
 // cachedExtraPermissions associated arbitrary email addresses to ExtraPermissions info.
-var cachedExtraPermissions map[string]*ExtraPermissions
+var cachedExtraPermissions map[string]*auth_models.ExtraPermissions
 
 func CacheExtraPermissions() {
-	newCache := make(map[string]*ExtraPermissions)
+	newCache := make(map[string]*auth_models.ExtraPermissions)
 	for index, entry := range config.Config.Slices("auth.extraPermissions") {
 		if email := entry.String("email"); email != "" {
-			newCache[email] = &ExtraPermissions{
+			newCache[email] = &auth_models.ExtraPermissions{
 				Suitable: entry.Bool("suitable"),
 			}
 		} else {

--- a/internal/auth/iap_auth/parse_iap.go
+++ b/internal/auth/iap_auth/parse_iap.go
@@ -1,0 +1,43 @@
+package iap_auth
+
+import (
+	"fmt"
+	"github.com/broadinstitute/sherlock/internal/errors"
+	"github.com/gin-gonic/gin"
+	"google.golang.org/api/idtoken"
+)
+
+const (
+	iapHeader  = "X-Goog-IAP-JWT-Assertion"
+	emailClaim = "email"
+	subClaim   = "sub"
+)
+
+func ParseIAP(ctx *gin.Context) (email string, googleID string, err error) {
+	iapJWT := ctx.GetHeader(iapHeader)
+	if iapJWT == "" {
+		return "", "", fmt.Errorf("(%s) no '%s' header set, IAP authentication required", errors.ProxyAuthenticationRequired, iapHeader)
+	}
+
+	// Sherlock is deployed behind an Apache proxy that checks that it is correctly wrapped by IAP, so we don't
+	// actually care about exhaustively validating here (and we lack all the audience information to do so),
+	// this is just the easiest way to decode the JWT payload.
+	payload, err := idtoken.Validate(ctx, iapJWT, "")
+	if err != nil {
+		return "", "", fmt.Errorf("(%s) failed to validate IAP JWT in 'X-Goog-IAP-JWT-Assertion' header: %v", errors.ProxyAuthenticationRequired, err)
+	}
+
+	emailValue := payload.Claims[emailClaim]
+	email, ok := emailValue.(string)
+	if !ok || email == "" {
+		return "", "", fmt.Errorf("(%s) IAP JWT seemed to pass validation but lacked an '%s' claim", errors.ProxyAuthenticationRequired, emailClaim)
+	}
+
+	subValue := payload.Claims[subClaim]
+	googleID, ok = subValue.(string)
+	if !ok || googleID == "" {
+		return "", "", fmt.Errorf("(%s) IAP JWT seemed to pass validation but lacked a '%s' claim", errors.ProxyAuthenticationRequired, subClaim)
+	}
+
+	return email, googleID, nil
+}

--- a/internal/auth/test_helpers.go
+++ b/internal/auth/test_helpers.go
@@ -1,8 +1,11 @@
 package auth
 
-import "testing"
+import (
+	"github.com/broadinstitute/sherlock/internal/auth/auth_models"
+	"testing"
+)
 
-func GenerateUser(t *testing.T, suitable bool) *User {
+func GenerateUser(t *testing.T, suitable bool) *auth_models.User {
 	if t == nil {
 		t.Errorf("refusing to generate user, testing.T was nil")
 		return nil
@@ -11,20 +14,24 @@ func GenerateUser(t *testing.T, suitable bool) *User {
 	if !suitable {
 		suspensionReason = "user was generated to be non-suitable"
 	}
-	return &User{
-		AuthenticatedEmail: "sherlock.holmes@broadinstitute.org",
-		MatchedFirecloudAccount: &FirecloudAccount{
-			Email:               "sherlock.holmes@firecloud.org",
-			AcceptedGoogleTerms: true,
-			EnrolledIn2fa:       true,
-			Suspended:           !suitable,
-			Archived:            false,
-			SuspensionReason:    suspensionReason,
-			Groups: &FirecloudGroupMembership{
-				FcAdmins:               true,
-				FirecloudProjectOwners: true,
+	return &auth_models.User{
+		StoredUserFields: auth_models.StoredUserFields{
+			Email:    "sherlock.holmes@broadinstitute.org",
+			GoogleID: "someidwouldgohere",
+		},
+		InferredUserFields: auth_models.InferredUserFields{
+			MatchedFirecloudAccount: &auth_models.FirecloudAccount{
+				Email:               "sherlock.holmes@firecloud.org",
+				AcceptedGoogleTerms: true,
+				EnrolledIn2fa:       true,
+				Suspended:           !suitable,
+				Archived:            false,
+				SuspensionReason:    suspensionReason,
+				Groups: &auth_models.FirecloudGroupMembership{
+					FcAdmins:               true,
+					FirecloudProjectOwners: true,
+				},
 			},
 		},
-		offline: true,
 	}
 }

--- a/internal/controllers/v2controllers/changeset_procedures.go
+++ b/internal/controllers/v2controllers/changeset_procedures.go
@@ -2,7 +2,7 @@ package v2controllers
 
 import (
 	"fmt"
-	"github.com/broadinstitute/sherlock/internal/auth"
+	"github.com/broadinstitute/sherlock/internal/auth/auth_models"
 	"github.com/broadinstitute/sherlock/internal/errors"
 	"github.com/broadinstitute/sherlock/internal/models/v2models"
 )
@@ -25,7 +25,7 @@ type ChangesetPlanRequestEnvironmentEntry struct {
 	ExcludeCharts                        []string `json:"excludeCharts"`
 }
 
-func (c ChangesetController) changesetPlanRequestToModelChangesets(request ChangesetPlanRequest, _ *auth.User) ([]v2models.Changeset, error) {
+func (c ChangesetController) changesetPlanRequestToModelChangesets(request ChangesetPlanRequest, _ *auth_models.User) ([]v2models.Changeset, error) {
 	modelChangesets := make(map[uint]v2models.Changeset)
 	exact := "exact"
 	follow := "follow"
@@ -170,7 +170,7 @@ func (c ChangesetController) changesetPlanRequestToModelChangesets(request Chang
 	return ret, nil
 }
 
-func (c ChangesetController) PlanAndApply(request ChangesetPlanRequest, user *auth.User) ([]Changeset, error) {
+func (c ChangesetController) PlanAndApply(request ChangesetPlanRequest, user *auth_models.User) ([]Changeset, error) {
 	modelChangesets, err := c.changesetPlanRequestToModelChangesets(request, user)
 	if err != nil {
 		return nil, err
@@ -187,7 +187,7 @@ func (c ChangesetController) PlanAndApply(request ChangesetPlanRequest, user *au
 	return ret, nil
 }
 
-func (c ChangesetController) Plan(request ChangesetPlanRequest, user *auth.User) ([]Changeset, error) {
+func (c ChangesetController) Plan(request ChangesetPlanRequest, user *auth_models.User) ([]Changeset, error) {
 	modelChangesets, err := c.changesetPlanRequestToModelChangesets(request, user)
 	if err != nil {
 		return nil, err
@@ -204,7 +204,7 @@ func (c ChangesetController) Plan(request ChangesetPlanRequest, user *auth.User)
 	return ret, nil
 }
 
-func (c ChangesetController) Apply(selectors []string, user *auth.User) ([]Changeset, error) {
+func (c ChangesetController) Apply(selectors []string, user *auth_models.User) ([]Changeset, error) {
 	modelChangesets, err := c.ChangesetEventStore.Apply(selectors, user)
 	if err != nil {
 		return nil, err

--- a/internal/controllers/v2controllers/chart.go
+++ b/internal/controllers/v2controllers/chart.go
@@ -1,7 +1,7 @@
 package v2controllers
 
 import (
-	"github.com/broadinstitute/sherlock/internal/auth"
+	"github.com/broadinstitute/sherlock/internal/auth/auth_models"
 	"github.com/broadinstitute/sherlock/internal/models/v2models"
 	"gorm.io/gorm"
 )
@@ -95,7 +95,7 @@ func modelChartToChart(model *v2models.Chart) *Chart {
 	}
 }
 
-func setChartDynamicDefaults(chart *CreatableChart, _ *v2models.StoreSet, _ *auth.User) error {
+func setChartDynamicDefaults(chart *CreatableChart, _ *v2models.StoreSet, _ *auth_models.User) error {
 	if chart.DefaultSubdomain == nil {
 		chart.DefaultSubdomain = &chart.Name
 	}

--- a/internal/controllers/v2controllers/chart_release.go
+++ b/internal/controllers/v2controllers/chart_release.go
@@ -2,10 +2,10 @@ package v2controllers
 
 import (
 	"fmt"
+	"github.com/broadinstitute/sherlock/internal/auth/auth_models"
 	"github.com/broadinstitute/sherlock/internal/config"
 	"strconv"
 
-	"github.com/broadinstitute/sherlock/internal/auth"
 	"github.com/broadinstitute/sherlock/internal/models/v2models"
 	"gorm.io/gorm"
 )
@@ -275,7 +275,7 @@ func modelChartReleaseToChartRelease(model *v2models.ChartRelease) *ChartRelease
 	}
 }
 
-func setChartReleaseDynamicDefaults(chartRelease *CreatableChartRelease, stores *v2models.StoreSet, _ *auth.User) error {
+func setChartReleaseDynamicDefaults(chartRelease *CreatableChartRelease, stores *v2models.StoreSet, _ *auth_models.User) error {
 	chart, err := stores.ChartStore.Get(chartRelease.Chart)
 	if err != nil {
 		return err

--- a/internal/controllers/v2controllers/controller_set.go
+++ b/internal/controllers/v2controllers/controller_set.go
@@ -12,6 +12,7 @@ type ControllerSet struct {
 	ChangesetController            *ChangesetController
 	PagerdutyIntegrationController *PagerdutyIntegrationController
 	DatabaseInstanceController     *DatabaseInstanceController
+	UserController                 *UserController
 }
 
 func NewControllerSet(stores *v2models.StoreSet) *ControllerSet {
@@ -25,5 +26,6 @@ func NewControllerSet(stores *v2models.StoreSet) *ControllerSet {
 		ChangesetController:            newChangesetController(stores),
 		PagerdutyIntegrationController: newPagerdutyIntegrationController(stores),
 		DatabaseInstanceController:     newDatabaseInstanceController(stores),
+		UserController:                 newUserController(stores),
 	}
 }

--- a/internal/controllers/v2controllers/database_instance.go
+++ b/internal/controllers/v2controllers/database_instance.go
@@ -1,7 +1,7 @@
 package v2controllers
 
 import (
-	"github.com/broadinstitute/sherlock/internal/auth"
+	"github.com/broadinstitute/sherlock/internal/auth/auth_models"
 	"github.com/broadinstitute/sherlock/internal/models/v2models"
 	"gorm.io/gorm"
 )
@@ -109,7 +109,7 @@ func modelDatabaseInstanceToDatabaseInstance(model *v2models.DatabaseInstance) *
 	}
 }
 
-func setDatabaseInstanceDynamicDefaults(databaseInstance *CreatableDatabaseInstance, stores *v2models.StoreSet, user *auth.User) error {
+func setDatabaseInstanceDynamicDefaults(databaseInstance *CreatableDatabaseInstance, stores *v2models.StoreSet, _ *auth_models.User) error {
 	if (databaseInstance.DefaultDatabase == nil || *databaseInstance.DefaultDatabase == "") && databaseInstance.ChartRelease != "" {
 		chartRelease, err := stores.ChartReleaseStore.Get(databaseInstance.ChartRelease)
 		if err != nil {

--- a/internal/controllers/v2controllers/environment.go
+++ b/internal/controllers/v2controllers/environment.go
@@ -2,6 +2,7 @@ package v2controllers
 
 import (
 	"fmt"
+	"github.com/broadinstitute/sherlock/internal/auth/auth_models"
 	"github.com/broadinstitute/sherlock/internal/config"
 	"github.com/broadinstitute/sherlock/internal/models/v2models/environment"
 	"github.com/broadinstitute/sherlock/internal/utils"
@@ -11,7 +12,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/broadinstitute/sherlock/internal/auth"
 	"github.com/broadinstitute/sherlock/internal/models/v2models"
 	petname "github.com/dustinkirkland/golang-petname"
 	"gorm.io/gorm"
@@ -219,7 +219,7 @@ func modelEnvironmentToEnvironment(model *v2models.Environment) *Environment {
 // setEnvironmentDynamicDefaults doesn't need to worry about validation, nor does it need to worry about any
 // static defaults defined in struct tags. The model handles validation, and the caller will handle struct tags
 // after this function runs.
-func setEnvironmentDynamicDefaults(environment *CreatableEnvironment, stores *v2models.StoreSet, user *auth.User) error {
+func setEnvironmentDynamicDefaults(environment *CreatableEnvironment, stores *v2models.StoreSet, user *auth_models.User) error {
 	if environment.TemplateEnvironment != "" {
 		templateEnvironment, err := stores.EnvironmentStore.Get(environment.TemplateEnvironment)
 		if err != nil {
@@ -274,7 +274,7 @@ func setEnvironmentDynamicDefaults(environment *CreatableEnvironment, stores *v2
 		environment.DefaultNamespace = fmt.Sprintf("terra-%s", environment.Name)
 	}
 	if environment.Owner == nil {
-		environment.Owner = &user.AuthenticatedEmail
+		environment.Owner = &user.Email
 	}
 
 	// set default firecloud-develop ref for live terra envs

--- a/internal/controllers/v2controllers/environment_test.go
+++ b/internal/controllers/v2controllers/environment_test.go
@@ -186,7 +186,7 @@ func (suite *environmentControllerSuite) TestEnvironmentCreate() {
 				assert.Equal(suite.T(), swatomationEnvironment.DefaultCluster, env.DefaultCluster)
 			})
 			suite.Run("fills owner", func() {
-				assert.Equal(suite.T(), user.AuthenticatedEmail, *env.Owner)
+				assert.Equal(suite.T(), user.Email, *env.Owner)
 			})
 			suite.Run("namespace of terra-$name", func() {
 				assert.Equal(suite.T(), fmt.Sprintf("terra-%s", env.Name), env.DefaultNamespace)
@@ -236,7 +236,7 @@ func (suite *environmentControllerSuite) TestEnvironmentCreate() {
 				assert.Equal(suite.T(), prodlikeTemplateEnvironment.DefaultCluster, env.DefaultCluster)
 			})
 			suite.Run("fills owner", func() {
-				assert.Equal(suite.T(), user.AuthenticatedEmail, *env.Owner)
+				assert.Equal(suite.T(), user.Email, *env.Owner)
 			})
 			suite.Run("namespace of terra-$name", func() {
 				assert.Equal(suite.T(), fmt.Sprintf("terra-%s", env.Name), env.DefaultNamespace)

--- a/internal/controllers/v2controllers/user.go
+++ b/internal/controllers/v2controllers/user.go
@@ -1,0 +1,65 @@
+package v2controllers
+
+import (
+	"github.com/broadinstitute/sherlock/internal/auth/auth_models"
+	"github.com/broadinstitute/sherlock/internal/models/v2models"
+	"gorm.io/gorm"
+)
+
+type User struct {
+	ReadableBaseType
+	auth_models.StoredUserFields
+}
+
+type CreatableUser struct {
+	EditableUser
+}
+
+type EditableUser struct {
+}
+
+//nolint:unused
+func (u User) toModel(_ *v2models.StoreSet) (v2models.User, error) {
+	return v2models.User{
+		Model: gorm.Model{
+			ID:        u.ID,
+			CreatedAt: u.CreatedAt,
+			UpdatedAt: u.UpdatedAt,
+		},
+		StoredUserFields: u.StoredUserFields,
+	}, nil
+}
+
+//nolint:unused
+func (u CreatableUser) toModel(storeSet *v2models.StoreSet) (v2models.User, error) {
+	return User{}.toModel(storeSet)
+}
+
+//nolint:unused
+func (u EditableUser) toModel(storeSet *v2models.StoreSet) (v2models.User, error) {
+	return CreatableUser{EditableUser: u}.toModel(storeSet)
+}
+
+type UserController = ModelController[v2models.User, User, CreatableUser, EditableUser]
+
+func newUserController(stores *v2models.StoreSet) *UserController {
+	return &UserController{
+		primaryStore:    stores.UserStore,
+		allStores:       stores,
+		modelToReadable: modelUserToUser,
+	}
+}
+
+func modelUserToUser(model *v2models.User) *User {
+	if model == nil {
+		return nil
+	}
+	return &User{
+		ReadableBaseType: ReadableBaseType{
+			ID:        model.ID,
+			CreatedAt: model.CreatedAt,
+			UpdatedAt: model.UpdatedAt,
+		},
+		StoredUserFields: model.StoredUserFields,
+	}
+}

--- a/internal/db/connect.go
+++ b/internal/db/connect.go
@@ -34,6 +34,7 @@ var (
 		&v1models.Deploy{},
 	}
 	v2ModelHierarchy = []any{
+		&v2models.User{},
 		&v2models.PagerdutyIntegration{},
 		&v2models.Cluster{},
 		&v2models.Environment{},

--- a/internal/handlers/misc/my_user.go
+++ b/internal/handlers/misc/my_user.go
@@ -2,15 +2,16 @@ package misc
 
 import (
 	"github.com/broadinstitute/sherlock/internal/auth"
+	"github.com/broadinstitute/sherlock/internal/auth/auth_models"
 	"github.com/broadinstitute/sherlock/internal/errors"
 	"github.com/gin-gonic/gin"
 	"net/http"
 )
 
 type MyUserResponse struct {
-	Email       string     `json:"email"`
-	Suitability string     `json:"suitability"`
-	RawInfo     *auth.User `json:"rawInfo"`
+	Email       string            `json:"email"`
+	Suitability string            `json:"suitability"`
+	RawInfo     *auth_models.User `json:"rawInfo"`
 }
 
 // MyUserHandler godoc
@@ -37,7 +38,7 @@ func MyUserHandler(ctx *gin.Context) {
 	}
 
 	ctx.JSON(http.StatusOK, MyUserResponse{
-		Email:       user.AuthenticatedEmail,
+		Email:       user.Email,
 		Suitability: suitabilityDescription,
 		RawInfo:     user,
 	})

--- a/internal/models/v2models/changeset.go
+++ b/internal/models/v2models/changeset.go
@@ -2,7 +2,7 @@ package v2models
 
 import (
 	"fmt"
-	"github.com/broadinstitute/sherlock/internal/auth"
+	"github.com/broadinstitute/sherlock/internal/auth/auth_models"
 	"github.com/broadinstitute/sherlock/internal/errors"
 	"gorm.io/gorm"
 	"strconv"
@@ -76,7 +76,7 @@ func validateChangeset(changeset *Changeset) error {
 	return nil
 }
 
-func preCreateChangeset(db *gorm.DB, toCreate *Changeset, _ *auth.User) error {
+func preCreateChangeset(db *gorm.DB, toCreate *Changeset, _ *auth_models.User) error {
 	if toCreate != nil {
 
 		// Resolve 'to' versions

--- a/internal/models/v2models/changeset_event_store.go
+++ b/internal/models/v2models/changeset_event_store.go
@@ -2,7 +2,7 @@ package v2models
 
 import (
 	"fmt"
-	"github.com/broadinstitute/sherlock/internal/auth"
+	"github.com/broadinstitute/sherlock/internal/auth/auth_models"
 	"github.com/broadinstitute/sherlock/internal/config"
 	"github.com/broadinstitute/sherlock/internal/errors"
 	"github.com/broadinstitute/sherlock/internal/pagerduty"
@@ -18,7 +18,7 @@ type ChangesetEventStore struct {
 	*internalChangesetEventStore
 }
 
-func (s *ChangesetEventStore) PlanAndApply(changesets []Changeset, user *auth.User) ([]Changeset, error) {
+func (s *ChangesetEventStore) PlanAndApply(changesets []Changeset, user *auth_models.User) ([]Changeset, error) {
 	var ret []Changeset
 	err := s.db.Transaction(func(tx *gorm.DB) error {
 		planned, err := s.plan(tx, changesets, user)
@@ -31,11 +31,11 @@ func (s *ChangesetEventStore) PlanAndApply(changesets []Changeset, user *auth.Us
 	return ret, err
 }
 
-func (s *ChangesetEventStore) Plan(changesets []Changeset, user *auth.User) ([]Changeset, error) {
+func (s *ChangesetEventStore) Plan(changesets []Changeset, user *auth_models.User) ([]Changeset, error) {
 	return s.plan(s.db, changesets, user)
 }
 
-func (s *ChangesetEventStore) Apply(selectors []string, user *auth.User) ([]Changeset, error) {
+func (s *ChangesetEventStore) Apply(selectors []string, user *auth_models.User) ([]Changeset, error) {
 	var queries []Changeset
 	for index, selector := range selectors {
 		query, err := s.internalChangesetEventStore.selectorToQueryModel(s.db, selector)
@@ -63,7 +63,7 @@ type internalChangesetEventStore struct {
 	*internalModelStore[Changeset]
 }
 
-func (s *internalChangesetEventStore) plan(db *gorm.DB, changesets []Changeset, user *auth.User) ([]Changeset, error) {
+func (s *internalChangesetEventStore) plan(db *gorm.DB, changesets []Changeset, user *auth_models.User) ([]Changeset, error) {
 	var ret []Changeset
 	err := db.Transaction(func(tx *gorm.DB) error {
 		for index, changeset := range changesets {
@@ -89,7 +89,7 @@ func (s *internalChangesetEventStore) plan(db *gorm.DB, changesets []Changeset, 
 	return ret, err
 }
 
-func (s *internalChangesetEventStore) apply(db *gorm.DB, changesets []Changeset, user *auth.User) ([]Changeset, error) {
+func (s *internalChangesetEventStore) apply(db *gorm.DB, changesets []Changeset, user *auth_models.User) ([]Changeset, error) {
 	var ret []Changeset
 	affectedChartReleases := make(map[uint]ChartRelease)
 	err := db.Transaction(func(tx *gorm.DB) error {

--- a/internal/models/v2models/chart_release.go
+++ b/internal/models/v2models/chart_release.go
@@ -2,7 +2,7 @@ package v2models
 
 import (
 	"fmt"
-	"github.com/broadinstitute/sherlock/internal/auth"
+	"github.com/broadinstitute/sherlock/internal/auth/auth_models"
 	"github.com/broadinstitute/sherlock/internal/errors"
 	"gorm.io/gorm"
 	"strconv"
@@ -235,7 +235,7 @@ func validateChartRelease(chartRelease *ChartRelease) error {
 	return chartRelease.ChartReleaseVersion.validate()
 }
 
-func preCreateChartRelease(db *gorm.DB, toCreate *ChartRelease, _ *auth.User) error {
+func preCreateChartRelease(db *gorm.DB, toCreate *ChartRelease, _ *auth_models.User) error {
 	if toCreate != nil {
 		if toCreate.EnvironmentID != nil {
 			toCreate.DestinationType = "environment"
@@ -247,7 +247,7 @@ func preCreateChartRelease(db *gorm.DB, toCreate *ChartRelease, _ *auth.User) er
 	return nil
 }
 
-func preDeletePostValidateChartRelease(db *gorm.DB, chartRelease *ChartRelease, user *auth.User) error {
+func preDeletePostValidateChartRelease(db *gorm.DB, chartRelease *ChartRelease, user *auth_models.User) error {
 	_, err := databaseInstanceStore.deleteIfExists(db, DatabaseInstance{ChartReleaseID: chartRelease.ID}, user)
 	return err
 }

--- a/internal/models/v2models/database_instance.go
+++ b/internal/models/v2models/database_instance.go
@@ -50,7 +50,7 @@ func databaseInstanceSelectorToQuery(db *gorm.DB, selector string) (DatabaseInst
 		}
 		query.ID = uint(id)
 		return query, nil
-	} else if strings.HasPrefix(selector, "chart-release/") {
+	} else if strings.HasPrefix(selector, "chart-release/") { // "chart-release/" + chart release
 		chartReleaseSubSelector := strings.TrimPrefix(selector, "chart-release/")
 		chartReleaseQuery, err := chartReleaseSelectorToQuery(db, chartReleaseSubSelector)
 		if err != nil {

--- a/internal/models/v2models/environment.go
+++ b/internal/models/v2models/environment.go
@@ -2,6 +2,7 @@ package v2models
 
 import (
 	"fmt"
+	"github.com/broadinstitute/sherlock/internal/auth/auth_models"
 	"github.com/broadinstitute/sherlock/internal/config"
 	"github.com/rs/zerolog/log"
 	"math/bits"
@@ -10,7 +11,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/broadinstitute/sherlock/internal/auth"
 	"github.com/broadinstitute/sherlock/internal/errors"
 	"github.com/broadinstitute/sherlock/internal/models/v2models/environment"
 	"gorm.io/gorm"
@@ -227,7 +227,7 @@ func validateEnvironment(environment *Environment) error {
 	return nil
 }
 
-func preCreateEnvironment(db *gorm.DB, environment *Environment, _ *auth.User) error {
+func preCreateEnvironment(db *gorm.DB, environment *Environment, _ *auth_models.User) error {
 	if environment != nil && environment.UniqueResourcePrefix == "" {
 		var generatedUniqueResourcePrefix bool
 
@@ -341,7 +341,7 @@ func generateUniqueResourcePrefix(sb *strings.Builder, number uint64) {
 	sb.WriteByte(characterBytes[r0])
 }
 
-func postCreateEnvironment(db *gorm.DB, environment *Environment, user *auth.User) error {
+func postCreateEnvironment(db *gorm.DB, environment *Environment, user *auth_models.User) error {
 	if environment.AutoPopulateChartReleases != nil && *environment.AutoPopulateChartReleases {
 		if environment.Lifecycle == "dynamic" && environment.TemplateEnvironmentID != nil {
 			// This is a dynamic environment that is getting created right now, let's copy the chart releases from the template too
@@ -429,7 +429,7 @@ func postCreateEnvironment(db *gorm.DB, environment *Environment, user *auth.Use
 	return nil
 }
 
-func preDeletePostValidateEnvironment(db *gorm.DB, environment *Environment, user *auth.User) error {
+func preDeletePostValidateEnvironment(db *gorm.DB, environment *Environment, user *auth_models.User) error {
 	chartReleases, err := chartReleaseStore.listAllMatchingByUpdated(db, 0, ChartRelease{EnvironmentID: &environment.ID})
 	if err != nil {
 		return fmt.Errorf("wasn't able to list chart releases: %v", err)

--- a/internal/models/v2models/model_store.go
+++ b/internal/models/v2models/model_store.go
@@ -2,7 +2,7 @@ package v2models
 
 import (
 	"fmt"
-	"github.com/broadinstitute/sherlock/internal/auth"
+	"github.com/broadinstitute/sherlock/internal/auth/auth_models"
 	"gorm.io/gorm"
 )
 
@@ -15,7 +15,7 @@ type ModelStore[M Model] struct {
 	*internalModelStore[M]
 }
 
-func (s ModelStore[M]) Create(model M, user *auth.User) (M, bool, error) {
+func (s ModelStore[M]) Create(model M, user *auth_models.User) (M, bool, error) {
 	return s.create(s.db, model, user)
 }
 
@@ -39,7 +39,7 @@ func (s ModelStore[M]) Get(selector string) (M, error) {
 	return ret, nil
 }
 
-func (s ModelStore[M]) Edit(selector string, editsToMake M, user *auth.User) (M, error) {
+func (s ModelStore[M]) Edit(selector string, editsToMake M, user *auth_models.User) (M, error) {
 	query, err := s.selectorToQueryModel(s.db, selector)
 	if err != nil {
 		return query, fmt.Errorf("query error parsing %T selector '%s': %v", query, selector, err)
@@ -51,7 +51,7 @@ func (s ModelStore[M]) Edit(selector string, editsToMake M, user *auth.User) (M,
 	return ret, nil
 }
 
-func (s ModelStore[M]) Delete(selector string, user *auth.User) (M, error) {
+func (s ModelStore[M]) Delete(selector string, user *auth_models.User) (M, error) {
 	query, err := s.selectorToQueryModel(s.db, selector)
 	if err != nil {
 		return query, fmt.Errorf("query error parsing %T selector '%s': %v", query, selector, err)

--- a/internal/models/v2models/pagerduty_integration.go
+++ b/internal/models/v2models/pagerduty_integration.go
@@ -2,7 +2,7 @@ package v2models
 
 import (
 	"fmt"
-	"github.com/broadinstitute/sherlock/internal/auth"
+	"github.com/broadinstitute/sherlock/internal/auth/auth_models"
 	"github.com/broadinstitute/sherlock/internal/errors"
 	"gorm.io/gorm"
 	"strconv"
@@ -105,7 +105,7 @@ func validatePagerdutyIntegration(pagerdutyIntegration *PagerdutyIntegration) er
 	return nil
 }
 
-func preDeletePostValidatePagerdutyIntegration(db *gorm.DB, pagerdutyIntegration *PagerdutyIntegration, _ *auth.User) error {
+func preDeletePostValidatePagerdutyIntegration(db *gorm.DB, pagerdutyIntegration *PagerdutyIntegration, _ *auth_models.User) error {
 	chartReleases, err := chartReleaseStore.listAllMatchingByUpdated(db, 0, ChartRelease{PagerdutyIntegrationID: &pagerdutyIntegration.ID})
 	if err != nil {
 		return fmt.Errorf("wasn't able to check for chart releases that use this integration: %v", err)

--- a/internal/models/v2models/store_set.go
+++ b/internal/models/v2models/store_set.go
@@ -15,6 +15,7 @@ type StoreSet struct {
 	ChartReleaseStore     *ModelStore[ChartRelease]
 	PagerdutyIntegration  *ModelStore[PagerdutyIntegration]
 	DatabaseInstanceStore *ModelStore[DatabaseInstance]
+	UserStore             *ModelStore[User]
 
 	ChangesetEventStore *ChangesetEventStore
 }
@@ -31,6 +32,7 @@ func NewStoreSet(db *gorm.DB) *StoreSet {
 		ChartReleaseStore:     &ModelStore[ChartRelease]{db: db, internalModelStore: chartReleaseStore},
 		PagerdutyIntegration:  &ModelStore[PagerdutyIntegration]{db: db, internalModelStore: pagerdutyIntegrationStore},
 		DatabaseInstanceStore: &ModelStore[DatabaseInstance]{db: db, internalModelStore: databaseInstanceStore},
+		UserStore:             &ModelStore[User]{db: db, internalModelStore: userStore},
 
 		ChangesetEventStore: &ChangesetEventStore{
 			ModelStore:                  &ModelStore[Changeset]{db: db, internalModelStore: changesetStore.internalModelStore},

--- a/internal/models/v2models/user.go
+++ b/internal/models/v2models/user.go
@@ -1,0 +1,82 @@
+package v2models
+
+import (
+	"fmt"
+	"github.com/broadinstitute/sherlock/internal/auth/auth_models"
+	"github.com/broadinstitute/sherlock/internal/errors"
+	"gorm.io/gorm"
+	"strconv"
+	"strings"
+)
+
+type User struct {
+	gorm.Model
+	auth_models.StoredUserFields
+}
+
+func (u User) TableName() string {
+	return "v2_users"
+}
+
+var userStore *internalModelStore[User]
+
+func init() {
+	userStore = &internalModelStore[User]{
+		selectorToQueryModel: userSelectorToQuery,
+		modelToSelectors:     userToSelectors,
+		validateModel:        validateUser,
+	}
+}
+
+func userSelectorToQuery(_ *gorm.DB, selector string) (User, error) {
+	if len(selector) == 0 {
+		return User{}, fmt.Errorf("(%s) user selector cannot be empty", errors.BadRequest)
+	}
+	var query User
+	if isNumeric(selector) { // ID
+		id, err := strconv.Atoi(selector)
+		if err != nil {
+			return User{}, fmt.Errorf("(%s) string to int conversion error of '%s': %v", errors.BadRequest, selector, err)
+		}
+		query.ID = uint(id)
+		return query, nil
+	} else if strings.Contains(selector, "@") { // email
+		query.Email = selector
+		return query, nil
+	} else if strings.HasPrefix(selector, "google-id/") { // "google-id/" + Google Subject ID
+		query.GoogleID = strings.TrimPrefix(selector, "google-id/")
+		return query, nil
+	}
+	return User{}, fmt.Errorf("(%s) invalid user selector '%s'", errors.BadRequest, selector)
+}
+
+func userToSelectors(user *User) []string {
+	var selectors []string
+	if user != nil {
+		if user.Email != "" {
+			selectors = append(selectors, user.Email)
+		}
+		if user.GoogleID != "" {
+			selectors = append(selectors, fmt.Sprintf("google-id/%s", user.GoogleID))
+		}
+		if user.ID != 0 {
+			selectors = append(selectors, fmt.Sprintf("%d", user.ID))
+		}
+	}
+	return selectors
+}
+
+func validateUser(user *User) error {
+	if user == nil {
+		return fmt.Errorf("the model passed was nil")
+	}
+	if user.Email == "" {
+		return fmt.Errorf("a %T must have an email", user)
+	} else if !strings.Contains(user.Email, "@") {
+		return fmt.Errorf("a %T must have an email: '%s' did not contain an '@'", user, user.Email)
+	}
+	if user.GoogleID == "" {
+		return fmt.Errorf("a %T must have a Google subject ID", user)
+	}
+	return nil
+}

--- a/internal/models/v2models/user_middleware_store.go
+++ b/internal/models/v2models/user_middleware_store.go
@@ -1,0 +1,63 @@
+package v2models
+
+import (
+	go_errors "errors"
+	"fmt"
+	"github.com/broadinstitute/sherlock/internal/auth/auth_models"
+	"github.com/broadinstitute/sherlock/internal/errors"
+	"github.com/jackc/pgconn"
+	"github.com/jackc/pgerrcode"
+	"gorm.io/gorm"
+)
+
+func NewUserMiddlewareStore(db *gorm.DB) *UserMiddlewareStore {
+	return &UserMiddlewareStore{
+		ModelStore: &ModelStore[User]{db: db, internalModelStore: userStore},
+	}
+}
+
+type UserMiddlewareStore struct {
+	*ModelStore[User]
+}
+
+func (s *UserMiddlewareStore) GetOrCreateUser(email, googleID string) (User, error) {
+	query := User{
+		StoredUserFields: auth_models.StoredUserFields{
+			Email: email,
+		},
+	}
+	existing, err := s.getIfExists(s.db, query)
+	if err != nil {
+		return User{}, err
+	} else if existing != nil {
+		if existing.GoogleID != googleID {
+			return User{}, fmt.Errorf("(%s) incoming google ID '%s' mismatched with stored '%s', please contact DevOps", errors.BadRequest, googleID, existing.GoogleID)
+		} else {
+			return *existing, nil
+		}
+	} else {
+		user, _, err := s.create(s.db, User{
+			StoredUserFields: auth_models.StoredUserFields{
+				Email:    email,
+				GoogleID: googleID,
+			},
+		}, nil)
+		if err != nil {
+			var pgErr *pgconn.PgError
+			if go_errors.As(err, &pgErr) && pgErr != nil && pgerrcode.UniqueViolation == pgErr.Code {
+				existing, err = s.getIfExists(s.db, query)
+				if err != nil {
+					return User{}, err
+				} else if existing != nil {
+					if existing.GoogleID != googleID {
+						return User{}, fmt.Errorf("(%s) incoming google ID '%s' mismatched with stored '%s', please contact DevOps", errors.BadRequest, googleID, existing.GoogleID)
+					} else {
+						return *existing, nil
+					}
+				}
+			}
+			return User{}, err
+		}
+		return user, nil
+	}
+}


### PR DESCRIPTION
This PR adds a super simple user table to Sherlock -- email + google id -- and just uses it in a passive way to basically validate that users google id doesn't change between invocations.

No, that's not very useful. The user table isn't actually exposed in the API yet and it isn't even really tested, but all the _other_ tests pass and that's what's important. There's no current need for an API here, and one will only become necessary once Sherlock does something else with users -- which will involve some model changes anyway, so the tests and API would need to be reworked. 