### PR TITLE
[DDO-2904] Expose metrics from Sherlock's CiRuns

### DIFF
--- a/sherlock/internal/metrics/v2metrics/metrics.go
+++ b/sherlock/internal/metrics/v2metrics/metrics.go
@@ -49,6 +49,14 @@ var (
 		"sherlock/v2_pagerduty_request_count",
 		"count of outgoing requests to pagerduty",
 		"requests")
+	GithubActionsCompletionCount = stats.Int64(
+		"sherlock/v2_github_actions_completion_count",
+		"count of completed GitHub Actions reported to Sherlock",
+		"workflows")
+	GithubActionsDurationCount = stats.Int64(
+		"sherlock/v2_github_actions_duration_count",
+		"count of seconds spent by GitHub Actions reported to Sherlock",
+		"seconds")
 )
 
 var (
@@ -63,6 +71,10 @@ var (
 	DataTypeKey                   = tag.MustNewKey("data_type")
 	PagerdutyRequestTypeKey       = tag.MustNewKey("pd_request_type")
 	PagerdutyResponseCodeKey      = tag.MustNewKey("pd_response_code")
+	GithubActionsRepoKey          = tag.MustNewKey("github_repo")
+	GithubActionsWorkflowFileKey  = tag.MustNewKey("workflow_file")
+	GithubActionsAttemptNumberKey = tag.MustNewKey("attempt_number")
+	GithubActionsOutcomeKey       = tag.MustNewKey("outcome")
 
 	ChangesetCountView = &view.View{
 		Name:        "v2_changeset_count",
@@ -127,6 +139,20 @@ var (
 		Description: EnvironmentStateCountMeasure.Description(),
 		Aggregation: view.LastValue(),
 	}
+	GithubActionsCompletionCountView = &view.View{
+		Name:        "v2_github_actions_completion_count",
+		Measure:     GithubActionsCompletionCount,
+		TagKeys:     []tag.Key{GithubActionsRepoKey, GithubActionsWorkflowFileKey, GithubActionsAttemptNumberKey, GithubActionsOutcomeKey},
+		Description: GithubActionsCompletionCount.Description(),
+		Aggregation: view.Count(),
+	}
+	GithubActionsDurationCountView = &view.View{
+		Name:        "v2_github_actions_duration_count",
+		Measure:     GithubActionsDurationCount,
+		TagKeys:     []tag.Key{GithubActionsRepoKey, GithubActionsWorkflowFileKey, GithubActionsAttemptNumberKey, GithubActionsOutcomeKey},
+		Description: GithubActionsDurationCount.Description(),
+		Aggregation: view.Count(),
+	}
 )
 
 func RegisterViews() error {
@@ -140,5 +166,7 @@ func RegisterViews() error {
 		DataTypeCountView,
 		PagerdutyRequestCountView,
 		EnvironmentStateCountView,
+		GithubActionsCompletionCountView,
+		GithubActionsDurationCountView,
 	)
 }

--- a/sherlock/internal/metrics/v2metrics/metrics.go
+++ b/sherlock/internal/metrics/v2metrics/metrics.go
@@ -45,15 +45,15 @@ var (
 
 // Unique per replica
 var (
-	PagerdutyRequestCount = stats.Int64(
+	PagerdutyRequestCountMeasure = stats.Int64(
 		"sherlock/v2_pagerduty_request_count",
 		"count of outgoing requests to pagerduty",
 		"requests")
-	GithubActionsCompletionCount = stats.Int64(
+	GithubActionsCompletionCountMeasure = stats.Int64(
 		"sherlock/v2_github_actions_completion_count",
 		"count of completed GitHub Actions reported to Sherlock",
 		"workflows")
-	GithubActionsDurationCount = stats.Int64(
+	GithubActionsDurationSumMeasure = stats.Int64(
 		"sherlock/v2_github_actions_duration_count",
 		"count of seconds spent by GitHub Actions reported to Sherlock",
 		"seconds")
@@ -127,9 +127,9 @@ var (
 	}
 	PagerdutyRequestCountView = &view.View{
 		Name:        "v2_pagerduty_request_count",
-		Measure:     PagerdutyRequestCount,
+		Measure:     PagerdutyRequestCountMeasure,
 		TagKeys:     []tag.Key{PagerdutyRequestTypeKey, PagerdutyResponseCodeKey},
-		Description: PagerdutyRequestCount.Description(),
+		Description: PagerdutyRequestCountMeasure.Description(),
 		Aggregation: view.Count(),
 	}
 	EnvironmentStateCountView = &view.View{
@@ -141,17 +141,17 @@ var (
 	}
 	GithubActionsCompletionCountView = &view.View{
 		Name:        "v2_github_actions_completion_count",
-		Measure:     GithubActionsCompletionCount,
+		Measure:     GithubActionsCompletionCountMeasure,
 		TagKeys:     []tag.Key{GithubActionsRepoKey, GithubActionsWorkflowFileKey, GithubActionsAttemptNumberKey, GithubActionsOutcomeKey},
-		Description: GithubActionsCompletionCount.Description(),
+		Description: GithubActionsCompletionCountMeasure.Description(),
 		Aggregation: view.Count(),
 	}
-	GithubActionsDurationCountView = &view.View{
-		Name:        "v2_github_actions_duration_count",
-		Measure:     GithubActionsDurationCount,
+	GithubActionsDurationSumView = &view.View{
+		Name:        "v2_github_actions_duration_sum",
+		Measure:     GithubActionsDurationSumMeasure,
 		TagKeys:     []tag.Key{GithubActionsRepoKey, GithubActionsWorkflowFileKey, GithubActionsAttemptNumberKey, GithubActionsOutcomeKey},
-		Description: GithubActionsDurationCount.Description(),
-		Aggregation: view.Count(),
+		Description: GithubActionsDurationSumMeasure.Description(),
+		Aggregation: view.Sum(),
 	}
 )
 
@@ -167,6 +167,6 @@ func RegisterViews() error {
 		PagerdutyRequestCountView,
 		EnvironmentStateCountView,
 		GithubActionsCompletionCountView,
-		GithubActionsDurationCountView,
+		GithubActionsDurationSumView,
 	)
 }

--- a/sherlock/internal/models/v2models/ci_run.go
+++ b/sherlock/internal/models/v2models/ci_run.go
@@ -228,7 +228,5 @@ func ciRunGithubActionsMetricsSend(ciRun *CiRun) {
 		return
 	}
 	stats.Record(ctx, v2metrics.GithubActionsCompletionCountMeasure.M(1))
-	seconds := int64(math.Round(ciRun.TerminalAt.Sub(*ciRun.StartedAt).Seconds()))
-	println(seconds)
-	stats.Record(ctx, v2metrics.GithubActionsDurationSumMeasure.M(seconds))
+	stats.Record(ctx, v2metrics.GithubActionsDurationSumMeasure.M(int64(math.Round(ciRun.TerminalAt.Sub(*ciRun.StartedAt).Seconds()))))
 }

--- a/sherlock/internal/models/v2models/ci_run.go
+++ b/sherlock/internal/models/v2models/ci_run.go
@@ -186,7 +186,7 @@ func preCreateCiRun(db *gorm.DB, toCreate *CiRun, user *auth_models.User) error 
 	return createCiRunIdentifiersJustInTime(db, toCreate, user)
 }
 
-func preEditCiRun(db *gorm.DB, toEdit *CiRun, editsToMake *CiRun, user *auth_models.User) error {
+func preEditCiRun(db *gorm.DB, _ *CiRun, editsToMake *CiRun, user *auth_models.User) error {
 	return createCiRunIdentifiersJustInTime(db, editsToMake, user)
 }
 

--- a/sherlock/internal/models/v2models/internal_model_store.go
+++ b/sherlock/internal/models/v2models/internal_model_store.go
@@ -69,7 +69,7 @@ type internalModelStore[M Model] struct {
 	// During creation, metrics will be sent if the predicate is true.
 	// During edits, metrics will be sent if the edits make the predicate become true.
 	//
-	// (This is otherwise really tricky to do for edits, because Gorm reuses the structs/pointers we pass so it such
+	// (This is otherwise really tricky to do for edits, because Gorm reuses the structs/pointers we pass to it such
 	// that we can't reliably compare before/after states of edits. This field abstracts over that complexity even if
 	// it is a bit of a weird interface.)
 	metricsOnceUponPredicate []struct {

--- a/sherlock/internal/pagerduty/metrics.go
+++ b/sherlock/internal/pagerduty/metrics.go
@@ -23,5 +23,5 @@ func recordMetrics(ctx context.Context, requestType string, err error) {
 	} else {
 		ctx, _ = tag.New(ctx, tag.Upsert(v2metrics.PagerdutyResponseCodeKey, strconv.Itoa(http.StatusAccepted)))
 	}
-	stats.Record(ctx, v2metrics.PagerdutyRequestCount.M(1))
+	stats.Record(ctx, v2metrics.PagerdutyRequestCountMeasure.M(1))
 }


### PR DESCRIPTION
It exposes a count of completions and a sum of seconds spent. Both can be broken down by repo, workflow file, attempt number, and outcome.

These are ephemeral Sherlock metrics, more similar to the PagerDuty request metrics (that I think I never demo-ed, but they're there) than the accelerate metrics. Rather than being calculated on startup and reported as "LastValue" they're sent as requests come in and reported as "Count" or "Sum" (thus being aggregated with existing values Thanos has stored, not replacing them).

## Testing

I ran Sherlock and the webhook proxy locally. Then I ran Sherlock's [test-auth-transparency.yaml](https://github.com/broadinstitute/sherlock/blob/main/.github/workflows/test-auth-transparency.yaml) workflow three times. The middle invocation was me retrying the first.

Here's what the webhook proxy printed out:

```
2023/06/09 18:30:57 sherlockClient.CiRuns.PutAPIV2CiRunsSelector(): created CiRun 821, 'queued'
2023/06/09 18:31:06 sherlockClient.CiRuns.PutAPIV2CiRunsSelector(): edited CiRun 821, 'in_progress'
2023/06/09 18:31:10 sherlockClient.CiRuns.PutAPIV2CiRunsSelector(): edited CiRun 821, 'success'
2023/06/09 18:31:43 sherlockClient.CiRuns.PutAPIV2CiRunsSelector(): created CiRun 822, 'in_progress'
2023/06/09 18:31:50 sherlockClient.CiRuns.PutAPIV2CiRunsSelector(): edited CiRun 822, 'success'
2023/06/09 18:32:27 sherlockClient.CiRuns.PutAPIV2CiRunsSelector(): created CiRun 823, 'queued'
2023/06/09 18:32:36 sherlockClient.CiRuns.PutAPIV2CiRunsSelector(): edited CiRun 823, 'in_progress'
2023/06/09 18:32:42 sherlockClient.CiRuns.PutAPIV2CiRunsSelector(): edited CiRun 823, 'success'
```

(Note that retry doesn't appear to get queued, it goes straight to in_progress. No matter, just interesting.)

Sherlock printed this out (ignore the timestamps, they're in UTC not local time):

```
sherlock_1  | 10:30PM DBG enforcing *v2models.CiRun selector uniqueness across 1 selectors ([github-actions/broadinstitute/sherlock/5226565377/1]); handleConflicts provided=false
sherlock_1  | 10:30PM INF GIN  | 201 |      14.9895ms |      172.20.0.1 |        fake@broadinstitute.org | PUT     /api/v2/ci-runs/github-actions/broadinstitute/sherlock/5226565377/1
sherlock_1  | 10:31PM INF GIN  | 200 |    16.005375ms |      172.20.0.1 |        fake@broadinstitute.org | PUT     /api/v2/ci-runs/github-actions/broadinstitute/sherlock/5226565377/1
sherlock_1  | 10:31PM INF GIN  | 200 |    10.130083ms |      172.20.0.1 |        fake@broadinstitute.org | PUT     /api/v2/ci-runs/github-actions/broadinstitute/sherlock/5226565377/1
sherlock_1  | 10:31PM DBG enforcing *v2models.CiRun selector uniqueness across 1 selectors ([github-actions/broadinstitute/sherlock/5226565377/2]); handleConflicts provided=false
sherlock_1  | 10:31PM INF GIN  | 201 |    10.542625ms |      172.20.0.1 |        fake@broadinstitute.org | PUT     /api/v2/ci-runs/github-actions/broadinstitute/sherlock/5226565377/2
sherlock_1  | 10:31PM INF GIN  | 200 |        13.63ms |      172.20.0.1 |        fake@broadinstitute.org | PUT     /api/v2/ci-runs/github-actions/broadinstitute/sherlock/5226565377/2
sherlock_1  | 10:32PM DBG enforcing *v2models.CiRun selector uniqueness across 1 selectors ([github-actions/broadinstitute/sherlock/5226574705/1]); handleConflicts provided=false
sherlock_1  | 10:32PM INF GIN  | 201 |    12.403583ms |      172.20.0.1 |        fake@broadinstitute.org | PUT     /api/v2/ci-runs/github-actions/broadinstitute/sherlock/5226574705/1
sherlock_1  | 10:32PM INF GIN  | 200 |     12.13475ms |      172.20.0.1 |        fake@broadinstitute.org | PUT     /api/v2/ci-runs/github-actions/broadinstitute/sherlock/5226574705/1
sherlock_1  | 10:32PM INF GIN  | 200 |    10.441833ms |      172.20.0.1 |        fake@broadinstitute.org | PUT     /api/v2/ci-runs/github-actions/broadinstitute/sherlock/5226574705/1

```

(Note that the 201 responses correspond to the creations, while 200 correspond to the edits)

Then, visiting Sherlock's metrics, we see this at the bottom:

```
# HELP sherlock_v2_github_actions_completion_count count of completed GitHub Actions reported to Sherlock
# TYPE sherlock_v2_github_actions_completion_count counter
sherlock_v2_github_actions_completion_count{attempt_number="1",github_repo="broadinstitute/sherlock",outcome="success",workflow_file=".github/workflows/test-auth-transparency.yaml"} 2
sherlock_v2_github_actions_completion_count{attempt_number="2",github_repo="broadinstitute/sherlock",outcome="success",workflow_file=".github/workflows/test-auth-transparency.yaml"} 1
# HELP sherlock_v2_github_actions_duration_sum count of seconds spent by GitHub Actions reported to Sherlock
# TYPE sherlock_v2_github_actions_duration_sum counter
sherlock_v2_github_actions_duration_sum{attempt_number="1",github_repo="broadinstitute/sherlock",outcome="success",workflow_file=".github/workflows/test-auth-transparency.yaml"} 28
sherlock_v2_github_actions_duration_sum{attempt_number="2",github_repo="broadinstitute/sherlock",outcome="success",workflow_file=".github/workflows/test-auth-transparency.yaml"} 17
```

In other words, exactly what I need to make a GHA dashboard.

## Risk

I'm modifying Sherlock's generic create and edit methods on top of Gorm, but I'm doing so in a way that A) can't error and B) is extremely lightweight and C) only impacts CiRun. This looks super low risk to me.