### PR TITLE
[DDO-2855] Fix API typo

### DIFF
--- a/internal/controllers/v2controllers/chart.go
+++ b/internal/controllers/v2controllers/chart.go
@@ -21,7 +21,7 @@ type EditableChart struct {
 	AppImageGitRepo       *string `json:"appImageGitRepo" form:"appImageGitRepo"`
 	AppImageGitMainBranch *string `json:"appImageGitMainBranch" form:"appImageGitMainBranch"`
 	ChartExposesEndpoint  *bool   `json:"chartExposesEndpoint" form:"chartExposesEndpoint" default:"false"` // Indicates if the default subdomain, protocol, and port fields are relevant for this chart
-	LegacyConfigsEnabled  *bool   `json:"legacyConfigsEnabled" form:"legacyConfigsEnbled" default:"false"`  // Indicates whether a chart requires config rendering from firecloud-develop
+	LegacyConfigsEnabled  *bool   `json:"legacyConfigsEnabled" form:"legacyConfigsEnabled" default:"false"` // Indicates whether a chart requires config rendering from firecloud-develop
 	DefaultSubdomain      *string `json:"defaultSubdomain" form:"defaultSubdomain"`                         // When creating, will default to the name of the chart
 	DefaultProtocol       *string `json:"defaultProtocol" form:"defaultProtocol" default:"https"`
 	DefaultPort           *uint   `json:"defaultPort" form:"defaultPort" default:"443"`


### PR DESCRIPTION
No one has used this field or they woulda noticed, I think. No references to the name in either Beehive or Thelma's codebase. This is just the query param name when listing charts, not the field name in the JSON.