### PR TITLE
[DDO-2747] Fix dispatch to terra-github-workflows

### DIFF
--- a/.github/workflows/client-set-environment-app-version.yaml
+++ b/.github/workflows/client-set-environment-app-version.yaml
@@ -248,7 +248,7 @@ jobs:
         uses: aurelien-baudet/workflow-dispatch@v2
         with: 
           repo: broadinstitute/terra-github-workflows
-          workflow: sync-release
+          workflow: .github/workflows/sync-release.yaml
           ref: refs/heads/main
           token: ${{ secrets.sync-git-token }}
           inputs: '{ "chart-release-names": "${{ needs.get-chart-release.outputs.name }}", "refresh-only": "false" }'


### PR DESCRIPTION
GitHub's API natively accepts either a numeric workflow ID or an exact file path. [Beehive uses the latter without issue](https://github.com/broadinstitute/beehive/blob/main/app/routes/_layout.review-changesets.tsx#L103) which tips me off that the issue was something specific to this workflow-dispatch action, because this action also accepts plaintext name...

If you look at the code, [it lists the workflows](https://github.com/aurelien-baudet/workflow-dispatch/blob/master/src/workflow-handler.ts#L171) and [iterates to find a match for the plaintext name](https://github.com/aurelien-baudet/workflow-dispatch/blob/master/src/workflow-handler.ts#L179), and if it can't find one, then it prints the [error we're seeing](https://github.com/aurelien-baudet/workflow-dispatch/blob/master/src/workflow-handler.ts#L180).

This looks reasonable enough until you hit the endpoint yourself:
```
gh api \
  -H "Accept: application/vnd.github+json" \
  -H "X-GitHub-Api-Version: 2022-11-28" \
  /repos/broadinstitute/terra-github-workflows/actions/workflows | jq '.workflows[] | {name, path}'
```

Surprise, no sync-release even though it is [definitely in the repo](https://github.com/broadinstitute/terra-github-workflows/blob/main/.github/workflows/sync-release.yaml). A quick trip to the docs...

![Screenshot 2023-03-23 at 11 00 39 AM](https://user-images.githubusercontent.com/29168264/227244715-d0b2d787-12ea-42b9-95e3-bd3d08ccb784.png)

🙄 

It's a paginated API, so the action's code only looks through the first 30 workflows. I don't feel like fixing a [fork](https://github.com/broadinstitute/workflow-dispatch) of a [fork](https://github.com/aurelien-baudet/workflow-dispatch) of a [fork](https://github.com/benc-uk/workflow-dispatch) while everything is on fire so whatever, just specify the file path like Beehive does.