### PR TITLE
[DDO-2847] Make Sherlock panic if `cloudsqladmin` role is in the test database

### DIFF
--- a/internal/db/test_helpers.go
+++ b/internal/db/test_helpers.go
@@ -1,12 +1,28 @@
 package db
 
 import (
+	"database/sql"
+	"fmt"
 	"github.com/broadinstitute/sherlock/internal/config"
 	"github.com/rs/zerolog/log"
 	"gorm.io/gorm"
 	"strings"
 	"testing"
 )
+
+// panicIfLooksLikeCloudSQL does what it says on the tin -- it exits fast and hard if the database has a 'cloudsqladmin'
+// role in it. That's not something Sherlock's migration would ever add but it's there by default on Cloud SQL, so
+// it's an extra gate to make sure we don't accidentally run tests against a remote database.
+func panicIfLooksLikeCloudSQL(t *testing.T, db *gorm.DB) {
+	var cloudSqlAdminRoleExists bool
+	err := db.Raw("SELECT 1 FROM pg_roles WHERE rolname='cloudsqladmin'").Row().Scan(&cloudSqlAdminRoleExists)
+	if err != nil && err != sql.ErrNoRows {
+		t.Fatal(fmt.Sprintf("failed to double-check that the database wasn't running in Cloud SQL: %v", err))
+	}
+	if cloudSqlAdminRoleExists {
+		t.Fatal("this database looks like it is running in Cloud SQL, refusing to proceed with test harness")
+	}
+}
 
 // ConnectAndConfigureFromTest is like Connect and Configure but accepts a testing.T in exchange for never returning an
 // error--the test will be failed instead if there is one.
@@ -20,6 +36,7 @@ func ConnectAndConfigureFromTest(t *testing.T) *gorm.DB {
 	if err != nil {
 		t.Errorf("failed to configure database during test: %v", err)
 	}
+	panicIfLooksLikeCloudSQL(t, gormDB)
 	return gormDB
 }
 
@@ -39,6 +56,7 @@ func Truncate(t *testing.T, db *gorm.DB) {
 		t.Errorf("refusing to truncate database, mode is '%s' instead of 'debug'", mode)
 		return
 	}
+	panicIfLooksLikeCloudSQL(t, db)
 	var statements []string
 	dryRunDB := db.Session(&gorm.Session{
 		// Performance boost, don't transact each delete individually

--- a/internal/db/test_helpers.go
+++ b/internal/db/test_helpers.go
@@ -2,7 +2,6 @@ package db
 
 import (
 	"database/sql"
-	"fmt"
 	"github.com/broadinstitute/sherlock/internal/config"
 	"github.com/rs/zerolog/log"
 	"gorm.io/gorm"
@@ -17,7 +16,7 @@ func panicIfLooksLikeCloudSQL(t *testing.T, db *gorm.DB) {
 	var cloudSqlAdminRoleExists bool
 	err := db.Raw("SELECT 1 FROM pg_roles WHERE rolname='cloudsqladmin'").Row().Scan(&cloudSqlAdminRoleExists)
 	if err != nil && err != sql.ErrNoRows {
-		t.Fatal(fmt.Sprintf("failed to double-check that the database wasn't running in Cloud SQL: %v", err))
+		t.Fatalf("failed to double-check that the database wasn't running in Cloud SQL: %v", err)
 	}
 	if cloudSqlAdminRoleExists {
 		t.Fatal("this database looks like it is running in Cloud SQL, refusing to proceed with test harness")


### PR DESCRIPTION
🤷 

I can't think of a good reason why we would ever want to run Sherlock tests against a database that had been set up by Cloud SQL... so this seems like an easy enough thing to add. It's not perfect but it's way hardier than doing nothing.

## Testing

It doesn't panic in the normal case, and then I modified the local postgres with datagrip to add a dummy role named `cloudsqladmin`. Running tests again immediately failed with 
```
test_helpers.go:20: this database looks like it is running in Cloud SQL, refusing to proceed with test harness
```
and then a giant stacktrace with a bunch of nil pointer dereferences and various panics. Close enough 🤷 