### PR TITLE
[DDO-2903] Add a startedAt field to the CiRun schema

### DIFF
--- a/sherlock/db/migrations/000043_add_started_at.down.sql
+++ b/sherlock/db/migrations/000043_add_started_at.down.sql
@@ -1,0 +1,2 @@
+alter table v2_ci_runs
+    drop column if exists started_at;

--- a/sherlock/db/migrations/000043_add_started_at.up.sql
+++ b/sherlock/db/migrations/000043_add_started_at.up.sql
@@ -1,0 +1,2 @@
+alter table v2_ci_runs
+    add if not exists started_at timestamp with time zone;

--- a/sherlock/internal/controllers/v2controllers/ci_run.go
+++ b/sherlock/internal/controllers/v2controllers/ci_run.go
@@ -43,6 +43,7 @@ type CiRunDataFields struct {
 }
 
 type CiRunStatusFields struct {
+	StartedAt  *time.Time `json:"startedAt,omitempty" form:"startedAt"`
 	TerminalAt *time.Time `json:"terminalAt,omitempty" form:"terminalAt"`
 	Status     *string    `json:"status,omitempty" form:"status"`
 }
@@ -64,6 +65,7 @@ func (c CiRun) toModel(_ *v2models.StoreSet) (v2models.CiRun, error) {
 		ArgoWorkflowsNamespace:     c.ArgoWorkflowsNamespace,
 		ArgoWorkflowsName:          c.ArgoWorkflowsName,
 		ArgoWorkflowsTemplate:      c.ArgoWorkflowsTemplate,
+		StartedAt:                  c.StartedAt,
 		TerminalAt:                 c.TerminalAt,
 		Status:                     c.Status,
 	}, nil
@@ -154,6 +156,7 @@ func (c CreatableCiRun) toModel(storeSet *v2models.StoreSet) (v2models.CiRun, er
 		ArgoWorkflowsNamespace:     c.ArgoWorkflowsNamespace,
 		ArgoWorkflowsName:          c.ArgoWorkflowsName,
 		ArgoWorkflowsTemplate:      c.ArgoWorkflowsTemplate,
+		StartedAt:                  c.StartedAt,
 		TerminalAt:                 c.TerminalAt,
 		Status:                     c.Status,
 		RelatedResources:           relatedResources,
@@ -208,6 +211,7 @@ func modelCiRunToCiRun(model *v2models.CiRun) *CiRun {
 			ArgoWorkflowsTemplate:      model.ArgoWorkflowsTemplate,
 		},
 		CiRunStatusFields: CiRunStatusFields{
+			StartedAt:  model.StartedAt,
 			TerminalAt: model.TerminalAt,
 			Status:     model.Status,
 		},

--- a/sherlock/internal/controllers/v2controllers/ci_run_test.go
+++ b/sherlock/internal/controllers/v2controllers/ci_run_test.go
@@ -80,7 +80,10 @@ func (suite *ciRunControllerSuite) TestCiFlow() {
 	// As the CI workflow changes state, new PUTs will hit the controller
 	payload = CreatableCiRun{
 		CiRunDataFields: ciRunData,
-		EditableCiRun:   EditableCiRun{CiRunStatusFields: CiRunStatusFields{Status: testutils.PointerTo("running")}},
+		EditableCiRun: EditableCiRun{CiRunStatusFields: CiRunStatusFields{
+			StartedAt: testutils.PointerTo(time.Now()),
+			Status:    testutils.PointerTo("running")},
+		},
 	}
 	ciRun, created, err = suite.CiRunController.Upsert(
 		ciRunSelector,
@@ -90,6 +93,7 @@ func (suite *ciRunControllerSuite) TestCiFlow() {
 	)
 	suite.Assert().NoError(err)
 	suite.Assert().False(created)
+	suite.Assert().NotNil(ciRun.StartedAt)
 	suite.Assert().Equal("running", *ciRun.Status)
 	testutils.AssertNoDiff(suite.T(), ciRunData, ciRun.CiRunDataFields)
 
@@ -152,6 +156,7 @@ func (suite *ciRunControllerSuite) TestCiFlow() {
 	suite.Assert().NoError(err)
 	suite.Assert().False(created)
 	suite.Assert().Equal("succeeded", *ciRun.Status)
+	suite.Assert().NotNil(ciRun.StartedAt)
 	suite.Assert().NotNil(ciRun.TerminalAt)
 	testutils.AssertNoDiff(suite.T(), ciRunData, ciRun.CiRunDataFields)
 
@@ -329,7 +334,10 @@ func (suite *ciRunControllerSuite) TestComplexCiFlow() {
 	// When the action starts running, suppose there's another webhook changing the status
 	payload = CreatableCiRun{
 		CiRunDataFields: ciRunData,
-		EditableCiRun:   EditableCiRun{CiRunStatusFields: CiRunStatusFields{Status: testutils.PointerTo("running")}},
+		EditableCiRun: EditableCiRun{CiRunStatusFields: CiRunStatusFields{
+			StartedAt: testutils.PointerTo(time.Now()),
+			Status:    testutils.PointerTo("running")},
+		},
 	}
 	ciRun, created, err = suite.CiRunController.Upsert(
 		ciRunSelector,
@@ -339,6 +347,7 @@ func (suite *ciRunControllerSuite) TestComplexCiFlow() {
 	)
 	suite.Assert().NoError(err)
 	suite.Assert().False(created)
+	suite.Assert().NotNil(ciRun.StartedAt)
 	suite.Assert().Equal("running", *ciRun.Status)
 	testutils.AssertNoDiff(suite.T(), ciRunData, ciRun.CiRunDataFields)
 
@@ -438,6 +447,7 @@ func (suite *ciRunControllerSuite) TestComplexCiFlow() {
 	suite.Assert().NoError(err)
 	suite.Assert().False(created)
 	suite.Assert().Equal("succeeded", *ciRun.Status)
+	suite.Assert().NotNil(ciRun.StartedAt)
 	suite.Assert().NotNil(ciRun.TerminalAt)
 	testutils.AssertNoDiff(suite.T(), ciRunData, ciRun.CiRunDataFields)
 

--- a/sherlock/internal/models/v2models/ci_run.go
+++ b/sherlock/internal/models/v2models/ci_run.go
@@ -25,6 +25,7 @@ type CiRun struct {
 	ArgoWorkflowsTemplate      string
 	// Mutable
 	RelatedResources []*CiIdentifier `gorm:"many2many:v2_ci_runs_for_identifiers; constraint:OnDelete:CASCADE,OnUpdate:CASCADE;"`
+	StartedAt        *time.Time
 	TerminalAt       *time.Time
 	Status           *string
 }


### PR DESCRIPTION
There's a createdAt that I was intending to use, but that actually gets set when the workflow is queued, as opposed to when it starts running (based on how GitHub sends up webhooks). Figure I'll make space to record the actual value and make a subsequent PR once this is deployed to update the cloud function.

## Testing

Migration worked against my copy of the database, and I added tests

## Risk

Minimal IMO