### PR TITLE
[DDO-2893] Remove image push double-writing

### DIFF
--- a/.github/workflows/sherlock-build.yaml
+++ b/.github/workflows/sherlock-build.yaml
@@ -140,7 +140,6 @@ jobs:
           # server image for backwards compatibility with old build behavior
           images: |
             ${{ env.GOOGLE_DOCKER_REPOSITORY }}/${{ env.GOOGLE_PROJECT }}/${{ env.REPOSITORY_NAME }}/${{ env.IMAGE_NAME }}
-            ${{ env.GOOGLE_DOCKER_REPOSITORY }}/${{ env.GOOGLE_PROJECT }}/${{ env.REPOSITORY_NAME }}/server
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
             type=raw,value=${{ steps.tag.outputs.new_tag }}
@@ -190,7 +189,6 @@ jobs:
         if: ${{ github.actor != 'dependabot[bot]' }}
         run: |
           docker push --all-tags ${{ env.GOOGLE_DOCKER_REPOSITORY }}/${{ env.GOOGLE_PROJECT }}/${{ env.REPOSITORY_NAME }}/${{ env.IMAGE_NAME }}
-          docker push --all-tags ${{ env.GOOGLE_DOCKER_REPOSITORY }}/${{ env.GOOGLE_PROJECT }}/${{ env.REPOSITORY_NAME }}/server
 
       - name: Commit changes
         if: ${{ github.event_name == 'push' }}


### PR DESCRIPTION
It was making both `sherlock` and `server` images before, but now that https://github.com/broadinstitute/terra-helmfile/pull/4277 is merged and deployed we don't need to do that

## Testing

https://ap-argocd.dsp-devops.broadinstitute.org/applications/sherlock-dsp-tools?resource=&node=argoproj.io%2FApplication%2Fap-argocd%2Fsherlock-dsp-tools%2F0 shows that the `sherlock` image is being used, not the `server` one

## Risk

Super low, worst case is that something gets out of date