### PR TITLE
[DDO-2903] Set startedAt from webhook

### DIFF
--- a/.github/workflows/sherlock-lint.yaml
+++ b/.github/workflows/sherlock-lint.yaml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        directory: ["sherlock", "go-shared"]
+        directory: ["sherlock", "go-shared", "sherlock-webhook-proxy"]
     steps:
       - uses: actions/checkout@v2
       - name: golangci-lint

--- a/sherlock-webhook-proxy/README.md
+++ b/sherlock-webhook-proxy/README.md
@@ -6,10 +6,12 @@ It receives webhooks, validates them, and turns them into IAP-authenticated call
 
 ```
 make local-up
-
-gh webhook forward --repo=broadinstitute/sherlock --events=workflow_run --url=http://localhost:8090 --secret=foo
-
+```
+```
 cd sherlock-webhook-proxy && FUNCTION_TARGET="HandleWebhook" IAP_TOKEN=$(thelma auth iap --echo) SHERLOCK_URL=http://localhost:8080 GITHUB_WEBHOOK_SECRET=foobar go run cmd/main.go
+```
+```
+gh webhook forward --repo=broadinstitute/sherlock --events=workflow_run --url=http://localhost:8090/webhook --secret=foobar
 ```
 
 You'll need to vary those commands to do things like talk to sherlock-dev or test different IAP behavior.

--- a/sherlock-webhook-proxy/pkg/handler.go
+++ b/sherlock-webhook-proxy/pkg/handler.go
@@ -188,7 +188,12 @@ func HandleWebhook(w http.ResponseWriter, r *http.Request) {
 			sherlockClient := client.New(_transport, strfmt.Default)
 
 			// Convert webhook fields into what we'll store in Sherlock
-			var status, terminalAt string
+			var startedAt, status, terminalAt string
+			if !payload.WorkflowRun.RunStartedAt.IsZero() {
+				// Seems like this field will always be present, but maybe it'll be zero if it hasn't actually started yet?
+				// Seems possible :shrug:
+				startedAt = payload.WorkflowRun.RunStartedAt.Format(time.RFC3339)
+			}
 			if payload.WorkflowRun.Conclusion != "" {
 				status = payload.WorkflowRun.Conclusion
 				terminalAt = payload.WorkflowRun.UpdatedAt.Format(time.RFC3339)
@@ -211,6 +216,7 @@ func HandleWebhook(w http.ResponseWriter, r *http.Request) {
 					GithubActionsRunID:         payload.WorkflowRun.ID,
 					GithubActionsAttemptNumber: payload.WorkflowRun.RunAttempt,
 					GithubActionsWorkflowPath:  payload.Workflow.Path,
+					StartedAt:                  startedAt,
 					TerminalAt:                 terminalAt,
 					Status:                     status,
 				},


### PR DESCRIPTION
Takes advantage of #178, just in the webhook. Also enables linting for the webhook directory.

## Testing

Deployed it and its happy. (The deploy process does some checks that it starts up and stuff, so it isn't a blind deploy)

## Risk

Minimal IMO