### PR TITLE
[DDO-2738] Don't update users every single time

### DIFF
--- a/internal/controllers/v2controllers/user_procedures.go
+++ b/internal/controllers/v2controllers/user_procedures.go
@@ -63,7 +63,9 @@ func (c UserController) recordGithubInformation(githubInformation *github.User, 
 		log.Info().Msgf("GH   | user %s linked github account (ID %s) has new username, from %s to %s", user.Email, *user.GithubID, *user.GithubUsername, *githubInformation.Login)
 		editsToMake.GithubUsername = githubInformation.Login
 	}
-	if (user.Name == nil || user.NameInferredFromGithub == nil || *user.NameInferredFromGithub) && githubInformation.Name != nil { // If we should grab the name from github
+
+	// If we have a github name, and we either don't store a name or should infer a different name than what we store
+	if githubInformation.Name != nil && (user.Name == nil || ((user.NameInferredFromGithub == nil || *user.NameInferredFromGithub) && *githubInformation.Name != *user.Name)) {
 		log.Info().Msgf("GH   | user %s github account data contained name %s, recording", user.Email, *githubInformation.Name)
 		editsToMake.Name = githubInformation.Name
 		trueValue := true

--- a/internal/controllers/v2controllers/user_test.go
+++ b/internal/controllers/v2controllers/user_test.go
@@ -168,6 +168,18 @@ func (suite *userControllerSuite) TestUserFlow() {
 	// This would also get pulled in again upon a new request.
 	generatedUser.StoredMutableUserFields = controllerUserWithGithub.StoredMutableUserFields
 
+	// Consecutive calls still read only (there was a bug here once, hence the weirdly specific test).
+	suite.Run("subsequent github record calls with name just read", func() {
+		readUserOne, updated, err := suite.UserController.recordGithubInformation(githubPayload, generatedUser)
+		assert.NoError(suite.T(), err)
+		assert.False(suite.T(), updated)
+		assert.Equal(suite.T(), controllerUserWithGithub.UpdatedAt, readUserOne.UpdatedAt)
+		readUserTwo, updated, err := suite.UserController.recordGithubInformation(githubPayload, generatedUser)
+		assert.NoError(suite.T(), err)
+		assert.False(suite.T(), updated)
+		assert.Equal(suite.T(), controllerUserWithGithub.UpdatedAt, readUserTwo.UpdatedAt)
+	})
+
 	// The name can be edited in the API...
 	otherName := "MALLORY"
 	controllerUserWithGithub, err = suite.UserController.Edit(generatedUser.Email, EditableUser{


### PR DESCRIPTION
Added a test for this very specific narrow case, that happens to be the case for a lot of real-world cases. Just meant some superfluous database writes when it was writing the same name as was already stored.