### PR TITLE
[DDO-2873] CiIdentifier and CiRun

### DIFF
--- a/db/migrations/000042_create_ci.down.sql
+++ b/db/migrations/000042_create_ci.down.sql
@@ -1,0 +1,5 @@
+drop table if exists v2_ci_runs_for_identifiers cascade;
+
+drop table if exists v2_ci_identifiers cascade;
+
+drop table if exists v2_ci_runs cascade;

--- a/db/migrations/000042_create_ci.up.sql
+++ b/db/migrations/000042_create_ci.up.sql
@@ -1,0 +1,52 @@
+create table v2_ci_identifiers
+(
+    id            bigserial
+        primary key,
+    created_at    timestamp with time zone,
+    updated_at    timestamp with time zone,
+    deleted_at    timestamp with time zone,
+    resource_type text,
+    resource_id   bigint
+);
+
+create index idx_v2_ci_identifiers_deleted_at
+    on v2_ci_identifiers (deleted_at);
+
+create index idx_v2_ci_identifiers_polymorphic_index
+    on v2_ci_identifiers (resource_type, resource_id);
+
+create table v2_ci_runs
+(
+    id                            bigserial
+        primary key,
+    created_at                    timestamp with time zone,
+    updated_at                    timestamp with time zone,
+    deleted_at                    timestamp with time zone,
+    platform                      text,
+    github_actions_owner          text,
+    github_actions_repo           text,
+    github_actions_run_id         bigint,
+    github_actions_attempt_number bigint,
+    github_actions_workflow_path  text,
+    argo_workflows_namespace      text,
+    argo_workflows_name           text,
+    argo_workflows_template       text,
+    terminal_at                   timestamp with time zone,
+    status                        text
+);
+
+create index idx_v2_ci_runs_deleted_at
+    on v2_ci_runs (deleted_at);
+
+create table v2_ci_runs_for_identifiers
+(
+    ci_run_id        bigint not null
+        constraint fk_v2_ci_runs_for_identifiers_ci_run
+            references v2_ci_runs
+            on update cascade on delete cascade,
+    ci_identifier_id bigint not null
+        constraint fk_v2_ci_runs_for_identifiers_ci_identifier
+            references v2_ci_identifiers
+            on update cascade on delete cascade,
+    primary key (ci_run_id, ci_identifier_id)
+);

--- a/db/migrations/000042_create_ci.up.sql
+++ b/db/migrations/000042_create_ci.up.sql
@@ -1,4 +1,4 @@
-create table v2_ci_identifiers
+create table if not exists v2_ci_identifiers
 (
     id            bigserial
         primary key,
@@ -9,13 +9,13 @@ create table v2_ci_identifiers
     resource_id   bigint
 );
 
-create index idx_v2_ci_identifiers_deleted_at
+create index if not exists idx_v2_ci_identifiers_deleted_at
     on v2_ci_identifiers (deleted_at);
 
-create index idx_v2_ci_identifiers_polymorphic_index
+create index if not exists idx_v2_ci_identifiers_polymorphic_index
     on v2_ci_identifiers (resource_type, resource_id);
 
-create table v2_ci_runs
+create table if not exists v2_ci_runs
 (
     id                            bigserial
         primary key,
@@ -35,10 +35,10 @@ create table v2_ci_runs
     status                        text
 );
 
-create index idx_v2_ci_runs_deleted_at
+create index if not exists idx_v2_ci_runs_deleted_at
     on v2_ci_runs (deleted_at);
 
-create table v2_ci_runs_for_identifiers
+create table if not exists v2_ci_runs_for_identifiers
 (
     ci_run_id        bigint not null
         constraint fk_v2_ci_runs_for_identifiers_ci_run

--- a/internal/controllers/v2controllers/app_version.go
+++ b/internal/controllers/v2controllers/app_version.go
@@ -11,8 +11,9 @@ import (
 
 type AppVersion struct {
 	ReadableBaseType
-	ChartInfo            *Chart      `json:"chartInfo,omitempty"  form:"-"`
-	ParentAppVersionInfo *AppVersion `json:"parentAppVersionInfo,omitempty" swaggertype:"object" form:"-"`
+	CiIdentifier         *CiIdentifier `json:"ciIdentifier,omitempty" form:"-"`
+	ChartInfo            *Chart        `json:"chartInfo,omitempty" form:"-"`
+	ParentAppVersionInfo *AppVersion   `json:"parentAppVersionInfo,omitempty" swaggertype:"object" form:"-"`
 	CreatableAppVersion
 }
 
@@ -118,6 +119,7 @@ func modelAppVersionToAppVersion(model *v2models.AppVersion) *AppVersion {
 			CreatedAt: model.CreatedAt,
 			UpdatedAt: model.UpdatedAt,
 		},
+		CiIdentifier:         modelCiIdentifierToCiIdentifier(model.CiIdentifier),
 		ChartInfo:            chart,
 		ParentAppVersionInfo: parentAppVersion,
 		CreatableAppVersion: CreatableAppVersion{

--- a/internal/controllers/v2controllers/changeset.go
+++ b/internal/controllers/v2controllers/changeset.go
@@ -11,6 +11,7 @@ import (
 
 type Changeset struct {
 	ReadableBaseType
+	CiIdentifier     *CiIdentifier `json:"ciIdentifier,omitempty" form:"-"`
 	ChartReleaseInfo *ChartRelease `json:"chartReleaseInfo,omitempty" form:"-"`
 
 	AppliedAt    *time.Time `json:"appliedAt,omitempty" form:"appliedAt"  format:"date-time"`
@@ -349,6 +350,7 @@ func modelChangesetToChangeset(model *v2models.Changeset) *Changeset {
 			CreatedAt: model.CreatedAt,
 			UpdatedAt: model.UpdatedAt,
 		},
+		CiIdentifier:                       modelCiIdentifierToCiIdentifier(model.CiIdentifier),
 		ChartReleaseInfo:                   chartRelease,
 		AppliedAt:                          model.AppliedAt,
 		SupersededAt:                       model.SupersededAt,

--- a/internal/controllers/v2controllers/chart.go
+++ b/internal/controllers/v2controllers/chart.go
@@ -8,6 +8,7 @@ import (
 
 type Chart struct {
 	ReadableBaseType
+	CiIdentifier *CiIdentifier `json:"ciIdentifier,omitempty" form:"-"`
 	CreatableChart
 }
 
@@ -83,6 +84,7 @@ func modelChartToChart(model *v2models.Chart) *Chart {
 			CreatedAt: model.CreatedAt,
 			UpdatedAt: model.UpdatedAt,
 		},
+		CiIdentifier: modelCiIdentifierToCiIdentifier(model.CiIdentifier),
 		CreatableChart: CreatableChart{
 			Name: model.Name,
 			EditableChart: EditableChart{

--- a/internal/controllers/v2controllers/chart_release.go
+++ b/internal/controllers/v2controllers/chart_release.go
@@ -12,6 +12,7 @@ import (
 
 type ChartRelease struct {
 	ReadableBaseType
+	CiIdentifier             *CiIdentifier         `json:"ciIdentifier,omitempty" form:"-"`
 	ChartInfo                *Chart                `json:"chartInfo,omitempty" form:"-"`
 	ClusterInfo              *Cluster              `json:"clusterInfo,omitempty" form:"-"`
 	EnvironmentInfo          *Environment          `json:"environmentInfo,omitempty" form:"-"`
@@ -242,6 +243,7 @@ func modelChartReleaseToChartRelease(model *v2models.ChartRelease) *ChartRelease
 			CreatedAt: model.CreatedAt,
 			UpdatedAt: model.UpdatedAt,
 		},
+		CiIdentifier:             modelCiIdentifierToCiIdentifier(model.CiIdentifier),
 		ChartInfo:                chart,
 		ClusterInfo:              cluster,
 		EnvironmentInfo:          environment,

--- a/internal/controllers/v2controllers/chart_release_test.go
+++ b/internal/controllers/v2controllers/chart_release_test.go
@@ -198,7 +198,7 @@ var (
 func (controllerSet *ControllerSet) seedChartReleases(t *testing.T, db *gorm.DB) {
 	for _, creatable := range chartReleaseSeedList {
 		if _, _, err := controllerSet.ChartReleaseController.Create(creatable, auth.GenerateUser(t, db, true)); err != nil {
-			t.Errorf("error seeding chart release for %s in %s/%s: %v", creatable.Chart, creatable.Environment, creatable.Cluster, err)
+			t.Errorf("error seeding chart release for %s, environment=%s cluster=%s : %v", creatable.Chart, creatable.Environment, creatable.Cluster, err)
 		}
 	}
 }

--- a/internal/controllers/v2controllers/chart_version.go
+++ b/internal/controllers/v2controllers/chart_version.go
@@ -11,6 +11,7 @@ import (
 
 type ChartVersion struct {
 	ReadableBaseType
+	CiIdentifier           *CiIdentifier `json:"ciIdentifier,omitempty" form:"-"`
 	ChartInfo              *Chart        `json:"chartInfo,omitempty" form:"-"`
 	ParentChartVersionInfo *ChartVersion `json:"parentChartVersionInfo,omitempty" swaggertype:"object" form:"-"`
 	CreatableChartVersion
@@ -114,6 +115,7 @@ func modelChartVersionToChartVersion(model *v2models.ChartVersion) *ChartVersion
 			CreatedAt: model.CreatedAt,
 			UpdatedAt: model.UpdatedAt,
 		},
+		CiIdentifier:           modelCiIdentifierToCiIdentifier(model.CiIdentifier),
 		ChartInfo:              chart,
 		ParentChartVersionInfo: parentChartVersion,
 		CreatableChartVersion: CreatableChartVersion{

--- a/internal/controllers/v2controllers/ci_identifier.go
+++ b/internal/controllers/v2controllers/ci_identifier.go
@@ -1,0 +1,102 @@
+package v2controllers
+
+import (
+	"github.com/broadinstitute/sherlock/internal/models/v2models"
+	"gorm.io/gorm"
+)
+
+type CiIdentifier struct {
+	ReadableBaseType
+	CiRuns       []CiRun `json:"ciRuns,omitempty" form:"-"`
+	ResourceType string  `json:"resourceType" form:"resourceType"`
+	ResourceID   uint    `json:"resourceID" form:"resourceID"`
+}
+
+type CreatableCiIdentifier struct {
+	ResourceType string `json:"resourceType" form:"resourceType"`
+	ResourceID   uint   `json:"resourceID" form:"resourceID"`
+	EditableCiIdentifier
+}
+
+type EditableCiIdentifier struct {
+	CiRuns []string `json:"ciRuns" form:"-"` // Always appends; will eliminate duplicates
+}
+
+//nolint:unused
+func (c CiIdentifier) toModel(_ *v2models.StoreSet) (v2models.CiIdentifier, error) {
+	return v2models.CiIdentifier{
+		Model: gorm.Model{
+			ID:        c.ID,
+			CreatedAt: c.CreatedAt,
+			UpdatedAt: c.UpdatedAt,
+		},
+		ResourceType: c.ResourceType,
+		ResourceID:   c.ResourceID,
+	}, nil
+}
+
+//nolint:unused
+func (c CreatableCiIdentifier) toModel(storeSet *v2models.StoreSet) (v2models.CiIdentifier, error) {
+	ciRuns := make([]*v2models.CiRun, len(c.EditableCiIdentifier.CiRuns))
+append:
+	for _, ciRunSelector := range c.CiRuns {
+		ciRun, err := storeSet.CiRunStore.Get(ciRunSelector)
+		if err != nil {
+			return v2models.CiIdentifier{}, err
+		}
+		// If we already have this one in the list, don't add it again
+		for _, existingCiRun := range ciRuns {
+			if existingCiRun.ID == ciRun.ID {
+				continue append
+			}
+		}
+		ciRuns = append(ciRuns, &ciRun)
+	}
+	return v2models.CiIdentifier{
+		CiRuns:       ciRuns,
+		ResourceType: c.ResourceType,
+		ResourceID:   c.ResourceID,
+	}, nil
+}
+
+//nolint:unused
+func (c EditableCiIdentifier) toModel(storeSet *v2models.StoreSet) (v2models.CiIdentifier, error) {
+	// We don't need to do anything special to handle the append behavior of the associations, the model will do that
+	// for us
+	return CreatableCiIdentifier{EditableCiIdentifier: c}.toModel(storeSet)
+}
+
+type CiIdentifierController = ModelController[v2models.CiIdentifier, CiIdentifier, CreatableCiIdentifier, EditableCiIdentifier]
+
+func newCiIdentifierController(stores *v2models.StoreSet) *CiIdentifierController {
+	return &CiIdentifierController{
+		primaryStore:    stores.CiIdentifierStore,
+		allStores:       stores,
+		modelToReadable: modelCiIdentifierToCiIdentifier,
+	}
+}
+
+func modelCiIdentifierToCiIdentifier(model *v2models.CiIdentifier) *CiIdentifier {
+	if model == nil {
+		return nil
+	}
+
+	var ciRuns []CiRun
+	for _, modelCiRun := range model.CiRuns {
+		ciRun := modelCiRunToCiRun(modelCiRun)
+		if ciRun != nil {
+			ciRuns = append(ciRuns, *ciRun)
+		}
+	}
+
+	return &CiIdentifier{
+		ReadableBaseType: ReadableBaseType{
+			ID:        model.ID,
+			CreatedAt: model.CreatedAt,
+			UpdatedAt: model.UpdatedAt,
+		},
+		CiRuns:       ciRuns,
+		ResourceType: model.ResourceType,
+		ResourceID:   model.ResourceID,
+	}
+}

--- a/internal/controllers/v2controllers/ci_run.go
+++ b/internal/controllers/v2controllers/ci_run.go
@@ -1,0 +1,216 @@
+package v2controllers
+
+import (
+	"github.com/broadinstitute/sherlock/internal/models/v2models"
+	"gorm.io/gorm"
+	"strconv"
+	"time"
+)
+
+type CiRun struct {
+	ReadableBaseType
+	CiRunDataFields
+	CiRunStatusFields
+	RelatedResources []CiIdentifier `json:"relatedResources" form:"-"`
+}
+
+type CreatableCiRun struct {
+	CiRunDataFields
+	EditableCiRun
+}
+
+type EditableCiRun struct {
+	CiRunStatusFields
+	Charts        []string `json:"charts" form:"-"`        // Always appends; will eliminate duplicates.
+	ChartVersions []string `json:"chartVersions" form:"-"` // Always appends; will eliminate duplicates.
+	AppVersions   []string `json:"appVersions" form:"-"`   // Always appends; will eliminate duplicates.
+	Clusters      []string `json:"clusters" form:"-"`      // Always appends; will eliminate duplicates.
+	Environments  []string `json:"environments" form:"-"`  // Always appends; will eliminate duplicates.
+	ChartReleases []string `json:"chartReleases" form:"-"` // Always appends; will eliminate duplicates. Spreads to associated environments and clusters.
+	Changesets    []string `json:"changesets" form:"-"`    // Always appends; will eliminate duplicates. Spreads to associated chart releases (and environments and clusters) and new app/chart versions.
+}
+
+type CiRunDataFields struct {
+	Platform                   string `json:"platform" form:"platform"`
+	GithubActionsOwner         string `json:"githubActionsOwner" form:"githubActionsOwner"`
+	GithubActionsRepo          string `json:"githubActionsRepo" form:"githubActionsRepo"`
+	GithubActionsRunID         uint   `json:"githubActionsRunID" form:"githubActionsRunID"`
+	GithubActionsAttemptNumber uint   `json:"githubActionsAttemptNumber" form:"githubActionsAttemptNumber"`
+	GithubActionsWorkflowPath  string `json:"githubActionsWorkflowPath" form:"githubActionsWorkflowPath"`
+	ArgoWorkflowsNamespace     string `json:"argoWorkflowsNamespace" form:"argoWorkflowsNamespace"`
+	ArgoWorkflowsName          string `json:"argoWorkflowsName" form:"argoWorkflowsName"`
+	ArgoWorkflowsTemplate      string `json:"argoWorkflowsTemplate" form:"argoWorkflowsTemplate"`
+}
+
+type CiRunStatusFields struct {
+	TerminalAt *time.Time `json:"terminalAt,omitempty" form:"terminalAt"`
+	Status     *string    `json:"status,omitempty" form:"status"`
+}
+
+//nolint:unused
+func (c CiRun) toModel(_ *v2models.StoreSet) (v2models.CiRun, error) {
+	return v2models.CiRun{
+		Model: gorm.Model{
+			ID:        c.ID,
+			CreatedAt: c.CreatedAt,
+			UpdatedAt: c.UpdatedAt,
+		},
+		Platform:                   c.Platform,
+		GithubActionsOwner:         c.GithubActionsOwner,
+		GithubActionsRepo:          c.GithubActionsRepo,
+		GithubActionsRunID:         c.GithubActionsRunID,
+		GithubActionsAttemptNumber: c.GithubActionsAttemptNumber,
+		GithubActionsWorkflowPath:  c.GithubActionsWorkflowPath,
+		ArgoWorkflowsNamespace:     c.ArgoWorkflowsNamespace,
+		ArgoWorkflowsName:          c.ArgoWorkflowsName,
+		ArgoWorkflowsTemplate:      c.ArgoWorkflowsTemplate,
+		TerminalAt:                 c.TerminalAt,
+		Status:                     c.Status,
+	}, nil
+}
+
+//nolint:unused
+func (c CreatableCiRun) toModel(storeSet *v2models.StoreSet) (v2models.CiRun, error) {
+	var relatedResources []*v2models.CiIdentifier
+
+	for _, changesetSelector := range c.Changesets {
+		changeset, err := storeSet.ChangesetStore.Get(changesetSelector)
+		if err != nil {
+			return v2models.CiRun{}, err
+		}
+		if changeset.ChartReleaseID != 0 {
+			c.ChartReleases = append(c.ChartReleases, strconv.FormatUint(uint64(changeset.ChartReleaseID), 10))
+		}
+		for _, newAppVersion := range changeset.NewAppVersions {
+			if newAppVersion != nil {
+				c.AppVersions = append(c.AppVersions, strconv.FormatUint(uint64(newAppVersion.ID), 10))
+			}
+		}
+		for _, newChartVersion := range changeset.NewChartVersions {
+			if newChartVersion != nil {
+				c.ChartVersions = append(c.ChartVersions, strconv.FormatUint(uint64(newChartVersion.ID), 10))
+			}
+		}
+		relatedResources = append(relatedResources, changeset.GetCiIdentifier())
+	}
+
+	for _, chartReleaseSelector := range c.ChartReleases {
+		chartRelease, err := storeSet.ChartReleaseStore.Get(chartReleaseSelector)
+		if err != nil {
+			return v2models.CiRun{}, err
+		}
+		if chartRelease.EnvironmentID != nil {
+			c.Environments = append(c.Environments, strconv.FormatUint(uint64(*chartRelease.EnvironmentID), 10))
+		}
+		if chartRelease.ClusterID != nil {
+			c.Clusters = append(c.Clusters, strconv.FormatUint(uint64(*chartRelease.ClusterID), 10))
+		}
+		relatedResources = append(relatedResources, chartRelease.GetCiIdentifier())
+	}
+
+	for _, chartSelector := range c.Charts {
+		chart, err := storeSet.ChartStore.Get(chartSelector)
+		if err != nil {
+			return v2models.CiRun{}, err
+		}
+		relatedResources = append(relatedResources, chart.GetCiIdentifier())
+	}
+	for _, chartVersionSelector := range c.ChartVersions {
+		chartVersion, err := storeSet.ChartVersionStore.Get(chartVersionSelector)
+		if err != nil {
+			return v2models.CiRun{}, err
+		}
+		relatedResources = append(relatedResources, chartVersion.GetCiIdentifier())
+	}
+	for _, appVersionSelector := range c.AppVersions {
+		appVersion, err := storeSet.AppVersionStore.Get(appVersionSelector)
+		if err != nil {
+			return v2models.CiRun{}, err
+		}
+		relatedResources = append(relatedResources, appVersion.GetCiIdentifier())
+	}
+	for _, clusterSelector := range c.Clusters {
+		cluster, err := storeSet.ClusterStore.Get(clusterSelector)
+		if err != nil {
+			return v2models.CiRun{}, err
+		}
+		relatedResources = append(relatedResources, cluster.GetCiIdentifier())
+	}
+	for _, environmentSelector := range c.Environments {
+		environment, err := storeSet.EnvironmentStore.Get(environmentSelector)
+		if err != nil {
+			return v2models.CiRun{}, err
+		}
+		relatedResources = append(relatedResources, environment.GetCiIdentifier())
+	}
+
+	return v2models.CiRun{
+		Platform:                   c.Platform,
+		GithubActionsOwner:         c.GithubActionsOwner,
+		GithubActionsRepo:          c.GithubActionsRepo,
+		GithubActionsRunID:         c.GithubActionsRunID,
+		GithubActionsAttemptNumber: c.GithubActionsAttemptNumber,
+		GithubActionsWorkflowPath:  c.GithubActionsWorkflowPath,
+		ArgoWorkflowsNamespace:     c.ArgoWorkflowsNamespace,
+		ArgoWorkflowsName:          c.ArgoWorkflowsName,
+		ArgoWorkflowsTemplate:      c.ArgoWorkflowsTemplate,
+		TerminalAt:                 c.TerminalAt,
+		Status:                     c.Status,
+		RelatedResources:           relatedResources,
+	}, nil
+}
+
+//nolint:unused
+func (c EditableCiRun) toModel(storeSet *v2models.StoreSet) (v2models.CiRun, error) {
+	// We don't need to do anything special to handle the append behavior of the associations, the model will do that
+	// for us
+	return CreatableCiRun{EditableCiRun: c}.toModel(storeSet)
+}
+
+type CiRunController = ModelController[v2models.CiRun, CiRun, CreatableCiRun, EditableCiRun]
+
+func newCiRunController(stores *v2models.StoreSet) *CiRunController {
+	return &CiRunController{
+		primaryStore:    stores.CiRunStore,
+		allStores:       stores,
+		modelToReadable: modelCiRunToCiRun,
+	}
+}
+
+func modelCiRunToCiRun(model *v2models.CiRun) *CiRun {
+	if model == nil {
+		return nil
+	}
+
+	var relatedResources []CiIdentifier
+	for _, modelCiIdentifier := range model.RelatedResources {
+		ciIdentifier := modelCiIdentifierToCiIdentifier(modelCiIdentifier)
+		if ciIdentifier != nil {
+			relatedResources = append(relatedResources, *ciIdentifier)
+		}
+	}
+
+	return &CiRun{
+		ReadableBaseType: ReadableBaseType{
+			ID:        model.ID,
+			CreatedAt: model.CreatedAt,
+			UpdatedAt: model.UpdatedAt,
+		},
+		CiRunDataFields: CiRunDataFields{
+			Platform:                   model.Platform,
+			GithubActionsOwner:         model.GithubActionsOwner,
+			GithubActionsRepo:          model.GithubActionsRepo,
+			GithubActionsRunID:         model.GithubActionsRunID,
+			GithubActionsAttemptNumber: model.GithubActionsAttemptNumber,
+			GithubActionsWorkflowPath:  model.GithubActionsWorkflowPath,
+			ArgoWorkflowsNamespace:     model.ArgoWorkflowsNamespace,
+			ArgoWorkflowsName:          model.ArgoWorkflowsName,
+			ArgoWorkflowsTemplate:      model.ArgoWorkflowsTemplate,
+		},
+		CiRunStatusFields: CiRunStatusFields{
+			TerminalAt: model.TerminalAt,
+			Status:     model.Status,
+		},
+		RelatedResources: relatedResources,
+	}
+}

--- a/internal/controllers/v2controllers/ci_run_test.go
+++ b/internal/controllers/v2controllers/ci_run_test.go
@@ -1,0 +1,450 @@
+package v2controllers
+
+import (
+	"fmt"
+	"github.com/broadinstitute/sherlock/internal/auth"
+	"github.com/broadinstitute/sherlock/internal/config"
+	"github.com/broadinstitute/sherlock/internal/db"
+	"github.com/broadinstitute/sherlock/internal/models/v2models"
+	"github.com/broadinstitute/sherlock/internal/testutils"
+	"github.com/stretchr/testify/suite"
+	"gorm.io/gorm"
+	"strconv"
+	"testing"
+	"time"
+)
+
+func TestCiRunControllerSuite(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping functional test")
+	}
+	suite.Run(t, new(ciRunControllerSuite))
+}
+
+type ciRunControllerSuite struct {
+	suite.Suite
+	*ControllerSet
+	db *gorm.DB
+}
+
+func (suite *ciRunControllerSuite) SetupTest() {
+	config.LoadTestConfig(suite.T())
+	suite.db = db.ConnectAndConfigureFromTest(suite.T())
+	suite.db.Begin()
+	suite.ControllerSet = NewControllerSet(v2models.NewStoreSet(suite.db))
+}
+
+func (suite *ciRunControllerSuite) TearDownTest() {
+	suite.db.Rollback()
+}
+
+// TestCiFlow covers both CiRun and CiIdentifier, since they're inter-referential and usage is very closely related.
+func (suite *ciRunControllerSuite) TestCiFlow() {
+	db.Truncate(suite.T(), suite.db)
+	suite.seedCharts(suite.T(), suite.db)
+	suite.seedAppVersions(suite.T(), suite.db)
+	suite.seedChartVersions(suite.T(), suite.db)
+	suite.seedClusters(suite.T(), suite.db)
+	suite.seedEnvironments(suite.T(), suite.db)
+	suite.seedChartReleases(suite.T(), suite.db)
+
+	// Let's play along with how a GitHub Actions run might be reported to Sherlock. Whether via webhook or the API,
+	// it'll still come through the controller layer.
+	ciRunData := CiRunDataFields{
+		Platform:                   "github-actions",
+		GithubActionsOwner:         "broadinstitute",
+		GithubActionsRepo:          "beehive",
+		GithubActionsRunID:         1234,
+		GithubActionsAttemptNumber: 1,
+		GithubActionsWorkflowPath:  ".github/workflows/build.yaml",
+	}
+	ciRunSelector := fmt.Sprintf("github-actions/%s/%s/%d/%d", ciRunData.GithubActionsOwner, ciRunData.GithubActionsRepo, ciRunData.GithubActionsRunID, ciRunData.GithubActionsAttemptNumber)
+
+	// Write operations are going to come from CI workflows, so we expect PUT (upsert) operations. Suppose a webhook
+	// or something tells Sherlock about the workflow being requested:
+	payload := CreatableCiRun{
+		CiRunDataFields: ciRunData,
+		EditableCiRun:   EditableCiRun{CiRunStatusFields: CiRunStatusFields{Status: testutils.PointerTo("requested")}},
+	}
+	ciRun, created, err := suite.CiRunController.Upsert(
+		ciRunSelector,
+		payload,
+		payload.EditableCiRun,
+		auth.GenerateUser(suite.T(), suite.db, false),
+	)
+	suite.Assert().NoError(err)
+	suite.Assert().True(created)
+	suite.Assert().Equal("requested", *ciRun.Status)
+	testutils.AssertNoDiff(suite.T(), ciRunData, ciRun.CiRunDataFields)
+
+	// As the CI workflow changes state, new PUTs will hit the controller
+	payload = CreatableCiRun{
+		CiRunDataFields: ciRunData,
+		EditableCiRun:   EditableCiRun{CiRunStatusFields: CiRunStatusFields{Status: testutils.PointerTo("running")}},
+	}
+	ciRun, created, err = suite.CiRunController.Upsert(
+		ciRunSelector,
+		payload,
+		payload.EditableCiRun,
+		auth.GenerateUser(suite.T(), suite.db, false),
+	)
+	suite.Assert().NoError(err)
+	suite.Assert().False(created)
+	suite.Assert().Equal("running", *ciRun.Status)
+	testutils.AssertNoDiff(suite.T(), ciRunData, ciRun.CiRunDataFields)
+
+	// Let's say that the CI workflow creates an app version
+	appVersion, created, err := suite.AppVersionController.Create(
+		CreatableAppVersion{Chart: "sam", AppVersion: "v1.2.3-ci-run-test"},
+		auth.GenerateUser(suite.T(), suite.db, false))
+	suite.Assert().NoError(err)
+	suite.Assert().True(created)
+
+	// Note that there's no CI identifier associated to the app version yet
+	suite.Assert().Nil(appVersion.CiIdentifier)
+
+	// Suppose the workflow then reports that it is related to the app version
+	payload = CreatableCiRun{
+		CiRunDataFields: ciRunData,
+		EditableCiRun:   EditableCiRun{AppVersions: []string{"sam/v1.2.3-ci-run-test"}},
+	}
+	ciRun, created, err = suite.CiRunController.Upsert(
+		ciRunSelector,
+		payload,
+		payload.EditableCiRun,
+		auth.GenerateUser(suite.T(), suite.db, false),
+	)
+	suite.Assert().NoError(err)
+	suite.Assert().False(created)
+	suite.Assert().Equal("running", *ciRun.Status)
+
+	// First, we can see that the resource was associated according to the CI run itself
+	suite.Assert().Len(ciRun.RelatedResources, 1)
+	suite.Assert().Equal(appVersion.ID, ciRun.RelatedResources[0].ResourceID)
+	suite.Assert().Equal("app-version", ciRun.RelatedResources[0].ResourceType)
+
+	// Second, we can see that a CI identifier got created for the app version if we load it again
+	appVersion, err = suite.AppVersionController.Get(strconv.FormatUint(uint64(appVersion.ID), 10))
+	suite.Assert().NoError(err)
+	suite.Assert().NotNil(appVersion.CiIdentifier)
+	suite.Assert().Equal(appVersion.ID, appVersion.CiIdentifier.ResourceID)
+	suite.Assert().Equal("app-version", appVersion.CiIdentifier.ResourceType)
+
+	// Future readers like Beehive can query that CI identifier to list out the CI runs
+	ciIdentifier, err := suite.CiIdentifierController.Get(strconv.FormatUint(uint64(appVersion.CiIdentifier.ID), 10))
+	suite.Assert().NoError(err)
+	suite.Assert().Len(ciIdentifier.CiRuns, 1)
+
+	// Suppose the workflow finishes
+	payload = CreatableCiRun{
+		CiRunDataFields: ciRunData,
+		EditableCiRun: EditableCiRun{CiRunStatusFields: CiRunStatusFields{
+			Status:     testutils.PointerTo("succeeded"),
+			TerminalAt: testutils.PointerTo(time.Now()),
+		}},
+	}
+	ciRun, created, err = suite.CiRunController.Upsert(
+		ciRunSelector,
+		payload,
+		payload.EditableCiRun,
+		auth.GenerateUser(suite.T(), suite.db, false),
+	)
+	suite.Assert().NoError(err)
+	suite.Assert().False(created)
+	suite.Assert().Equal("succeeded", *ciRun.Status)
+	suite.Assert().NotNil(ciRun.TerminalAt)
+	testutils.AssertNoDiff(suite.T(), ciRunData, ciRun.CiRunDataFields)
+
+	// Maybe the action glitches out or there's a misconfiguration, we get another completion report indicating a
+	// failure -- it all still gets recorded
+	payload = CreatableCiRun{
+		CiRunDataFields: ciRunData,
+		EditableCiRun: EditableCiRun{CiRunStatusFields: CiRunStatusFields{
+			Status:     testutils.PointerTo("failed"),
+			TerminalAt: testutils.PointerTo(time.Now()),
+		}},
+	}
+	ciRun, created, err = suite.CiRunController.Upsert(
+		ciRunSelector,
+		payload,
+		payload.EditableCiRun,
+		auth.GenerateUser(suite.T(), suite.db, false),
+	)
+	suite.Assert().NoError(err)
+	suite.Assert().False(created)
+	suite.Assert().Equal("failed", *ciRun.Status)
+	suite.Assert().NotNil(ciRun.TerminalAt)
+	testutils.AssertNoDiff(suite.T(), ciRunData, ciRun.CiRunDataFields)
+
+	// The resource association is still there
+	suite.Assert().Len(ciRun.RelatedResources, 1)
+	suite.Assert().Equal(appVersion.ID, ciRun.RelatedResources[0].ResourceID)
+	suite.Assert().Equal("app-version", ciRun.RelatedResources[0].ResourceType)
+}
+
+func (suite *ciRunControllerSuite) TestComplexCiFlow() {
+	db.Truncate(suite.T(), suite.db)
+	suite.seedCharts(suite.T(), suite.db)
+	suite.seedAppVersions(suite.T(), suite.db)
+	suite.seedChartVersions(suite.T(), suite.db)
+	suite.seedClusters(suite.T(), suite.db)
+	suite.seedEnvironments(suite.T(), suite.db)
+	suite.seedChartReleases(suite.T(), suite.db)
+
+	// Let's show off a bit. Sherlock isn't just shoving webhook payloads into the database to generate metrics, it's
+	// taking advantage of its unique position in our infrastructure to know more about the action than the action knows
+	// about itself.
+
+	// We'll do a bit of setup to demonstrate. Suppose we've got Leonardo app versions A, B, C, and D and chart versions
+	// X, Y, and Z.
+	appVersionA, created, err := suite.AppVersionController.Create(
+		CreatableAppVersion{Chart: "leonardo", AppVersion: "A"},
+		auth.GenerateUser(suite.T(), suite.db, true))
+	suite.Assert().NoError(err)
+	suite.Assert().True(created)
+	appVersionB, created, err := suite.AppVersionController.Create(
+		CreatableAppVersion{Chart: "leonardo", AppVersion: "B", ParentAppVersion: "leonardo/A"},
+		auth.GenerateUser(suite.T(), suite.db, true))
+	suite.Assert().NoError(err)
+	suite.Assert().True(created)
+	suite.Assert().Equal(appVersionA.ID, appVersionB.ParentAppVersionInfo.ID)
+	appVersionC, created, err := suite.AppVersionController.Create(
+		CreatableAppVersion{Chart: "leonardo", AppVersion: "C", ParentAppVersion: "leonardo/B"},
+		auth.GenerateUser(suite.T(), suite.db, true))
+	suite.Assert().NoError(err)
+	suite.Assert().True(created)
+	suite.Assert().Equal(appVersionB.ID, appVersionC.ParentAppVersionInfo.ID)
+	appVersionD, created, err := suite.AppVersionController.Create(
+		CreatableAppVersion{Chart: "leonardo", AppVersion: "D", ParentAppVersion: "leonardo/C"},
+		auth.GenerateUser(suite.T(), suite.db, true))
+	suite.Assert().NoError(err)
+	suite.Assert().True(created)
+	suite.Assert().Equal(appVersionC.ID, appVersionD.ParentAppVersionInfo.ID)
+	chartVersionX, created, err := suite.ChartVersionController.Create(
+		CreatableChartVersion{Chart: "leonardo", ChartVersion: "X"},
+		auth.GenerateUser(suite.T(), suite.db, true))
+	suite.Assert().NoError(err)
+	suite.Assert().True(created)
+	chartVersionY, created, err := suite.ChartVersionController.Create(
+		CreatableChartVersion{Chart: "leonardo", ChartVersion: "Y", ParentChartVersion: "leonardo/X"},
+		auth.GenerateUser(suite.T(), suite.db, true))
+	suite.Assert().NoError(err)
+	suite.Assert().True(created)
+	suite.Assert().Equal(chartVersionX.ID, chartVersionY.ParentChartVersionInfo.ID)
+	chartVersionZ, created, err := suite.ChartVersionController.Create(
+		CreatableChartVersion{Chart: "leonardo", ChartVersion: "Z", ParentChartVersion: "leonardo/Y"},
+		auth.GenerateUser(suite.T(), suite.db, true))
+	suite.Assert().NoError(err)
+	suite.Assert().True(created)
+	suite.Assert().Equal(chartVersionY.ID, chartVersionZ.ParentChartVersionInfo.ID)
+
+	// Suppose we've got Leonardo staging the earliest version and dev on the latest
+	_, err = suite.ChangesetController.PlanAndApply(ChangesetPlanRequest{
+		ChartReleases: []ChangesetPlanRequestChartReleaseEntry{
+			{CreatableChangeset: CreatableChangeset{ChartRelease: "leonardo-terra-staging",
+				ToAppVersionExact: testutils.PointerTo("A"), ToAppVersionResolver: testutils.PointerTo("exact"),
+				ToChartVersionExact: testutils.PointerTo("X"), ToChartVersionResolver: testutils.PointerTo("exact")}},
+			{CreatableChangeset: CreatableChangeset{ChartRelease: "leonardo-terra-dev",
+				ToAppVersionExact: testutils.PointerTo("D"), ToAppVersionResolver: testutils.PointerTo("exact"),
+				ToChartVersionExact: testutils.PointerTo("Z"), ToChartVersionResolver: testutils.PointerTo("exact")}},
+		}}, auth.GenerateUser(suite.T(), suite.db, true))
+	suite.Assert().NoError(err)
+
+	// Also suppose that the dev environment already has a CiIdentifier. We'll fudge the creation here:
+	terraStagingEnvironmentWithoutIdentifier, err := suite.EnvironmentController.Get("terra-staging")
+	suite.Assert().NoError(err)
+	terraStagingIdentifier, created, err := suite.CiIdentifierController.Create(
+		CreatableCiIdentifier{ResourceType: "environment", ResourceID: terraStagingEnvironmentWithoutIdentifier.ID},
+		auth.GenerateUser(suite.T(), suite.db, true))
+	suite.Assert().NoError(err)
+	suite.Assert().True(created)
+	terraStagingEnvironmentWithIdentifier, err := suite.EnvironmentController.Get("terra-staging")
+	suite.Assert().NoError(err)
+	suite.Assert().Equal(terraStagingIdentifier.ID, terraStagingEnvironmentWithIdentifier.CiIdentifier.ID)
+
+	// Now let's say that someone goes to Beehive and calculates out a changeset to deploy the dev versions to staging
+	changesets, err := suite.ChangesetController.Plan(ChangesetPlanRequest{
+		ChartReleases: []ChangesetPlanRequestChartReleaseEntry{{
+			CreatableChangeset:                    CreatableChangeset{ChartRelease: "leonardo-terra-staging"},
+			UseExactVersionsFromOtherChartRelease: testutils.PointerTo("leonardo-terra-dev"),
+		}}}, auth.GenerateUser(suite.T(), suite.db, true))
+	suite.Assert().NoError(err)
+	suite.Assert().Len(changesets, 1)
+
+	// That changeset knows the app version is going from A->B->C->D and chart version X->Y->Z
+	suite.Assert().Equal("A", *changesets[0].FromAppVersionExact)
+	suite.Assert().Equal(strconv.FormatUint(uint64(appVersionA.ID), 10), changesets[0].FromAppVersionReference)
+	suite.Assert().Len(changesets[0].NewAppVersions, 3)
+	suite.Assert().Equal("B", changesets[0].NewAppVersions[0].AppVersion)
+	suite.Assert().Equal(appVersionB.ID, changesets[0].NewAppVersions[0].ID)
+	suite.Assert().Equal("C", changesets[0].NewAppVersions[1].AppVersion)
+	suite.Assert().Equal(appVersionC.ID, changesets[0].NewAppVersions[1].ID)
+	suite.Assert().Equal("D", changesets[0].NewAppVersions[2].AppVersion)
+	suite.Assert().Equal(appVersionD.ID, changesets[0].NewAppVersions[2].ID)
+	suite.Assert().Equal("D", *changesets[0].ToAppVersionExact)
+	suite.Assert().Equal(strconv.FormatUint(uint64(appVersionD.ID), 10), changesets[0].ToAppVersionReference)
+	suite.Assert().Equal("X", *changesets[0].FromChartVersionExact)
+	suite.Assert().Equal(strconv.FormatUint(uint64(chartVersionX.ID), 10), changesets[0].FromChartVersionReference)
+	suite.Assert().Len(changesets[0].NewChartVersions, 2)
+	suite.Assert().Equal("Y", changesets[0].NewChartVersions[0].ChartVersion)
+	suite.Assert().Equal(chartVersionY.ID, changesets[0].NewChartVersions[0].ID)
+	suite.Assert().Equal("Z", changesets[0].NewChartVersions[1].ChartVersion)
+	suite.Assert().Equal(chartVersionZ.ID, changesets[0].NewChartVersions[1].ID)
+	suite.Assert().Equal("Z", *changesets[0].ToChartVersionExact)
+	suite.Assert().Equal(strconv.FormatUint(uint64(chartVersionZ.ID), 10), changesets[0].ToChartVersionReference)
+
+	// Suppose the user hits the apply button in Beehive for this changeset. First, the changeset gets applied:
+	changesets, err = suite.ChangesetController.Apply([]string{strconv.FormatUint(uint64(changesets[0].ID), 10)},
+		auth.GenerateUser(suite.T(), suite.db, true))
+	suite.Assert().NoError(err)
+	suite.Assert().Len(changesets, 1)
+	suite.NotNil(changesets[0].AppliedAt)
+
+	// Next, a GitHub Action gets started to sync ArgoCD. A GitHub webhook will probably hit Sherlock notifying it
+	// of the GitHub Action existing before it is even running:
+	ciRunData := CiRunDataFields{
+		Platform:                   "github-actions",
+		GithubActionsOwner:         "broadinstitute",
+		GithubActionsRepo:          "terra-github-workflows",
+		GithubActionsRunID:         1234,
+		GithubActionsAttemptNumber: 1,
+		GithubActionsWorkflowPath:  ".github/workflows/sync-release.yaml",
+	}
+	ciRunSelector := fmt.Sprintf("github-actions/%s/%s/%d/%d", ciRunData.GithubActionsOwner, ciRunData.GithubActionsRepo, ciRunData.GithubActionsRunID, ciRunData.GithubActionsAttemptNumber)
+
+	payload := CreatableCiRun{
+		CiRunDataFields: ciRunData,
+		EditableCiRun:   EditableCiRun{CiRunStatusFields: CiRunStatusFields{Status: testutils.PointerTo("requested")}},
+	}
+	ciRun, created, err := suite.CiRunController.Upsert(
+		ciRunSelector,
+		payload,
+		payload.EditableCiRun,
+		auth.GenerateUser(suite.T(), suite.db, false))
+	suite.Assert().NoError(err)
+	suite.Assert().True(created)
+	suite.Assert().Equal("requested", *ciRun.Status)
+	testutils.AssertNoDiff(suite.T(), ciRunData, ciRun.CiRunDataFields)
+
+	// When the action starts running, suppose there's another webhook changing the status
+	payload = CreatableCiRun{
+		CiRunDataFields: ciRunData,
+		EditableCiRun:   EditableCiRun{CiRunStatusFields: CiRunStatusFields{Status: testutils.PointerTo("running")}},
+	}
+	ciRun, created, err = suite.CiRunController.Upsert(
+		ciRunSelector,
+		payload,
+		payload.EditableCiRun,
+		auth.GenerateUser(suite.T(), suite.db, false),
+	)
+	suite.Assert().NoError(err)
+	suite.Assert().False(created)
+	suite.Assert().Equal("running", *ciRun.Status)
+	testutils.AssertNoDiff(suite.T(), ciRunData, ciRun.CiRunDataFields)
+
+	// Here's the key: something in the workflow tells Sherlock that it is running against that particular changeset.
+	payload = CreatableCiRun{
+		CiRunDataFields: ciRunData,
+		EditableCiRun:   EditableCiRun{Changesets: []string{strconv.FormatUint(uint64(changesets[0].ID), 10)}},
+	}
+	ciRun, created, err = suite.CiRunController.Upsert(
+		ciRunSelector,
+		payload,
+		payload.EditableCiRun,
+		auth.GenerateUser(suite.T(), suite.db, false),
+	)
+	suite.Assert().NoError(err)
+	suite.Assert().False(created)
+	suite.Assert().Equal("running", *ciRun.Status)
+	testutils.AssertNoDiff(suite.T(), ciRunData, ciRun.CiRunDataFields)
+
+	// Sherlock just did a *ton*: the CiRun is now associated to *nine* different resources.
+	suite.Assert().Len(ciRun.RelatedResources, 9)
+
+	// Let's quickly count those different resource types:
+	var changesetCount, appVersionCount, chartVersionCount, chartReleaseCount, environmentCount, clusterCount int
+	for _, ciIdentifier := range ciRun.RelatedResources {
+		switch ciIdentifier.ResourceType {
+		case "changeset":
+			changesetCount++
+		case "app-version":
+			appVersionCount++
+		case "chart-version":
+			chartVersionCount++
+		case "chart-release":
+			chartReleaseCount++
+		case "environment":
+			environmentCount++
+		case "cluster":
+			clusterCount++
+		}
+	}
+	suite.Assert().Equal(changesetCount, 1)
+	suite.Assert().Equal(appVersionCount, 3)
+	suite.Assert().Equal(chartVersionCount, 2)
+	suite.Assert().Equal(chartReleaseCount, 1)
+	suite.Assert().Equal(environmentCount, 1)
+	suite.Assert().Equal(clusterCount, 1)
+
+	// From those counts we can see that Sherlock has marked this CI run as affecting the changeset, all the new app
+	// and chart versions, the chart release, and the chart release's environment/cluster.
+	// You might recall that we already made a CiIdentifier for the terra-staging environment. We can see that's
+	// correctly referenced:
+	for _, ciIdentifier := range ciRun.RelatedResources {
+		if ciIdentifier.ResourceType == "environment" {
+			suite.Assert().Equal(terraStagingIdentifier.ID, ciIdentifier.ID)
+		}
+	}
+
+	// If we get that identifier again, we'll see the CI run on it:
+	terraStagingIdentifier, err = suite.CiIdentifierController.Get(strconv.FormatUint(uint64(terraStagingIdentifier.ID), 10))
+	suite.Assert().NoError(err)
+	suite.Assert().Len(terraStagingIdentifier.CiRuns, 1)
+	suite.Assert().Equal(ciRun.ID, terraStagingIdentifier.CiRuns[0].ID)
+
+	// For all the other resources, the just-in-time CI identifier creation kicked in. For example, those new Y and Z
+	// chart versions both now have CI identifiers.
+	chartVersionY, err = suite.ChartVersionController.Get("leonardo/Y")
+	suite.Assert().NoError(err)
+	suite.Assert().NotNil(chartVersionY.CiIdentifier)
+	chartVersionZ, err = suite.ChartVersionController.Get("leonardo/Z")
+	suite.Assert().NoError(err)
+	suite.Assert().NotNil(chartVersionZ.CiIdentifier)
+
+	// Those just-in-time CI identifiers reference the CI run too, again if we query them directly:
+	chartVersionYIdentifier, err := suite.CiIdentifierController.Get(strconv.FormatUint(uint64(chartVersionY.CiIdentifier.ID), 10))
+	suite.Assert().NoError(err)
+	suite.Assert().Len(chartVersionYIdentifier.CiRuns, 1)
+	suite.Assert().Equal(ciRun.ID, chartVersionYIdentifier.CiRuns[0].ID)
+	chartVersionZIdentifier, err := suite.CiIdentifierController.Get("chart-version/leonardo/Z")
+	suite.Assert().NoError(err)
+	suite.Assert().Len(chartVersionZIdentifier.CiRuns, 1)
+	suite.Assert().Equal(ciRun.ID, chartVersionZIdentifier.CiRuns[0].ID)
+
+	// To wrap up, suppose a webhook tells Sherlock that the run succeeded:
+	payload = CreatableCiRun{
+		CiRunDataFields: ciRunData,
+		EditableCiRun: EditableCiRun{CiRunStatusFields: CiRunStatusFields{
+			Status:     testutils.PointerTo("succeeded"),
+			TerminalAt: testutils.PointerTo(time.Now()),
+		}},
+	}
+	ciRun, created, err = suite.CiRunController.Upsert(
+		ciRunSelector,
+		payload,
+		payload.EditableCiRun,
+		auth.GenerateUser(suite.T(), suite.db, false),
+	)
+	suite.Assert().NoError(err)
+	suite.Assert().False(created)
+	suite.Assert().Equal("succeeded", *ciRun.Status)
+	suite.Assert().NotNil(ciRun.TerminalAt)
+	testutils.AssertNoDiff(suite.T(), ciRunData, ciRun.CiRunDataFields)
+
+	// The CI run when accessed through another resource will say it's succeeded:
+	chartVersionZIdentifier, err = suite.CiIdentifierController.Get("chart-version/leonardo/Z")
+	suite.Assert().NoError(err)
+	suite.Assert().Len(chartVersionZIdentifier.CiRuns, 1)
+	suite.Assert().Equal(ciRun.ID, chartVersionZIdentifier.CiRuns[0].ID)
+	suite.Assert().Equal("succeeded", *chartVersionZIdentifier.CiRuns[0].Status)
+}

--- a/internal/controllers/v2controllers/cluster.go
+++ b/internal/controllers/v2controllers/cluster.go
@@ -10,6 +10,7 @@ import (
 //	@description	The full set of Cluster fields that can be read or used for filtering queries
 type Cluster struct {
 	ReadableBaseType
+	CiIdentifier *CiIdentifier `json:"ciIdentifier,omitempty" form:"-"`
 	CreatableCluster
 }
 
@@ -86,6 +87,7 @@ func modelClusterToCluster(model *v2models.Cluster) *Cluster {
 			CreatedAt: model.CreatedAt,
 			UpdatedAt: model.UpdatedAt,
 		},
+		CiIdentifier: modelCiIdentifierToCiIdentifier(model.CiIdentifier),
 		CreatableCluster: CreatableCluster{
 			Name:              model.Name,
 			Provider:          model.Provider,

--- a/internal/controllers/v2controllers/controller_set.go
+++ b/internal/controllers/v2controllers/controller_set.go
@@ -13,6 +13,8 @@ type ControllerSet struct {
 	PagerdutyIntegrationController *PagerdutyIntegrationController
 	DatabaseInstanceController     *DatabaseInstanceController
 	UserController                 *UserController
+	CiIdentifierController         *CiIdentifierController
+	CiRunController                *CiRunController
 }
 
 func NewControllerSet(stores *v2models.StoreSet) *ControllerSet {
@@ -27,5 +29,7 @@ func NewControllerSet(stores *v2models.StoreSet) *ControllerSet {
 		PagerdutyIntegrationController: newPagerdutyIntegrationController(stores),
 		DatabaseInstanceController:     newDatabaseInstanceController(stores),
 		UserController:                 newUserController(stores),
+		CiIdentifierController:         newCiIdentifierController(stores),
+		CiRunController:                newCiRunController(stores),
 	}
 }

--- a/internal/controllers/v2controllers/environment.go
+++ b/internal/controllers/v2controllers/environment.go
@@ -19,6 +19,7 @@ import (
 
 type Environment struct {
 	ReadableBaseType
+	CiIdentifier             *CiIdentifier         `json:"ciIdentifier,omitempty" form:"-"`
 	TemplateEnvironmentInfo  *Environment          `json:"templateEnvironmentInfo,omitempty" swaggertype:"object" form:"-"` // Single-layer recursive; provides info of the template environment if this environment has one
 	DefaultClusterInfo       *Cluster              `json:"defaultClusterInfo,omitempty" form:"-"`
 	PagerdutyIntegrationInfo *PagerdutyIntegration `json:"pagerdutyIntegrationInfo,omitempty" form:"-"`
@@ -202,6 +203,7 @@ func modelEnvironmentToEnvironment(model *v2models.Environment) *Environment {
 			CreatedAt: model.CreatedAt,
 			UpdatedAt: model.UpdatedAt,
 		},
+		CiIdentifier:             modelCiIdentifierToCiIdentifier(model.CiIdentifier),
 		TemplateEnvironmentInfo:  templateEnvironment,
 		DefaultClusterInfo:       defaultCluster,
 		PagerdutyIntegrationInfo: pagerdutyIntegration,

--- a/internal/db/connect.go
+++ b/internal/db/connect.go
@@ -34,6 +34,8 @@ var (
 		&v1models.Deploy{},
 	}
 	v2ModelHierarchy = []any{
+		&v2models.CiIdentifier{},
+		&v2models.CiRun{},
 		&v2models.User{},
 		&v2models.PagerdutyIntegration{},
 		&v2models.Cluster{},

--- a/internal/handlers/v2handlers/ci_identifier.go
+++ b/internal/handlers/v2handlers/ci_identifier.go
@@ -1,0 +1,106 @@
+package v2handlers
+
+import (
+	"github.com/broadinstitute/sherlock/internal/controllers/v2controllers"
+	"github.com/gin-gonic/gin"
+)
+
+func RegisterCiIdentifierHandlers(routerGroup *gin.RouterGroup, controller *v2controllers.CiIdentifierController) {
+	routerGroup.POST("/ci-identifiers", createCiIdentifier(controller))
+	routerGroup.GET("/ci-identifiers", listCiIdentifier(controller))
+	routerGroup.GET("/ci-identifiers/*selector", getCiIdentifier(controller))
+	routerGroup.PATCH("/ci-identifiers/*selector", editCiIdentifier(controller))
+	routerGroup.PUT("/ci-identifiers/*selector", upsertCiIdentifier(controller))
+	routerGroup.GET("/selectors/ci-identifiers/*selector", listCiIdentifierSelectors(controller))
+}
+
+// createCiIdentifier godoc
+//
+//	@summary		Create a new CiIdentifier entry
+//	@description	Create a new CiIdentifier entry. Note that some fields are immutable after creation; /edit lists mutable fields.
+//	@tags			CiIdentifiers
+//	@accept			json
+//	@produce		json
+//	@param			ci-identifier			body		v2controllers.CreatableCiIdentifier	true	"The CiIdentifier to create"
+//	@success		200,201					{object}	v2controllers.CiIdentifier
+//	@failure		400,403,404,407,409,500	{object}	errors.ErrorResponse
+//	@router			/api/v2/ci-identifiers [post]
+func createCiIdentifier(controller *v2controllers.CiIdentifierController) func(ctx *gin.Context) {
+	return handleCreate(controller)
+}
+
+// listCiIdentifier godoc
+//
+//	@summary		List CiIdentifier entries
+//	@description	List existing CiIdentifier entries, ordered by most recently updated.
+//	@tags			CiIdentifiers
+//	@produce		json
+//	@param			filter					query		v2controllers.CiIdentifier	false	"Optional filters to apply to the returned entries"
+//	@param			limit					query		int							false	"An optional limit to the number of entries returned"
+//	@success		200						{array}		v2controllers.CiIdentifier
+//	@failure		400,403,404,407,409,500	{object}	errors.ErrorResponse
+//	@router			/api/v2/ci-identifiers [get]
+func listCiIdentifier(controller *v2controllers.CiIdentifierController) func(ctx *gin.Context) {
+	return handleList(controller)
+}
+
+// getCiIdentifier godoc
+//
+//	@summary		Get a CiIdentifier entry
+//	@description	Get an existing CiIdentifier entry via one of its "selectors": ID or type + '/' + selector of the referenced type.
+//	@tags			CiIdentifiers
+//	@produce		json
+//	@param			selector				path		string	true	"The CiIdentifier to get's selector: ID or type + '/' + selector of the referenced type"
+//	@success		200						{object}	v2controllers.CiIdentifier
+//	@failure		400,403,404,407,409,500	{object}	errors.ErrorResponse
+//	@router			/api/v2/ci-identifiers/{selector} [get]
+func getCiIdentifier(controller *v2controllers.CiIdentifierController) func(ctx *gin.Context) {
+	return handleGet(controller)
+}
+
+// editCiIdentifier godoc
+//
+//	@summary		Edit a CiIdentifier entry
+//	@description	Edit an existing CiIdentifier entry via one of its "selectors": ID or type + '/' + selector of the referenced type. Note that only mutable fields are available here, immutable fields can only be set using /create.
+//	@tags			CiIdentifiers
+//	@accept			json
+//	@produce		json
+//	@param			selector				path		string								true	"The CiIdentifier to edit's selector: ID or type + '/' + selector of the referenced type"
+//	@param			ci-identifier			body		v2controllers.EditableCiIdentifier	true	"The edits to make to the CiIdentifier"
+//	@success		200						{object}	v2controllers.CiIdentifier
+//	@failure		400,403,404,407,409,500	{object}	errors.ErrorResponse
+//	@router			/api/v2/ci-identifiers/{selector} [patch]
+func editCiIdentifier(controller *v2controllers.CiIdentifierController) func(ctx *gin.Context) {
+	return handleEdit(controller)
+}
+
+// upsertCiIdentifier godoc
+//
+//	@summary		Create or edit a CiIdentifier entry
+//	@description	Create or edit a CiIdentifier entry. Attempts to edit and will attempt to create upon an error.
+//	@description	If an edit was made or the creation process de-duplicates, this method will return normally with a 200.
+//	@tags			CiIdentifiers
+//	@accept			json
+//	@produce		json
+//	@param			selector				path		string								true	"The CiIdentifier to upsert's selector: ID or type + '/' + selector of the referenced type"
+//	@param			ci-identifier			body		v2controllers.CreatableCiIdentifier	true	"The CiIdentifier to upsert"
+//	@success		200,201					{object}	v2controllers.CiIdentifier
+//	@failure		400,403,404,407,409,500	{object}	errors.ErrorResponse
+//	@router			/api/v2/ci-identifiers/{selector} [put]
+func upsertCiIdentifier(controller *v2controllers.CiIdentifierController) func(ctx *gin.Context) {
+	return handleUpsert(controller)
+}
+
+// listCiIdentifierSelectors godoc
+//
+//	@summary		List CiIdentifier selectors
+//	@description	Validate a given CiIdentifier selector and provide any other selectors that would match the same CiIdentifier.
+//	@tags			CiIdentifiers
+//	@produce		json
+//	@param			selector				path		string	true	"The selector of the CiIdentifier to list other selectors for"
+//	@success		200						{array}		string
+//	@failure		400,403,404,407,409,500	{object}	errors.ErrorResponse
+//	@router			/api/v2/selectors/ci-identifiers/{selector} [get]
+func listCiIdentifierSelectors(controller *v2controllers.CiIdentifierController) func(ctx *gin.Context) {
+	return handleSelectorList(controller)
+}

--- a/internal/handlers/v2handlers/ci_run.go
+++ b/internal/handlers/v2handlers/ci_run.go
@@ -1,0 +1,121 @@
+package v2handlers
+
+import (
+	"github.com/broadinstitute/sherlock/internal/controllers/v2controllers"
+	"github.com/gin-gonic/gin"
+)
+
+func RegisterCiRunHandlers(routerGroup *gin.RouterGroup, controller *v2controllers.CiRunController) {
+	routerGroup.POST("/ci-runs", createCiRun(controller))
+	routerGroup.GET("/ci-runs", listCiRun(controller))
+	routerGroup.GET("/ci-runs/*selector", getCiRun(controller))
+	routerGroup.PATCH("/ci-runs/*selector", editCiRun(controller))
+	routerGroup.PUT("/ci-runs/*selector", upsertCiRun(controller))
+	routerGroup.DELETE("/ci-runs/*selector", deleteCiRun(controller))
+	routerGroup.GET("/selectors/ci-runs/*selector", listCiRunSelectors(controller))
+}
+
+// createCiRun godoc
+//
+//	@summary		Create a new CiRun entry
+//	@description	Create a new CiRun entry. Note that some fields are immutable after creation; /edit lists mutable fields.
+//	@tags			CiRuns
+//	@accept			json
+//	@produce		json
+//	@param			ci-run					body		v2controllers.CreatableCiRun	true	"The CiRun to create"
+//	@success		200,201					{object}	v2controllers.CiRun
+//	@failure		400,403,404,407,409,500	{object}	errors.ErrorResponse
+//	@router			/api/v2/ci-runs [post]
+func createCiRun(controller *v2controllers.CiRunController) func(ctx *gin.Context) {
+	return handleCreate(controller)
+}
+
+// listCiRun godoc
+//
+//	@summary		List CiRun entries
+//	@description	List existing CiRun entries, ordered by most recently updated.
+//	@tags			CiRuns
+//	@produce		json
+//	@param			filter					query		v2controllers.CiRun	false	"Optional filters to apply to the returned entries"
+//	@param			limit					query		int					false	"An optional limit to the number of entries returned"
+//	@success		200						{array}		v2controllers.CiRun
+//	@failure		400,403,404,407,409,500	{object}	errors.ErrorResponse
+//	@router			/api/v2/ci-runs [get]
+func listCiRun(controller *v2controllers.CiRunController) func(ctx *gin.Context) {
+	return handleList(controller)
+}
+
+// getCiRun godoc
+//
+//	@summary		Get a CiRun entry
+//	@description	Get an existing CiRun entry via one of its "selectors": ID, 'github-actions/' + owner + repo + run ID + attempt number, or 'argo-workflows/' + namespace + name.
+//	@tags			CiRuns
+//	@produce		json
+//	@param			selector				path		string	true	"The CiRun to get's selector: ID, 'github-actions/' + owner + repo + run ID + attempt number, or 'argo-workflows/' + namespace + name"
+//	@success		200						{object}	v2controllers.CiRun
+//	@failure		400,403,404,407,409,500	{object}	errors.ErrorResponse
+//	@router			/api/v2/ci-runs/{selector} [get]
+func getCiRun(controller *v2controllers.CiRunController) func(ctx *gin.Context) {
+	return handleGet(controller)
+}
+
+// editCiRun godoc
+//
+//	@summary		Edit a CiRun entry
+//	@description	Edit an existing CiRun entry via one of its "selectors": ID, 'github-actions/' + owner + repo + run ID + attempt number, or 'argo-workflows/' + namespace + name. Note that only mutable fields are available here, immutable fields can only be set using /create.
+//	@tags			CiRuns
+//	@accept			json
+//	@produce		json
+//	@param			selector				path		string						true	"The CiRun to edit's selector: ID, 'github-actions/' + owner + repo + run ID + attempt number, or 'argo-workflows/' + namespace + name"
+//	@param			ci-run					body		v2controllers.EditableCiRun	true	"The edits to make to the CiRun"
+//	@success		200						{object}	v2controllers.CiRun
+//	@failure		400,403,404,407,409,500	{object}	errors.ErrorResponse
+//	@router			/api/v2/ci-runs/{selector} [patch]
+func editCiRun(controller *v2controllers.CiRunController) func(ctx *gin.Context) {
+	return handleEdit(controller)
+}
+
+// upsertCiRun godoc
+//
+//	@summary		Create or edit a CiRun entry
+//	@description	Create or edit a CiRun entry. Attempts to edit and will attempt to create upon an error.
+//	@description	If an edit was made or the creation process de-duplicates, this method will return normally with a 200.
+//	@tags			CiRuns
+//	@accept			json
+//	@produce		json
+//	@param			selector				path		string							true	"The CiRun to upsert's selector: ID, 'github-actions/' + owner + repo + run ID + attempt number, or 'argo-workflows/' + namespace + name"
+//	@param			ci-run					body		v2controllers.CreatableCiRun	true	"The CiRun to upsert"
+//	@success		200,201					{object}	v2controllers.CiRun
+//	@failure		400,403,404,407,409,500	{object}	errors.ErrorResponse
+//	@router			/api/v2/ci-runs/{selector} [put]
+func upsertCiRun(controller *v2controllers.CiRunController) func(ctx *gin.Context) {
+	return handleUpsert(controller)
+}
+
+// deleteCiRun godoc
+//
+//	@summary		Delete a CiRun entry
+//	@description	Delete an existing CiRun entry via one of its "selectors": ID, 'github-actions/' + owner + repo + run ID + attempt number, or 'argo-workflows/' + namespace + name.
+//	@tags			CiRuns
+//	@produce		json
+//	@param			selector				path		string	true	"The CiRun to delete's selector: ID, 'github-actions/' + owner + repo + run ID + attempt number, or 'argo-workflows/' + namespace + name"
+//	@success		200						{object}	v2controllers.CiRun
+//	@failure		400,403,404,407,409,500	{object}	errors.ErrorResponse
+//	@router			/api/v2/ci-runs/{selector} [delete]
+func deleteCiRun(controller *v2controllers.CiRunController) func(ctx *gin.Context) {
+	return handleDelete(controller)
+}
+
+// listCiRunSelectors godoc
+//
+//	@summary		List CiRun selectors
+//	@description	Validate a given CiRun selector and provide any other selectors that would match the same CiRun.
+//	@tags			CiRuns
+//	@produce		json
+//	@param			selector				path		string	true	"The selector of the CiRun to list other selectors for"
+//	@success		200						{array}		string
+//	@failure		400,403,404,407,409,500	{object}	errors.ErrorResponse
+//	@router			/api/v2/selectors/ci-runs/{selector} [get]
+func listCiRunSelectors(controller *v2controllers.CiRunController) func(ctx *gin.Context) {
+	return handleSelectorList(controller)
+}

--- a/internal/models/v2models/app_version_test.go
+++ b/internal/models/v2models/app_version_test.go
@@ -3,6 +3,7 @@ package v2models
 import (
 	"github.com/broadinstitute/sherlock/internal/testutils"
 	"gorm.io/gorm"
+	"reflect"
 	"testing"
 )
 
@@ -251,6 +252,73 @@ func Test_rejectDuplicateAppVersion(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if err := rejectDuplicateAppVersion(tt.args.existing, tt.args.new); (err != nil) != tt.wantErr {
 				t.Errorf("rejectDuplicateAppVersion() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestAppVersion_GetCiIdentifier(t *testing.T) {
+	type fields struct {
+		Model              gorm.Model
+		CiIdentifier       *CiIdentifier
+		Chart              *Chart
+		ChartID            uint
+		AppVersion         string
+		GitCommit          string
+		GitBranch          string
+		Description        string
+		ParentAppVersion   *AppVersion
+		ParentAppVersionID *uint
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   *CiIdentifier
+	}{
+		{
+			name: "returns existing",
+			fields: fields{
+				CiIdentifier: &CiIdentifier{
+					Model: gorm.Model{
+						ID: 123,
+					},
+				},
+			},
+			want: &CiIdentifier{
+				Model: gorm.Model{
+					ID: 123,
+				},
+			},
+		},
+		{
+			name: "returns generated if no existing",
+			fields: fields{
+				Model: gorm.Model{
+					ID: 123,
+				},
+			},
+			want: &CiIdentifier{
+				ResourceType: "app-version",
+				ResourceID:   123,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := AppVersion{
+				Model:              tt.fields.Model,
+				CiIdentifier:       tt.fields.CiIdentifier,
+				Chart:              tt.fields.Chart,
+				ChartID:            tt.fields.ChartID,
+				AppVersion:         tt.fields.AppVersion,
+				GitCommit:          tt.fields.GitCommit,
+				GitBranch:          tt.fields.GitBranch,
+				Description:        tt.fields.Description,
+				ParentAppVersion:   tt.fields.ParentAppVersion,
+				ParentAppVersionID: tt.fields.ParentAppVersionID,
+			}
+			if got := a.GetCiIdentifier(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetCiIdentifier() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/internal/models/v2models/changeset.go
+++ b/internal/models/v2models/changeset.go
@@ -17,6 +17,7 @@ import (
 
 type Changeset struct {
 	gorm.Model
+	CiIdentifier   *CiIdentifier `gorm:"polymorphic:Resource; polymorphicValue:changeset"`
 	ChartRelease   *ChartRelease
 	ChartReleaseID uint
 
@@ -34,6 +35,14 @@ func (c Changeset) TableName() string {
 
 func (c Changeset) getID() uint {
 	return c.ID
+}
+
+func (c Changeset) GetCiIdentifier() *CiIdentifier {
+	if c.CiIdentifier != nil {
+		return c.CiIdentifier
+	} else {
+		return &CiIdentifier{ResourceType: "changeset", ResourceID: c.ID}
+	}
 }
 
 type internalChangesetStore struct {

--- a/internal/models/v2models/changeset_test.go
+++ b/internal/models/v2models/changeset_test.go
@@ -1,6 +1,7 @@
 package v2models
 
 import (
+	"reflect"
 	"testing"
 	"time"
 
@@ -319,6 +320,73 @@ func Test_validateChangeset(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if err := validateChangeset(tt.args.changeset); (err != nil) != tt.wantErr {
 				t.Errorf("validateChangeset() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestChangeset_GetCiIdentifier(t *testing.T) {
+	type fields struct {
+		Model            gorm.Model
+		CiIdentifier     *CiIdentifier
+		ChartRelease     *ChartRelease
+		ChartReleaseID   uint
+		From             ChartReleaseVersion
+		To               ChartReleaseVersion
+		AppliedAt        *time.Time
+		SupersededAt     *time.Time
+		NewAppVersions   []*AppVersion
+		NewChartVersions []*ChartVersion
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   *CiIdentifier
+	}{
+		{
+			name: "returns existing",
+			fields: fields{
+				CiIdentifier: &CiIdentifier{
+					Model: gorm.Model{
+						ID: 123,
+					},
+				},
+			},
+			want: &CiIdentifier{
+				Model: gorm.Model{
+					ID: 123,
+				},
+			},
+		},
+		{
+			name: "returns generated if no existing",
+			fields: fields{
+				Model: gorm.Model{
+					ID: 123,
+				},
+			},
+			want: &CiIdentifier{
+				ResourceType: "changeset",
+				ResourceID:   123,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := Changeset{
+				Model:            tt.fields.Model,
+				CiIdentifier:     tt.fields.CiIdentifier,
+				ChartRelease:     tt.fields.ChartRelease,
+				ChartReleaseID:   tt.fields.ChartReleaseID,
+				From:             tt.fields.From,
+				To:               tt.fields.To,
+				AppliedAt:        tt.fields.AppliedAt,
+				SupersededAt:     tt.fields.SupersededAt,
+				NewAppVersions:   tt.fields.NewAppVersions,
+				NewChartVersions: tt.fields.NewChartVersions,
+			}
+			if got := c.GetCiIdentifier(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetCiIdentifier() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/internal/models/v2models/chart.go
+++ b/internal/models/v2models/chart.go
@@ -11,7 +11,8 @@ import (
 
 type Chart struct {
 	gorm.Model
-	Name string `gorm:"not null; default:null; unique"`
+	CiIdentifier *CiIdentifier `gorm:"polymorphic:Resource; polymorphicValue:chart"`
+	Name         string        `gorm:"not null; default:null; unique"`
 	// Mutable
 	ChartRepo             *string `gorm:"not null; default:null"`
 	AppImageGitRepo       *string
@@ -31,6 +32,14 @@ func (c Chart) TableName() string {
 
 func (c Chart) getID() uint {
 	return c.ID
+}
+
+func (c Chart) GetCiIdentifier() *CiIdentifier {
+	if c.CiIdentifier != nil {
+		return c.CiIdentifier
+	} else {
+		return &CiIdentifier{ResourceType: "chart", ResourceID: c.ID}
+	}
 }
 
 var chartStore *internalModelStore[Chart]

--- a/internal/models/v2models/chart_release_test.go
+++ b/internal/models/v2models/chart_release_test.go
@@ -1,6 +1,7 @@
 package v2models
 
 import (
+	"reflect"
 	"testing"
 	"time"
 
@@ -648,6 +649,89 @@ func Test_validateChartRelease(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if err := validateChartRelease(tt.args.chartRelease); (err != nil) != tt.wantErr {
 				t.Errorf("validateChartRelease() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestChartRelease_GetCiIdentifier(t *testing.T) {
+	type fields struct {
+		Model                   gorm.Model
+		CiIdentifier            *CiIdentifier
+		Chart                   *Chart
+		ChartID                 uint
+		Cluster                 *Cluster
+		ClusterID               *uint
+		DestinationType         string
+		Environment             *Environment
+		EnvironmentID           *uint
+		Name                    string
+		Namespace               string
+		ChartReleaseVersion     ChartReleaseVersion
+		Subdomain               *string
+		Protocol                *string
+		Port                    *uint
+		PagerdutyIntegration    *PagerdutyIntegration
+		PagerdutyIntegrationID  *uint
+		IncludeInBulkChangesets *bool
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   *CiIdentifier
+	}{
+		{
+			name: "returns existing",
+			fields: fields{
+				CiIdentifier: &CiIdentifier{
+					Model: gorm.Model{
+						ID: 123,
+					},
+				},
+			},
+			want: &CiIdentifier{
+				Model: gorm.Model{
+					ID: 123,
+				},
+			},
+		},
+		{
+			name: "returns generated if no existing",
+			fields: fields{
+				Model: gorm.Model{
+					ID: 123,
+				},
+			},
+			want: &CiIdentifier{
+				ResourceType: "chart-release",
+				ResourceID:   123,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := ChartRelease{
+				Model:                   tt.fields.Model,
+				CiIdentifier:            tt.fields.CiIdentifier,
+				Chart:                   tt.fields.Chart,
+				ChartID:                 tt.fields.ChartID,
+				Cluster:                 tt.fields.Cluster,
+				ClusterID:               tt.fields.ClusterID,
+				DestinationType:         tt.fields.DestinationType,
+				Environment:             tt.fields.Environment,
+				EnvironmentID:           tt.fields.EnvironmentID,
+				Name:                    tt.fields.Name,
+				Namespace:               tt.fields.Namespace,
+				ChartReleaseVersion:     tt.fields.ChartReleaseVersion,
+				Subdomain:               tt.fields.Subdomain,
+				Protocol:                tt.fields.Protocol,
+				Port:                    tt.fields.Port,
+				PagerdutyIntegration:    tt.fields.PagerdutyIntegration,
+				PagerdutyIntegrationID:  tt.fields.PagerdutyIntegrationID,
+				IncludeInBulkChangesets: tt.fields.IncludeInBulkChangesets,
+			}
+			if got := c.GetCiIdentifier(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetCiIdentifier() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/internal/models/v2models/chart_test.go
+++ b/internal/models/v2models/chart_test.go
@@ -1,6 +1,7 @@
 package v2models
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/broadinstitute/sherlock/internal/testutils"
@@ -161,6 +162,79 @@ func Test_validateChart(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if err := validateChart(tt.args.chart); (err != nil) != tt.wantErr {
 				t.Errorf("validateChart() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestChart_GetCiIdentifier(t *testing.T) {
+	type fields struct {
+		Model                 gorm.Model
+		CiIdentifier          *CiIdentifier
+		Name                  string
+		ChartRepo             *string
+		AppImageGitRepo       *string
+		AppImageGitMainBranch *string
+		ChartExposesEndpoint  *bool
+		DefaultSubdomain      *string
+		DefaultProtocol       *string
+		DefaultPort           *uint
+		LegacyConfigsEnabled  *bool
+		Description           *string
+		PlaybookURL           *string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   *CiIdentifier
+	}{
+		{
+			name: "returns existing",
+			fields: fields{
+				CiIdentifier: &CiIdentifier{
+					Model: gorm.Model{
+						ID: 123,
+					},
+				},
+			},
+			want: &CiIdentifier{
+				Model: gorm.Model{
+					ID: 123,
+				},
+			},
+		},
+		{
+			name: "returns generated if no existing",
+			fields: fields{
+				Model: gorm.Model{
+					ID: 123,
+				},
+			},
+			want: &CiIdentifier{
+				ResourceType: "chart",
+				ResourceID:   123,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := Chart{
+				Model:                 tt.fields.Model,
+				CiIdentifier:          tt.fields.CiIdentifier,
+				Name:                  tt.fields.Name,
+				ChartRepo:             tt.fields.ChartRepo,
+				AppImageGitRepo:       tt.fields.AppImageGitRepo,
+				AppImageGitMainBranch: tt.fields.AppImageGitMainBranch,
+				ChartExposesEndpoint:  tt.fields.ChartExposesEndpoint,
+				DefaultSubdomain:      tt.fields.DefaultSubdomain,
+				DefaultProtocol:       tt.fields.DefaultProtocol,
+				DefaultPort:           tt.fields.DefaultPort,
+				LegacyConfigsEnabled:  tt.fields.LegacyConfigsEnabled,
+				Description:           tt.fields.Description,
+				PlaybookURL:           tt.fields.PlaybookURL,
+			}
+			if got := c.GetCiIdentifier(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetCiIdentifier() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/internal/models/v2models/chart_version_test.go
+++ b/internal/models/v2models/chart_version_test.go
@@ -3,6 +3,7 @@ package v2models
 import (
 	"github.com/broadinstitute/sherlock/internal/testutils"
 	"gorm.io/gorm"
+	"reflect"
 	"testing"
 )
 
@@ -203,6 +204,69 @@ func Test_rejectDuplicateChartVersion(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if err := rejectDuplicateChartVersion(tt.args.existing, tt.args.new); (err != nil) != tt.wantErr {
 				t.Errorf("rejectDuplicateChartVersion() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestChartVersion_GetCiIdentifier(t *testing.T) {
+	type fields struct {
+		Model                gorm.Model
+		CiIdentifier         *CiIdentifier
+		Chart                *Chart
+		ChartID              uint
+		ChartVersion         string
+		Description          string
+		ParentChartVersion   *ChartVersion
+		ParentChartVersionID *uint
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   *CiIdentifier
+	}{
+		{
+			name: "returns existing",
+			fields: fields{
+				CiIdentifier: &CiIdentifier{
+					Model: gorm.Model{
+						ID: 123,
+					},
+				},
+			},
+			want: &CiIdentifier{
+				Model: gorm.Model{
+					ID: 123,
+				},
+			},
+		},
+		{
+			name: "returns generated if no existing",
+			fields: fields{
+				Model: gorm.Model{
+					ID: 123,
+				},
+			},
+			want: &CiIdentifier{
+				ResourceType: "chart-version",
+				ResourceID:   123,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := ChartVersion{
+				Model:                tt.fields.Model,
+				CiIdentifier:         tt.fields.CiIdentifier,
+				Chart:                tt.fields.Chart,
+				ChartID:              tt.fields.ChartID,
+				ChartVersion:         tt.fields.ChartVersion,
+				Description:          tt.fields.Description,
+				ParentChartVersion:   tt.fields.ParentChartVersion,
+				ParentChartVersionID: tt.fields.ParentChartVersionID,
+			}
+			if got := c.GetCiIdentifier(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetCiIdentifier() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/internal/models/v2models/ci_identifier.go
+++ b/internal/models/v2models/ci_identifier.go
@@ -1,0 +1,157 @@
+package v2models
+
+import (
+	"fmt"
+	"github.com/broadinstitute/sherlock/internal/auth/auth_models"
+	"github.com/broadinstitute/sherlock/internal/errors"
+	"github.com/broadinstitute/sherlock/internal/models/model_actions"
+	"github.com/broadinstitute/sherlock/internal/utils"
+	"gorm.io/gorm"
+	"strconv"
+	"strings"
+)
+
+// CiIdentifiable is an interface to help align functionality across other types that can have a CiIdentifier.
+type CiIdentifiable interface {
+	// GetCiIdentifier should return either a type's loaded CiIdentifier or a generated one based on resource type and
+	// resource ID. It's important for the caller to understand that this function can return things not in the
+	// database yet.
+	//
+	// In reality, this function is meant to go hand-in-hand with createCiRunIdentifiersJustInTime. This function will
+	// return CiIdentifier instances that may or may not exist, and that function will create them all before the
+	// CiRun actually enters the database. If there's a breakdown in communication, it's actually fine for superfluous
+	// creates to be attempted -- rejectDuplicateCiIdentifier will make it so that the creates will behave just like
+	// gets.
+	GetCiIdentifier() *CiIdentifier
+}
+
+type CiIdentifier struct {
+	gorm.Model
+	ResourceType string `gorm:"index:idx_v2_ci_identifiers_polymorphic_index,priority:1"`
+	ResourceID   uint   `gorm:"index:idx_v2_ci_identifiers_polymorphic_index,priority:2"`
+	// Mutable
+	CiRuns []*CiRun `gorm:"many2many:v2_ci_runs_for_identifiers; constraint:OnDelete:CASCADE,OnUpdate:CASCADE;"`
+}
+
+func (c CiIdentifier) TableName() string {
+	return "v2_ci_identifiers"
+}
+
+func (c CiIdentifier) getID() uint {
+	return c.ID
+}
+
+var ciIdentifierStore *internalModelStore[CiIdentifier]
+
+func init() {
+	ciIdentifierStore = &internalModelStore[CiIdentifier]{
+		selectorToQueryModel:    ciIdentifierSelectorToQuery,
+		modelToSelectors:        ciIdentifierToSelectors,
+		errorIfForbidden:        ciIdentifierErrorIfForbidden,
+		validateModel:           validateCiIdentifier,
+		handleIncomingDuplicate: rejectDuplicateCiIdentifier,
+		editsAppendManyToMany: map[string]func(edits *CiIdentifier) any{
+			"CiRuns": func(edits *CiIdentifier) any { return edits.CiRuns },
+		},
+	}
+}
+
+func ciIdentifierSelectorToQuery(db *gorm.DB, selector string) (CiIdentifier, error) {
+	if len(selector) == 0 {
+		return CiIdentifier{}, fmt.Errorf("(%s) CI identifier selector cannot be empty", errors.BadRequest)
+	}
+	var query CiIdentifier
+	if utils.IsNumeric(selector) {
+		// ID
+		id, err := strconv.Atoi(selector)
+		if err != nil {
+			return CiIdentifier{}, fmt.Errorf("(%s) string to int conversion error of '%s': %v", errors.BadRequest, selector, err)
+		}
+		query.ID = uint(id)
+		return query, nil
+	} else if strings.Count(selector, "/") > 0 {
+		// resource type + type's selector ...
+		parts := strings.Split(selector, "/")
+		query.ResourceType = parts[0]
+		resourceSelector := strings.Join(parts[1:], "/")
+		var resolver selectorResolver
+		switch query.ResourceType {
+		case "chart":
+			resolver = chartStore
+		case "chart-version":
+			resolver = chartVersionStore
+		case "app-version":
+			resolver = appVersionStore
+		case "cluster":
+			resolver = clusterStore
+		case "environment":
+			resolver = environmentStore
+		case "chart-release":
+			resolver = chartReleaseStore
+		case "changeset":
+			resolver = changesetStore
+		default:
+			return CiIdentifier{}, fmt.Errorf("(%s) invalid CI identifier selector '%s', resource type sub-selector '%s' wasn't recognized", errors.BadRequest, selector, query.ResourceType)
+		}
+		id, err := resolver.resolveSelector(db, resourceSelector)
+		if err != nil {
+			return CiIdentifier{}, fmt.Errorf("invalid CI identifier selector '%s', resource sub-selector '%s' had an error: %v", selector, resourceSelector, err)
+		}
+		query.ResourceID = id
+		return query, nil
+	}
+	return CiIdentifier{}, fmt.Errorf("(%s) invalid CI identifier selector '%s'", errors.BadRequest, selector)
+}
+
+func ciIdentifierToSelectors(ciIdentifier *CiIdentifier) []string {
+	var selectors []string
+	if ciIdentifier != nil {
+		if ciIdentifier.ID != 0 {
+			selectors = append(selectors, strconv.FormatUint(uint64(ciIdentifier.ID), 10))
+		}
+		if ciIdentifier.ResourceType != "" && ciIdentifier.ResourceID != 0 {
+			selectors = append(selectors, fmt.Sprintf("%s/%d", ciIdentifier.ResourceType, ciIdentifier.ResourceID))
+		}
+	}
+	return selectors
+}
+
+func ciIdentifierErrorIfForbidden(_ *gorm.DB, ciIdentifier *CiIdentifier, actionType model_actions.ActionType, _ *auth_models.User) error {
+	if actionType == model_actions.DELETE {
+		return fmt.Errorf("(%s) deleting a %T is not allowed", errors.Forbidden, ciIdentifier)
+	} else {
+		return nil
+	}
+}
+
+func validateCiIdentifier(ciIdentifier *CiIdentifier) error {
+	if ciIdentifier == nil {
+		return fmt.Errorf("the model passed was nil")
+	}
+	if ciIdentifier.ResourceType == "" {
+		return fmt.Errorf("a %T must have a resource type", ciIdentifier)
+	}
+	if ciIdentifier.ResourceID == 0 {
+		return fmt.Errorf("a %T must have a resource ID", ciIdentifier)
+	}
+	return nil
+}
+
+func rejectDuplicateCiIdentifier(existing *CiIdentifier, new *CiIdentifier) error {
+	if existing.ResourceType != new.ResourceType {
+		return fmt.Errorf("%T resource type mismatch during upsert attempt, new was %s but existing was %s", new, new.ResourceType, existing.ResourceType)
+	}
+	if existing.ResourceID != new.ResourceID {
+		return fmt.Errorf("%T resource ID mismatch during upsert attempt, new was %d but existing was %d", new, new.ResourceID, existing.ResourceID)
+	}
+	if new.CiRuns != nil && len(new.CiRuns) > 0 {
+		// We care about this because if this function *doesn't* error, the new CiIdentifier actually gets thrown out
+		// and the existing one is returned as what was created. If the new CiIdentifier has CiRuns that the existing
+		// one doesn't, we'd be returning a 200 while having forgotten about those CiRuns. We could potentially build
+		// fancy handling here to determine if the new CiRuns list is a subset of the existing one, but I can't think
+		// of how a client would ever even make realistic use of that behavior. For now, we just say that the new
+		// CiIdentifier specifying any CiRuns at all is potentially unsafe and we bail out.
+		return fmt.Errorf("%d new CiRuns would be lost during upsert attempt on %T", len(new.CiRuns), new)
+	}
+	return nil
+}

--- a/internal/models/v2models/ci_identifier_test.go
+++ b/internal/models/v2models/ci_identifier_test.go
@@ -1,0 +1,277 @@
+package v2models
+
+import (
+	"github.com/broadinstitute/sherlock/internal/auth/auth_models"
+	"github.com/broadinstitute/sherlock/internal/models/model_actions"
+	"github.com/broadinstitute/sherlock/internal/testutils"
+	"gorm.io/gorm"
+	"testing"
+)
+
+func Test_ciIdentifierSelectorToQuery(t *testing.T) {
+	type args struct {
+		db       *gorm.DB
+		selector string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    CiIdentifier
+		wantErr bool
+	}{
+		{
+			name:    "empty",
+			args:    args{selector: ""},
+			wantErr: true,
+		},
+		{
+			name:    "invalid",
+			args:    args{selector: "something obviously invalid!"},
+			wantErr: true,
+		},
+		{
+			name: "valid id",
+			args: args{selector: "123"},
+			want: CiIdentifier{Model: gorm.Model{ID: 123}},
+		},
+		{
+			name:    "invalid id",
+			args:    args{selector: testutils.StringNumberTooBigForInt},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ciIdentifierSelectorToQuery(tt.args.db, tt.args.selector)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ciIdentifierSelectorToQuery() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			testutils.AssertNoDiff(t, tt.want, got)
+		})
+	}
+}
+
+func Test_ciIdentifierToSelectors(t *testing.T) {
+	type args struct {
+		ciIdentifier *CiIdentifier
+	}
+	tests := []struct {
+		name string
+		args args
+		want []string
+	}{
+		{
+			name: "nil",
+			want: nil,
+		},
+		{
+			name: "none",
+			args: args{ciIdentifier: &CiIdentifier{}},
+			want: nil,
+		},
+		{
+			name: "id",
+			args: args{ciIdentifier: &CiIdentifier{Model: gorm.Model{ID: 123}}},
+			want: []string{"123"},
+		},
+		{
+			name: "resource type + resource id",
+			args: args{ciIdentifier: &CiIdentifier{ResourceType: "type", ResourceID: 456}},
+			want: []string{"type/456"},
+		},
+		{
+			name: "id, resource type + resource id",
+			args: args{ciIdentifier: &CiIdentifier{
+				Model:        gorm.Model{ID: 123},
+				ResourceType: "type", ResourceID: 456,
+			}},
+			want: []string{"123", "type/456"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ciIdentifierToSelectors(tt.args.ciIdentifier)
+			testutils.AssertNoDiff(t, tt.want, got)
+		})
+	}
+}
+
+func Test_rejectDuplicateCiIdentifier(t *testing.T) {
+	type args struct {
+		existing *CiIdentifier
+		new      *CiIdentifier
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "valid",
+			args: args{
+				existing: &CiIdentifier{
+					ResourceType: "a",
+					ResourceID:   123,
+				},
+				new: &CiIdentifier{
+					ResourceType: "a",
+					ResourceID:   123,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "mismatched type",
+			args: args{
+				existing: &CiIdentifier{
+					ResourceType: "a",
+					ResourceID:   123,
+				},
+				new: &CiIdentifier{
+					ResourceType: "b",
+					ResourceID:   123,
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "mismatched id",
+			args: args{
+				existing: &CiIdentifier{
+					ResourceType: "a",
+					ResourceID:   123,
+				},
+				new: &CiIdentifier{
+					ResourceType: "a",
+					ResourceID:   124,
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "runs in new are invalid",
+			args: args{
+				existing: &CiIdentifier{
+					ResourceType: "a",
+					ResourceID:   123,
+				},
+				new: &CiIdentifier{
+					ResourceType: "a",
+					ResourceID:   123,
+					CiRuns: []*CiRun{
+						{},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "runs in existing are okay",
+			args: args{
+				existing: &CiIdentifier{
+					ResourceType: "a",
+					ResourceID:   123,
+					CiRuns: []*CiRun{
+						{},
+					},
+				},
+				new: &CiIdentifier{
+					ResourceType: "a",
+					ResourceID:   123,
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := rejectDuplicateCiIdentifier(tt.args.existing, tt.args.new); (err != nil) != tt.wantErr {
+				t.Errorf("rejectDuplicateCiIdentifier() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func Test_validateCiIdentifier(t *testing.T) {
+	type args struct {
+		ciIdentifier *CiIdentifier
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name:    "nil",
+			args:    args{ciIdentifier: nil},
+			wantErr: true,
+		},
+		{
+			name: "no resource type",
+			args: args{ciIdentifier: &CiIdentifier{
+				ResourceID: 123,
+			}},
+			wantErr: true,
+		},
+		{
+			name: "no resource ID",
+			args: args{ciIdentifier: &CiIdentifier{
+				ResourceType: "type",
+			}},
+			wantErr: true,
+		},
+		{
+			name: "valid",
+			args: args{ciIdentifier: &CiIdentifier{
+				ResourceID:   123,
+				ResourceType: "type",
+			}},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := validateCiIdentifier(tt.args.ciIdentifier); (err != nil) != tt.wantErr {
+				t.Errorf("validateCiIdentifier() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func Test_ciIdentifierErrorIfForbidden(t *testing.T) {
+	type args struct {
+		db           *gorm.DB
+		ciIdentifier *CiIdentifier
+		actionType   model_actions.ActionType
+		user         *auth_models.User
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name:    "valid if create",
+			args:    args{ciIdentifier: &CiIdentifier{}, actionType: model_actions.CREATE},
+			wantErr: false,
+		},
+		{
+			name:    "valid if edit",
+			args:    args{ciIdentifier: &CiIdentifier{}, actionType: model_actions.EDIT},
+			wantErr: false,
+		},
+		{
+			name:    "invalid if delete",
+			args:    args{ciIdentifier: &CiIdentifier{}, actionType: model_actions.DELETE},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := ciIdentifierErrorIfForbidden(tt.args.db, tt.args.ciIdentifier, tt.args.actionType, tt.args.user); (err != nil) != tt.wantErr {
+				t.Errorf("ciIdentifierErrorIfForbidden() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/models/v2models/ci_run.go
+++ b/internal/models/v2models/ci_run.go
@@ -1,0 +1,199 @@
+package v2models
+
+import (
+	"fmt"
+	"github.com/broadinstitute/sherlock/internal/auth/auth_models"
+	"github.com/broadinstitute/sherlock/internal/errors"
+	"github.com/broadinstitute/sherlock/internal/utils"
+	"github.com/rs/zerolog/log"
+	"gorm.io/gorm"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type CiRun struct {
+	gorm.Model
+	Platform                   string
+	GithubActionsOwner         string
+	GithubActionsRepo          string
+	GithubActionsRunID         uint
+	GithubActionsAttemptNumber uint
+	GithubActionsWorkflowPath  string
+	ArgoWorkflowsNamespace     string
+	ArgoWorkflowsName          string
+	ArgoWorkflowsTemplate      string
+	// Mutable
+	RelatedResources []*CiIdentifier `gorm:"many2many:v2_ci_runs_for_identifiers; constraint:OnDelete:CASCADE,OnUpdate:CASCADE;"`
+	TerminalAt       *time.Time
+	Status           *string
+}
+
+func (c CiRun) TableName() string {
+	return "v2_ci_runs"
+}
+
+func (c CiRun) getID() uint {
+	return c.ID
+}
+
+var ciRunStore *internalModelStore[CiRun]
+
+func init() {
+	ciRunStore = &internalModelStore[CiRun]{
+		selectorToQueryModel: ciRunSelectorToQuery,
+		modelToSelectors:     ciRunToSelectors,
+		validateModel:        validateCiRun,
+		preCreate:            preCreateCiRun,
+		preEdit:              preEditCiRun,
+		editsAppendManyToMany: map[string]func(edits *CiRun) any{
+			"RelatedResources": func(edits *CiRun) any { return edits.RelatedResources },
+		},
+	}
+}
+
+func ciRunSelectorToQuery(_ *gorm.DB, selector string) (CiRun, error) {
+	if len(selector) == 0 {
+		return CiRun{}, fmt.Errorf("(%s) CI run selector cannot be empty", errors.BadRequest)
+	}
+	var query CiRun
+	if utils.IsNumeric(selector) {
+		// ID
+		id, err := strconv.Atoi(selector)
+		if err != nil {
+			return CiRun{}, fmt.Errorf("(%s) string to int conversion error of '%s': %v", errors.BadRequest, selector, err)
+		}
+		query.ID = uint(id)
+		return query, nil
+	} else if strings.HasPrefix(selector, "github-actions/") && strings.Count(selector, "/") == 4 {
+		// "github-actions" + owner + repo + run ID + attempt number
+		parts := strings.Split(selector, "/")
+
+		owner := parts[1]
+		if owner == "" {
+			return CiRun{}, fmt.Errorf("(%s) invalid CI run selector %s, owner sub-selector was empty", errors.BadRequest, selector)
+		}
+
+		repo := parts[2]
+		if repo == "" {
+			return CiRun{}, fmt.Errorf("(%s) invalid CI run selector %s, repo sub-selector was empty", errors.BadRequest, selector)
+		}
+
+		runID, err := strconv.Atoi(parts[3])
+		if err != nil {
+			return CiRun{}, fmt.Errorf("(%s) invalid CI run selector %s, run ID sub-selector '%s' had string to int conversion error: %v", errors.BadRequest, selector, parts[3], err)
+		}
+
+		attemptNumber, err := strconv.Atoi(parts[4])
+		if err != nil {
+			return CiRun{}, fmt.Errorf("(%s) invalid CI run selector %s, attempt number sub-selector '%s' had string to int conversion error: %v", errors.BadRequest, selector, parts[3], err)
+		}
+
+		query.Platform = "github-actions"
+		query.GithubActionsOwner = owner
+		query.GithubActionsRepo = repo
+		query.GithubActionsRunID = uint(runID)
+		query.GithubActionsAttemptNumber = uint(attemptNumber)
+		return query, nil
+	} else if strings.HasPrefix(selector, "argo-workflows/") && strings.Count(selector, "/") == 2 {
+		// "argo-workflows" + namespace + name
+		parts := strings.Split(selector, "/")
+
+		namespace := parts[1]
+		if namespace == "" {
+			return CiRun{}, fmt.Errorf("(%s) invalid CI run selector %s, namespace sub-selector was empty", errors.BadRequest, selector)
+		}
+
+		name := parts[2]
+		if name == "" {
+			return CiRun{}, fmt.Errorf("(%s) invalid CI run selector %s, name sub-selector was empty", errors.BadRequest, selector)
+		}
+
+		query.Platform = "argo-workflows"
+		query.ArgoWorkflowsNamespace = namespace
+		query.ArgoWorkflowsName = name
+		return query, nil
+	}
+	return CiRun{}, fmt.Errorf("(%s) invalid CI run selector '%s'", errors.BadRequest, selector)
+}
+
+func ciRunToSelectors(ciRun *CiRun) []string {
+	var selectors []string
+	if ciRun != nil {
+		if ciRun.ID != 0 {
+			selectors = append(selectors, strconv.FormatUint(uint64(ciRun.ID), 10))
+		}
+		switch ciRun.Platform {
+		case "github-actions":
+			if ciRun.GithubActionsOwner != "" && ciRun.GithubActionsRepo != "" && ciRun.GithubActionsRunID != 0 {
+				selectors = append(selectors, fmt.Sprintf("github-actions/%s/%s/%d/%d", ciRun.GithubActionsOwner, ciRun.GithubActionsRepo, ciRun.GithubActionsRunID, ciRun.GithubActionsAttemptNumber))
+			}
+		case "argo-workflows":
+			if ciRun.ArgoWorkflowsNamespace != "" && ciRun.ArgoWorkflowsName != "" {
+				selectors = append(selectors, fmt.Sprintf("argo-workflows/%s/%s", ciRun.ArgoWorkflowsNamespace, ciRun.ArgoWorkflowsName))
+			}
+		}
+	}
+	return selectors
+}
+
+func validateCiRun(ciRun *CiRun) error {
+	if ciRun == nil {
+		return fmt.Errorf("the model passed was nil")
+	}
+
+	switch ciRun.Platform {
+	case "github-actions":
+		if ciRun.GithubActionsOwner == "" || ciRun.GithubActionsRepo == "" || ciRun.GithubActionsRunID == 0 || ciRun.GithubActionsAttemptNumber == 0 || ciRun.GithubActionsWorkflowPath == "" {
+			return fmt.Errorf("a github-actions %T must have githubActions data", ciRun)
+		}
+		if ciRun.ArgoWorkflowsNamespace != "" || ciRun.ArgoWorkflowsName != "" || ciRun.ArgoWorkflowsTemplate != "" {
+			return fmt.Errorf("a github-actions %T must not have argoWorkflows data", ciRun)
+		}
+	case "argo-workflows":
+		if ciRun.ArgoWorkflowsNamespace == "" || ciRun.ArgoWorkflowsName == "" || ciRun.ArgoWorkflowsTemplate == "" {
+			return fmt.Errorf("a argo-workflows %T must have argoWorkflows data", ciRun)
+		}
+		if ciRun.GithubActionsOwner != "" || ciRun.GithubActionsRepo != "" || ciRun.GithubActionsRunID != 0 || ciRun.GithubActionsAttemptNumber != 0 || ciRun.GithubActionsWorkflowPath != "" {
+			return fmt.Errorf("a argo-workflows %T must not have githubActions data", ciRun)
+		}
+	default:
+		return fmt.Errorf("a %T must have a platform of either github-actions or argo-workflows", ciRun)
+	}
+
+	if ciRun.TerminalAt != nil && ciRun.Status == nil {
+		return fmt.Errorf("a terminal %T must have a status", ciRun)
+	}
+	return nil
+}
+
+func preCreateCiRun(db *gorm.DB, toCreate *CiRun, user *auth_models.User) error {
+	return createCiRunIdentifiersJustInTime(db, toCreate, user)
+}
+
+func preEditCiRun(db *gorm.DB, _ *CiRun, editsToMake *CiRun, user *auth_models.User) error {
+	return createCiRunIdentifiersJustInTime(db, editsToMake, user)
+}
+
+func createCiRunIdentifiersJustInTime(db *gorm.DB, ciRun *CiRun, user *auth_models.User) error {
+	if ciRun.RelatedResources != nil {
+		for idx, ciIdentifier := range ciRun.RelatedResources {
+			if ciIdentifier != nil && ciIdentifier.ID == 0 {
+				// We do gate this whole block on the CiIdentifier not having an ID (meaning it probably doesn't really
+				// exist yet), but even if it does, our create here should still be safe. CiIdentifier handles duplicates
+				// so that it won't complain, it'll just return the existing match in the database.
+				result, created, err := ciIdentifierStore.create(db, *ciIdentifier, user)
+				if err != nil {
+					return fmt.Errorf("failed to create %T just-in-time for %s ID %d", ciIdentifier, ciIdentifier.ResourceType, ciIdentifier.ResourceID)
+				}
+				if created {
+					log.Info().Msgf("DB   | successfully created CI identifier just-in-time: %s/%d", ciIdentifier.ResourceType, ciIdentifier.ResourceID)
+				}
+				// Now we replace the ciIdentifier in the list with what we either created from the database or what
+				// existing thing we got out of the database.
+				ciRun.RelatedResources[idx] = &result
+			}
+		}
+	}
+	return nil
+}

--- a/internal/models/v2models/ci_run_test.go
+++ b/internal/models/v2models/ci_run_test.go
@@ -1,0 +1,468 @@
+package v2models
+
+import (
+	"fmt"
+	"github.com/broadinstitute/sherlock/internal/testutils"
+	"gorm.io/gorm"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func Test_ciRunSelectorToQuery(t *testing.T) {
+	type args struct {
+		db       *gorm.DB
+		selector string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    CiRun
+		wantErr bool
+	}{
+		{
+			name:    "empty",
+			args:    args{selector: ""},
+			wantErr: true,
+		},
+		{
+			name:    "invalid",
+			args:    args{selector: "something obviously invalid!"},
+			wantErr: true,
+		},
+		{
+			name: "valid id",
+			args: args{selector: "123"},
+			want: CiRun{Model: gorm.Model{ID: 123}},
+		},
+		{
+			name:    "invalid id",
+			args:    args{selector: testutils.StringNumberTooBigForInt},
+			wantErr: true,
+		},
+		{
+			name:    "gha + empty owner",
+			args:    args{selector: "github-actions//beehive/1/1"},
+			wantErr: true,
+		},
+		{
+			name:    "gha + empty repo",
+			args:    args{selector: "github-actions/broadinstitute//1/1"},
+			wantErr: true,
+		},
+		{
+			name:    "gha + bad run id",
+			args:    args{selector: fmt.Sprintf("github-actions/broadinstitute/beehive/%s/1", testutils.StringNumberTooBigForInt)},
+			wantErr: true,
+		},
+		{
+			name:    "gha + bad attempt number",
+			args:    args{selector: fmt.Sprintf("github-actions/broadinstitute/beehive/1/%s", testutils.StringNumberTooBigForInt)},
+			wantErr: true,
+		},
+		{
+			name: "valid gha",
+			args: args{selector: "github-actions/broadinstitute/beehive/2/1"},
+			want: CiRun{
+				Platform:                   "github-actions",
+				GithubActionsOwner:         "broadinstitute",
+				GithubActionsRepo:          "beehive",
+				GithubActionsRunID:         2,
+				GithubActionsAttemptNumber: 1,
+			},
+		},
+		{
+			name:    "argo + empty namespace",
+			args:    args{selector: "argo-workflows//name"},
+			wantErr: true,
+		},
+		{
+			name:    "argo + empty name",
+			args:    args{selector: "argo-workflows/namespace/"},
+			wantErr: true,
+		},
+		{
+			name: "valid argo",
+			args: args{selector: "argo-workflows/namespace/name"},
+			want: CiRun{
+				Platform:               "argo-workflows",
+				ArgoWorkflowsNamespace: "namespace",
+				ArgoWorkflowsName:      "name",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ciRunSelectorToQuery(tt.args.db, tt.args.selector)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ciRunSelectorToQuery() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ciRunSelectorToQuery() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_ciRunToSelectors(t *testing.T) {
+	type args struct {
+		ciRun *CiRun
+	}
+	tests := []struct {
+		name string
+		args args
+		want []string
+	}{
+		{
+			name: "nil",
+			args: args{ciRun: nil},
+			want: nil,
+		},
+		{
+			name: "none",
+			args: args{ciRun: &CiRun{}},
+			want: nil,
+		},
+		{
+			name: "id",
+			args: args{ciRun: &CiRun{
+				Model: gorm.Model{ID: 1},
+			}},
+			want: []string{"1"},
+		},
+		{
+			name: "gha",
+			args: args{ciRun: &CiRun{
+				Platform:                   "github-actions",
+				GithubActionsOwner:         "broadinstitute",
+				GithubActionsRepo:          "beehive",
+				GithubActionsRunID:         123,
+				GithubActionsAttemptNumber: 1,
+			}},
+			want: []string{"github-actions/broadinstitute/beehive/123/1"},
+		},
+		{
+			name: "argo",
+			args: args{ciRun: &CiRun{
+				Platform:               "argo-workflows",
+				ArgoWorkflowsNamespace: "namespace",
+				ArgoWorkflowsName:      "name",
+			}},
+			want: []string{"argo-workflows/namespace/name"},
+		},
+		{
+			name: "id + gha",
+			args: args{ciRun: &CiRun{
+				Model:                      gorm.Model{ID: 1},
+				Platform:                   "github-actions",
+				GithubActionsOwner:         "broadinstitute",
+				GithubActionsRepo:          "beehive",
+				GithubActionsRunID:         123,
+				GithubActionsAttemptNumber: 1,
+			}},
+			want: []string{"1", "github-actions/broadinstitute/beehive/123/1"},
+		},
+		{
+			name: "id + argo",
+			args: args{ciRun: &CiRun{
+				Model:                  gorm.Model{ID: 1},
+				Platform:               "argo-workflows",
+				ArgoWorkflowsNamespace: "namespace",
+				ArgoWorkflowsName:      "name",
+			}},
+			want: []string{"1", "argo-workflows/namespace/name"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ciRunToSelectors(tt.args.ciRun); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ciRunToSelectors() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_validateCiRun(t *testing.T) {
+	type args struct {
+		ciRun *CiRun
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name:    "nil",
+			args:    args{ciRun: nil},
+			wantErr: true,
+		},
+		{
+			name:    "empty",
+			args:    args{ciRun: &CiRun{}},
+			wantErr: true,
+		},
+		{
+			name: "invalid platform",
+			args: args{ciRun: &CiRun{
+				Platform: "foobar",
+			}},
+			wantErr: true,
+		},
+		{
+			name: "valid GHA",
+			args: args{ciRun: &CiRun{
+				Platform:                   "github-actions",
+				GithubActionsOwner:         "broadinstitute",
+				GithubActionsRepo:          "beehive",
+				GithubActionsRunID:         123,
+				GithubActionsAttemptNumber: 1,
+				GithubActionsWorkflowPath:  ".github/workflows/build.yaml",
+			}},
+			wantErr: false,
+		},
+		{
+			name: "GHA missing owner",
+			args: args{ciRun: &CiRun{
+				Platform:                   "github-actions",
+				GithubActionsRepo:          "beehive",
+				GithubActionsRunID:         123,
+				GithubActionsAttemptNumber: 1,
+				GithubActionsWorkflowPath:  ".github/workflows/build.yaml",
+			}},
+			wantErr: true,
+		},
+		{
+			name: "GHA missing repo",
+			args: args{ciRun: &CiRun{
+				Platform:                   "github-actions",
+				GithubActionsOwner:         "broadinstitute",
+				GithubActionsRunID:         123,
+				GithubActionsAttemptNumber: 1,
+				GithubActionsWorkflowPath:  ".github/workflows/build.yaml",
+			}},
+			wantErr: true,
+		},
+		{
+			name: "GHA missing run ID",
+			args: args{ciRun: &CiRun{
+				Platform:                   "github-actions",
+				GithubActionsOwner:         "broadinstitute",
+				GithubActionsRepo:          "beehive",
+				GithubActionsAttemptNumber: 1,
+				GithubActionsWorkflowPath:  ".github/workflows/build.yaml",
+			}},
+			wantErr: true,
+		},
+		{
+			name: "GHA missing attempt number",
+			args: args{ciRun: &CiRun{
+				Platform:                  "github-actions",
+				GithubActionsOwner:        "broadinstitute",
+				GithubActionsRepo:         "beehive",
+				GithubActionsRunID:        123,
+				GithubActionsWorkflowPath: ".github/workflows/build.yaml",
+			}},
+			wantErr: true,
+		},
+		{
+			name: "GHA missing workflow path",
+			args: args{ciRun: &CiRun{
+				Platform:                   "github-actions",
+				GithubActionsOwner:         "broadinstitute",
+				GithubActionsRepo:          "beehive",
+				GithubActionsRunID:         123,
+				GithubActionsAttemptNumber: 1,
+			}},
+			wantErr: true,
+		},
+		{
+			name: "GHA with argo namespace",
+			args: args{ciRun: &CiRun{
+				Platform:                   "github-actions",
+				GithubActionsOwner:         "broadinstitute",
+				GithubActionsRepo:          "beehive",
+				GithubActionsRunID:         123,
+				GithubActionsAttemptNumber: 1,
+				GithubActionsWorkflowPath:  ".github/workflows/build.yaml",
+				ArgoWorkflowsNamespace:     "namespace",
+			}},
+			wantErr: true,
+		},
+		{
+			name: "GHA with argo name",
+			args: args{ciRun: &CiRun{
+				Platform:                   "github-actions",
+				GithubActionsOwner:         "broadinstitute",
+				GithubActionsRepo:          "beehive",
+				GithubActionsRunID:         123,
+				GithubActionsAttemptNumber: 1,
+				GithubActionsWorkflowPath:  ".github/workflows/build.yaml",
+				ArgoWorkflowsName:          "name",
+			}},
+			wantErr: true,
+		},
+		{
+			name: "GHA with argo template",
+			args: args{ciRun: &CiRun{
+				Platform:                   "github-actions",
+				GithubActionsOwner:         "broadinstitute",
+				GithubActionsRepo:          "beehive",
+				GithubActionsRunID:         123,
+				GithubActionsAttemptNumber: 1,
+				GithubActionsWorkflowPath:  ".github/workflows/build.yaml",
+				ArgoWorkflowsTemplate:      "template",
+			}},
+			wantErr: true,
+		},
+		{
+			name: "valid argo",
+			args: args{ciRun: &CiRun{
+				Platform:               "argo-workflows",
+				ArgoWorkflowsNamespace: "namespace",
+				ArgoWorkflowsName:      "name",
+				ArgoWorkflowsTemplate:  "template",
+			}},
+			wantErr: false,
+		},
+		{
+			name: "argo missing namespace",
+			args: args{ciRun: &CiRun{
+				Platform:              "argo-workflows",
+				ArgoWorkflowsName:     "name",
+				ArgoWorkflowsTemplate: "template",
+			}},
+			wantErr: true,
+		},
+		{
+			name: "argo missing name",
+			args: args{ciRun: &CiRun{
+				Platform:               "argo-workflows",
+				ArgoWorkflowsNamespace: "namespace",
+				ArgoWorkflowsTemplate:  "template",
+			}},
+			wantErr: true,
+		},
+		{
+			name: "argo missing template",
+			args: args{ciRun: &CiRun{
+				Platform:               "argo-workflows",
+				ArgoWorkflowsNamespace: "namespace",
+				ArgoWorkflowsName:      "name",
+			}},
+			wantErr: true,
+		},
+		{
+			name: "argo with GHA owner",
+			args: args{ciRun: &CiRun{
+				Platform:               "argo-workflows",
+				ArgoWorkflowsNamespace: "namespace",
+				ArgoWorkflowsName:      "name",
+				ArgoWorkflowsTemplate:  "template",
+				GithubActionsOwner:     "broadinstitute",
+			}},
+			wantErr: true,
+		},
+		{
+			name: "argo with GHA repo",
+			args: args{ciRun: &CiRun{
+				Platform:               "argo-workflows",
+				ArgoWorkflowsNamespace: "namespace",
+				ArgoWorkflowsName:      "name",
+				ArgoWorkflowsTemplate:  "template",
+				GithubActionsRepo:      "beehive",
+			}},
+			wantErr: true,
+		},
+		{
+			name: "argo with GHA run ID",
+			args: args{ciRun: &CiRun{
+				Platform:               "argo-workflows",
+				ArgoWorkflowsNamespace: "namespace",
+				ArgoWorkflowsName:      "name",
+				ArgoWorkflowsTemplate:  "template",
+				GithubActionsRunID:     123,
+			}},
+			wantErr: true,
+		},
+		{
+			name: "argo with GHA attempt number",
+			args: args{ciRun: &CiRun{
+				Platform:                   "argo-workflows",
+				ArgoWorkflowsNamespace:     "namespace",
+				ArgoWorkflowsName:          "name",
+				ArgoWorkflowsTemplate:      "template",
+				GithubActionsAttemptNumber: 1,
+			}},
+			wantErr: true,
+		},
+		{
+			name: "argo with GHA workflow path",
+			args: args{ciRun: &CiRun{
+				Platform:                  "argo-workflows",
+				ArgoWorkflowsNamespace:    "namespace",
+				ArgoWorkflowsName:         "name",
+				ArgoWorkflowsTemplate:     "template",
+				GithubActionsWorkflowPath: ".github/workflows/build.yaml",
+			}},
+			wantErr: true,
+		},
+		{
+			name: "valid terminal GHA",
+			args: args{ciRun: &CiRun{
+				Platform:                   "github-actions",
+				GithubActionsOwner:         "broadinstitute",
+				GithubActionsRepo:          "beehive",
+				GithubActionsRunID:         123,
+				GithubActionsAttemptNumber: 1,
+				GithubActionsWorkflowPath:  ".github/workflows/build.yaml",
+				TerminalAt:                 testutils.PointerTo(time.Now()),
+				Status:                     testutils.PointerTo("failed"),
+			}},
+			wantErr: false,
+		},
+		{
+			name: "valid terminal argo",
+			args: args{ciRun: &CiRun{
+				Platform:               "argo-workflows",
+				ArgoWorkflowsNamespace: "namespace",
+				ArgoWorkflowsName:      "name",
+				ArgoWorkflowsTemplate:  "template",
+				TerminalAt:             testutils.PointerTo(time.Now()),
+				Status:                 testutils.PointerTo("failed"),
+			}},
+			wantErr: false,
+		},
+		{
+			name: "terminal GHA without status",
+			args: args{ciRun: &CiRun{
+				Platform:                   "github-actions",
+				GithubActionsOwner:         "broadinstitute",
+				GithubActionsRepo:          "beehive",
+				GithubActionsRunID:         123,
+				GithubActionsAttemptNumber: 1,
+				GithubActionsWorkflowPath:  ".github/workflows/build.yaml",
+				TerminalAt:                 testutils.PointerTo(time.Now()),
+			}},
+			wantErr: true,
+		},
+		{
+			name: "terminal argo without status",
+			args: args{ciRun: &CiRun{
+				Platform:               "argo-workflows",
+				ArgoWorkflowsNamespace: "namespace",
+				ArgoWorkflowsName:      "name",
+				ArgoWorkflowsTemplate:  "template",
+				TerminalAt:             testutils.PointerTo(time.Now()),
+			}},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := validateCiRun(tt.args.ciRun); (err != nil) != tt.wantErr {
+				t.Errorf("validateCiRun() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/models/v2models/cluster.go
+++ b/internal/models/v2models/cluster.go
@@ -13,8 +13,9 @@ import (
 
 type Cluster struct {
 	gorm.Model
-	Name              string `gorm:"not null; default:null; unique"`
-	Provider          string `gorm:"not null; default:null"`
+	CiIdentifier      *CiIdentifier `gorm:"polymorphic:Resource; polymorphicValue:cluster"`
+	Name              string        `gorm:"not null; default:null; unique"`
+	Provider          string        `gorm:"not null; default:null"`
 	GoogleProject     string
 	AzureSubscription string
 	Location          string `gorm:"not null; default:null"`
@@ -31,6 +32,14 @@ func (c Cluster) TableName() string {
 
 func (c Cluster) getID() uint {
 	return c.ID
+}
+
+func (c Cluster) GetCiIdentifier() *CiIdentifier {
+	if c.CiIdentifier != nil {
+		return c.CiIdentifier
+	} else {
+		return &CiIdentifier{ResourceType: "cluster", ResourceID: c.ID}
+	}
 }
 
 var clusterStore *internalModelStore[Cluster]

--- a/internal/models/v2models/database_instance.go
+++ b/internal/models/v2models/database_instance.go
@@ -56,15 +56,11 @@ func databaseInstanceSelectorToQuery(db *gorm.DB, selector string) (DatabaseInst
 		return query, nil
 	} else if strings.HasPrefix(selector, "chart-release/") { // "chart-release/" + chart release
 		chartReleaseSubSelector := strings.TrimPrefix(selector, "chart-release/")
-		chartReleaseQuery, err := chartReleaseSelectorToQuery(db, chartReleaseSubSelector)
-		if err != nil {
-			return DatabaseInstance{}, fmt.Errorf("invalid database instance selector %s, chart release sub-selector error: %v", selector, err)
-		}
-		chartRelease, err := chartReleaseStore.get(db, chartReleaseQuery)
+		chartReleaseID, err := chartReleaseStore.resolveSelector(db, chartReleaseSubSelector)
 		if err != nil {
 			return DatabaseInstance{}, fmt.Errorf("error handling database instance subselector %s: %v", chartReleaseSubSelector, err)
 		}
-		query.ChartReleaseID = chartRelease.ID
+		query.ChartReleaseID = chartReleaseID
 		return query, nil
 	}
 	return DatabaseInstance{}, fmt.Errorf("(%s) invalid database instance selector '%s'", errors.BadRequest, selector)

--- a/internal/models/v2models/environment.go
+++ b/internal/models/v2models/environment.go
@@ -20,6 +20,7 @@ import (
 
 type Environment struct {
 	gorm.Model
+	CiIdentifier              *CiIdentifier `gorm:"polymorphic:Resource; polymorphicValue:environment"`
 	Base                      string
 	Lifecycle                 string `gorm:"not null; default:null"`
 	Name                      string `gorm:"not null; default:null"`
@@ -60,6 +61,14 @@ func (e Environment) TableName() string {
 
 func (e Environment) getID() uint {
 	return e.ID
+}
+
+func (e Environment) GetCiIdentifier() *CiIdentifier {
+	if e.CiIdentifier != nil {
+		return e.CiIdentifier
+	} else {
+		return &CiIdentifier{ResourceType: "environment", ResourceID: e.ID}
+	}
 }
 
 var environmentStore *internalModelStore[Environment]

--- a/internal/models/v2models/environment_test.go
+++ b/internal/models/v2models/environment_test.go
@@ -3,6 +3,7 @@ package v2models
 import (
 	"fmt"
 	"github.com/broadinstitute/sherlock/internal/models/v2models/environment"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -827,6 +828,119 @@ func Test_generateUniqueResourcePrefix(t *testing.T) {
 			generateUniqueResourcePrefix(&sb, tt.input)
 			testutils.AssertNoDiff(t, tt.output, sb.String())
 			sb.Reset()
+		})
+	}
+}
+
+func TestEnvironment_GetCiIdentifier(t *testing.T) {
+	type fields struct {
+		Model                       gorm.Model
+		CiIdentifier                *CiIdentifier
+		Base                        string
+		Lifecycle                   string
+		Name                        string
+		NamePrefix                  string
+		TemplateEnvironment         *Environment
+		TemplateEnvironmentID       *uint
+		ValuesName                  string
+		AutoPopulateChartReleases   *bool
+		UniqueResourcePrefix        string
+		DefaultNamespace            string
+		DefaultCluster              *Cluster
+		DefaultClusterID            *uint
+		DefaultFirecloudDevelopRef  *string
+		Owner                       *User
+		OwnerID                     *uint
+		LegacyOwner                 *string
+		RequiresSuitability         *bool
+		BaseDomain                  *string
+		NamePrefixesDomain          *bool
+		HelmfileRef                 *string
+		PreventDeletion             *bool
+		AutoDelete                  *environment.AutoDelete
+		Description                 *string
+		PagerdutyIntegration        *PagerdutyIntegration
+		PagerdutyIntegrationID      *uint
+		Offline                     *bool
+		OfflineScheduleBeginEnabled *bool
+		OfflineScheduleBeginTime    *string
+		OfflineScheduleEndEnabled   *bool
+		OfflineScheduleEndTime      *string
+		OfflineScheduleEndWeekends  *bool
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   *CiIdentifier
+	}{
+		{
+			name: "returns existing",
+			fields: fields{
+				CiIdentifier: &CiIdentifier{
+					Model: gorm.Model{
+						ID: 123,
+					},
+				},
+			},
+			want: &CiIdentifier{
+				Model: gorm.Model{
+					ID: 123,
+				},
+			},
+		},
+		{
+			name: "returns generated if no existing",
+			fields: fields{
+				Model: gorm.Model{
+					ID: 123,
+				},
+			},
+			want: &CiIdentifier{
+				ResourceType: "environment",
+				ResourceID:   123,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := Environment{
+				Model:                       tt.fields.Model,
+				CiIdentifier:                tt.fields.CiIdentifier,
+				Base:                        tt.fields.Base,
+				Lifecycle:                   tt.fields.Lifecycle,
+				Name:                        tt.fields.Name,
+				NamePrefix:                  tt.fields.NamePrefix,
+				TemplateEnvironment:         tt.fields.TemplateEnvironment,
+				TemplateEnvironmentID:       tt.fields.TemplateEnvironmentID,
+				ValuesName:                  tt.fields.ValuesName,
+				AutoPopulateChartReleases:   tt.fields.AutoPopulateChartReleases,
+				UniqueResourcePrefix:        tt.fields.UniqueResourcePrefix,
+				DefaultNamespace:            tt.fields.DefaultNamespace,
+				DefaultCluster:              tt.fields.DefaultCluster,
+				DefaultClusterID:            tt.fields.DefaultClusterID,
+				DefaultFirecloudDevelopRef:  tt.fields.DefaultFirecloudDevelopRef,
+				Owner:                       tt.fields.Owner,
+				OwnerID:                     tt.fields.OwnerID,
+				LegacyOwner:                 tt.fields.LegacyOwner,
+				RequiresSuitability:         tt.fields.RequiresSuitability,
+				BaseDomain:                  tt.fields.BaseDomain,
+				NamePrefixesDomain:          tt.fields.NamePrefixesDomain,
+				HelmfileRef:                 tt.fields.HelmfileRef,
+				PreventDeletion:             tt.fields.PreventDeletion,
+				AutoDelete:                  tt.fields.AutoDelete,
+				Description:                 tt.fields.Description,
+				PagerdutyIntegration:        tt.fields.PagerdutyIntegration,
+				PagerdutyIntegrationID:      tt.fields.PagerdutyIntegrationID,
+				Offline:                     tt.fields.Offline,
+				OfflineScheduleBeginEnabled: tt.fields.OfflineScheduleBeginEnabled,
+				OfflineScheduleBeginTime:    tt.fields.OfflineScheduleBeginTime,
+				OfflineScheduleEndEnabled:   tt.fields.OfflineScheduleEndEnabled,
+				OfflineScheduleEndTime:      tt.fields.OfflineScheduleEndTime,
+				OfflineScheduleEndWeekends:  tt.fields.OfflineScheduleEndWeekends,
+			}
+			if got := e.GetCiIdentifier(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetCiIdentifier() = %v, want %v", got, tt.want)
+			}
 		})
 	}
 }

--- a/internal/models/v2models/pagerduty_integration.go
+++ b/internal/models/v2models/pagerduty_integration.go
@@ -44,7 +44,7 @@ func pagerdutyIntegrationSelectorToQuery(_ *gorm.DB, selector string) (Pagerduty
 		return PagerdutyIntegration{}, fmt.Errorf("(%s) pagerduty integration selector cannot be empty", errors.BadRequest)
 	}
 	var query PagerdutyIntegration
-	if utils.IsNumeric(selector) {
+	if utils.IsNumeric(selector) { // ID
 		id, err := strconv.Atoi(selector)
 		if err != nil {
 			return PagerdutyIntegration{}, fmt.Errorf("(%s) string to int conversion error of '%s': %v", errors.BadRequest, selector, err)

--- a/internal/models/v2models/store_set.go
+++ b/internal/models/v2models/store_set.go
@@ -17,6 +17,8 @@ type StoreSet struct {
 	DatabaseInstanceStore *ModelStore[DatabaseInstance]
 	UserStore             *ModelStore[User]
 	ChangesetStore        *ChangesetStore
+	CiIdentifierStore     *ModelStore[CiIdentifier]
+	CiRunStore            *ModelStore[CiRun]
 }
 
 func NewStoreSet(db *gorm.DB) *StoreSet {
@@ -41,5 +43,7 @@ func NewStoreSet(db *gorm.DB) *StoreSet {
 		ChangesetStore: &ChangesetStore{
 			ModelStore: &ModelStore[Changeset]{db: db, internalModelStore: changesetStore.internalModelStore},
 		},
+		CiIdentifierStore: &ModelStore[CiIdentifier]{db: db, internalModelStore: ciIdentifierStore},
+		CiRunStore:        &ModelStore[CiRun]{db: db, internalModelStore: ciRunStore},
 	}
 }

--- a/internal/sherlock/routes.go
+++ b/internal/sherlock/routes.go
@@ -105,6 +105,8 @@ func (a *Application) buildRouter() {
 	v2handlers.RegisterPagerdutyIntegrationHandlers(v2api, a.v2controllers.PagerdutyIntegrationController)
 	v2handlers.RegisterDatabaseInstanceHandlers(v2api, a.v2controllers.DatabaseInstanceController)
 	v2handlers.RegisterUserHandlers(v2api, a.v2controllers.UserController)
+	v2handlers.RegisterCiIdentifierHandlers(v2api, a.v2controllers.CiIdentifierController)
+	v2handlers.RegisterCiRunHandlers(v2api, a.v2controllers.CiRunController)
 
 	a.Handler = router
 }

--- a/internal/utils/set.go
+++ b/internal/utils/set.go
@@ -1,0 +1,9 @@
+package utils
+
+func MakeSet[T comparable](list []T) map[T]struct{} {
+	set := make(map[T]struct{})
+	for _, t := range list {
+		set[t] = struct{}{}
+	}
+	return set
+}


### PR DESCRIPTION
Adds CiIdentifier and CiRun types to Sherlock. Here's the database modifications.

![Screenshot 2023-05-25 at 12 48 48 PM](https://github.com/broadinstitute/sherlock/assets/29168264/b139a349-6c3d-4ed3-a5c3-60d2f7031cf3)

The trick here is we're relying on Gorm to grab the appropriate CiIdentifier when one exists for another type. When Gorm reads a v2models.Chart, for example, it'll also query the v2_ci_identifiers table for resource_type = "chart" and resource_id equal to the chart's ID. If there's a match, it'll include it in the returned v2models.Chart. I made a composite index that should help speed that up.

It _is_ possible to create a CI identifier directly, there's API methods for it. But you probably won't ever need to do that.

The CiRun data type is really what does the magic. When you create or edit a CiRun, you can include selectors of other types to associate that run to. If any of those types don't already have CiIdentifiers, _Sherlock will automatically create them just-in-time for your request to go through_.

So the write flow here is "GitHub Action runs and reports info to Sherlock. Any data types it affects will have CiIdentifiers silently created for them." Meanwhile the read flow is "Beehive gets a data type, and if it contains a CiIdentifier, Beehive knows it can query that to list out any CiRuns for that data type." (I'm using data type to mean singular instances here, like a single Chart--you get the gist).

Sherlock will get super smart with this, too. If a GitHub Action says it affects a Changeset, Sherlock is going to record it as affecting:
- that Changeset
- any new App Versions the Changeset is deploying (it's that changelog gimmick again, so it'll pick up intermediate versions)
- ditto for Chart Versions
- the Chart Release being affected
- the Environment the Chart Release is in, if there is one
- the Cluster the Chart Release is in, if there is one

I've got a test written for precisely this behavior, because that's like 90% of how we're probably gonna populate this CiIdentifier table and get stuff showing up in Beehive.

## Testing

Speaking of testing, here's [the big test](https://github.com/broadinstitute/sherlock/blob/DDO-2873-ci/internal/controllers/v2controllers/ci_run_test.go). If there's part of this that anyone's gonna look at, I think it should be this part. I think the test file is the best documentation of how everything works together.

There's also a ton of unit tests for all the validation code etc

## Risk

So the API design here was carefully done so that existing API responses don't balloon in size. There's no pagination if you load a CiIdentifier or CiRun directly, [so we may need to address that down the line](https://broadinstitute.slack.com/archives/CQ6SL4N5T/p1685025006984109), but it won't cause a regression in existing behavior if that becomes an issue. Otherwise I think the risk is pretty low--will deploy to dev before prod to make sure.