### PR TITLE
[DDO-2794] Fix swaggo version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/stretchr/testify v1.8.1
 	github.com/swaggo/files v0.0.0-20220728132757-551d4a08d97a
 	github.com/swaggo/gin-swagger v1.5.3
-	github.com/swaggo/swag v1.8.8
+	github.com/swaggo/swag v1.16.1
 	go.opencensus.io v0.24.0
 	golang.org/x/oauth2 v0.3.0
 	google.golang.org/api v0.103.0


### PR DESCRIPTION
Swaggo made a change in an update so newer versions of the CLI were producing input that old versions of the library said were invalid. Time to bump the dependency.