### PR TITLE
Revert "[DDO-2904] Expose metrics from Sherlock's CiRuns (#180)"

### DIFF
--- a/sherlock/internal/metrics/v2metrics/metrics.go
+++ b/sherlock/internal/metrics/v2metrics/metrics.go
@@ -45,18 +45,10 @@ var (
 
 // Unique per replica
 var (
-	PagerdutyRequestCountMeasure = stats.Int64(
+	PagerdutyRequestCount = stats.Int64(
 		"sherlock/v2_pagerduty_request_count",
 		"count of outgoing requests to pagerduty",
 		"requests")
-	GithubActionsCompletionCountMeasure = stats.Int64(
-		"sherlock/v2_github_actions_completion_count",
-		"count of completed GitHub Actions reported to Sherlock",
-		"workflows")
-	GithubActionsDurationSumMeasure = stats.Int64(
-		"sherlock/v2_github_actions_duration_count",
-		"count of seconds spent by GitHub Actions reported to Sherlock",
-		"seconds")
 )
 
 var (
@@ -71,10 +63,6 @@ var (
 	DataTypeKey                   = tag.MustNewKey("data_type")
 	PagerdutyRequestTypeKey       = tag.MustNewKey("pd_request_type")
 	PagerdutyResponseCodeKey      = tag.MustNewKey("pd_response_code")
-	GithubActionsRepoKey          = tag.MustNewKey("github_repo")
-	GithubActionsWorkflowFileKey  = tag.MustNewKey("workflow_file")
-	GithubActionsAttemptNumberKey = tag.MustNewKey("attempt_number")
-	GithubActionsOutcomeKey       = tag.MustNewKey("outcome")
 
 	ChangesetCountView = &view.View{
 		Name:        "v2_changeset_count",
@@ -127,9 +115,9 @@ var (
 	}
 	PagerdutyRequestCountView = &view.View{
 		Name:        "v2_pagerduty_request_count",
-		Measure:     PagerdutyRequestCountMeasure,
+		Measure:     PagerdutyRequestCount,
 		TagKeys:     []tag.Key{PagerdutyRequestTypeKey, PagerdutyResponseCodeKey},
-		Description: PagerdutyRequestCountMeasure.Description(),
+		Description: PagerdutyRequestCount.Description(),
 		Aggregation: view.Count(),
 	}
 	EnvironmentStateCountView = &view.View{
@@ -138,20 +126,6 @@ var (
 		TagKeys:     []tag.Key{EnvironmentLifecycleKey, EnvironmentOfflineKey, EnvironmentPreventDeletionKey},
 		Description: EnvironmentStateCountMeasure.Description(),
 		Aggregation: view.LastValue(),
-	}
-	GithubActionsCompletionCountView = &view.View{
-		Name:        "v2_github_actions_completion_count",
-		Measure:     GithubActionsCompletionCountMeasure,
-		TagKeys:     []tag.Key{GithubActionsRepoKey, GithubActionsWorkflowFileKey, GithubActionsAttemptNumberKey, GithubActionsOutcomeKey},
-		Description: GithubActionsCompletionCountMeasure.Description(),
-		Aggregation: view.Count(),
-	}
-	GithubActionsDurationSumView = &view.View{
-		Name:        "v2_github_actions_duration_sum",
-		Measure:     GithubActionsDurationSumMeasure,
-		TagKeys:     []tag.Key{GithubActionsRepoKey, GithubActionsWorkflowFileKey, GithubActionsAttemptNumberKey, GithubActionsOutcomeKey},
-		Description: GithubActionsDurationSumMeasure.Description(),
-		Aggregation: view.Sum(),
 	}
 )
 
@@ -166,7 +140,5 @@ func RegisterViews() error {
 		DataTypeCountView,
 		PagerdutyRequestCountView,
 		EnvironmentStateCountView,
-		GithubActionsCompletionCountView,
-		GithubActionsDurationSumView,
 	)
 }

--- a/sherlock/internal/models/v2models/ci_run.go
+++ b/sherlock/internal/models/v2models/ci_run.go
@@ -1,17 +1,12 @@
 package v2models
 
 import (
-	"context"
 	"fmt"
 	"github.com/broadinstitute/sherlock/sherlock/internal/auth/auth_models"
 	"github.com/broadinstitute/sherlock/sherlock/internal/errors"
-	"github.com/broadinstitute/sherlock/sherlock/internal/metrics/v2metrics"
 	"github.com/broadinstitute/sherlock/sherlock/internal/utils"
 	"github.com/rs/zerolog/log"
-	"go.opencensus.io/stats"
-	"go.opencensus.io/tag"
 	"gorm.io/gorm"
-	"math"
 	"strconv"
 	"strings"
 	"time"
@@ -54,15 +49,6 @@ func init() {
 		preEdit:              preEditCiRun,
 		editsAppendManyToMany: map[string]func(edits *CiRun) any{
 			"RelatedResources": func(edits *CiRun) any { return edits.RelatedResources },
-		},
-		metricsOnceUponPredicate: []struct {
-			predicate   func(model *CiRun) bool
-			sendMetrics func(model *CiRun)
-		}{
-			{
-				predicate:   ciRunGithubActionsMetricsPredicate,
-				sendMetrics: ciRunGithubActionsMetricsSend,
-			},
 		},
 	}
 }
@@ -211,22 +197,4 @@ func createCiRunIdentifiersJustInTime(db *gorm.DB, ciRun *CiRun, user *auth_mode
 		}
 	}
 	return nil
-}
-
-func ciRunGithubActionsMetricsPredicate(ciRun *CiRun) bool {
-	return ciRun.Platform == "github-actions" && ciRun.Status != nil && ciRun.StartedAt != nil && ciRun.TerminalAt != nil
-}
-
-func ciRunGithubActionsMetricsSend(ciRun *CiRun) {
-	ctx, err := tag.New(context.Background(),
-		tag.Insert(v2metrics.GithubActionsRepoKey, fmt.Sprintf("%s/%s", ciRun.GithubActionsOwner, ciRun.GithubActionsRepo)),
-		tag.Insert(v2metrics.GithubActionsWorkflowFileKey, ciRun.GithubActionsWorkflowPath),
-		tag.Insert(v2metrics.GithubActionsAttemptNumberKey, strconv.FormatUint(uint64(ciRun.GithubActionsAttemptNumber), 10)),
-		tag.Insert(v2metrics.GithubActionsOutcomeKey, *ciRun.Status))
-	if err != nil {
-		log.Warn().Msg("reportCiRunCompletionMetrics couldn't create metrics context?")
-		return
-	}
-	stats.Record(ctx, v2metrics.GithubActionsCompletionCountMeasure.M(1))
-	stats.Record(ctx, v2metrics.GithubActionsDurationSumMeasure.M(int64(math.Round(ciRun.TerminalAt.Sub(*ciRun.StartedAt).Seconds()))))
 }

--- a/sherlock/internal/models/v2models/internal_model_store.go
+++ b/sherlock/internal/models/v2models/internal_model_store.go
@@ -64,18 +64,6 @@ type internalModelStore[M Model] struct {
 	// to Gorm's "associations mode" to append to that association. https://gorm.io/docs/associations.html#Append-Associations
 	// Realistically, this is useful for mutable many2many relations, because Gorm won't touch those on its own.
 	editsAppendManyToMany map[string]func(edits *M) any
-	// metricsOnceUponPredicate is a hack to let a data type define metrics that should be sent when a predicate becomes
-	// true.
-	// During creation, metrics will be sent if the predicate is true.
-	// During edits, metrics will be sent if the edits make the predicate become true.
-	//
-	// (This is otherwise really tricky to do for edits, because Gorm reuses the structs/pointers we pass to it such
-	// that we can't reliably compare before/after states of edits. This field abstracts over that complexity even if
-	// it is a bit of a weird interface.)
-	metricsOnceUponPredicate []struct {
-		predicate   func(model *M) bool
-		sendMetrics func(model *M)
-	}
 }
 
 func (s internalModelStore[M]) wrappedErrorIfForbidden(db *gorm.DB, model *M, action model_actions.ActionType, user *auth_models.User) error {
@@ -169,13 +157,6 @@ func (s internalModelStore[M]) create(db *gorm.DB, model M, user *auth_models.Us
 		ret = result
 		return nil
 	})
-	if err == nil && s.metricsOnceUponPredicate != nil {
-		for _, entry := range s.metricsOnceUponPredicate {
-			if entry.predicate(&ret) {
-				entry.sendMetrics(&ret)
-			}
-		}
-	}
 	return ret, err == nil, err
 }
 
@@ -240,13 +221,6 @@ func (s internalModelStore[M]) edit(db *gorm.DB, query M, editsToMake M, user *a
 			return toEdit, fmt.Errorf("pre-edit error: %v", err)
 		}
 	}
-	var cachedMetricsPredicateResults []bool
-	if s.metricsOnceUponPredicate != nil {
-		cachedMetricsPredicateResults = make([]bool, len(s.metricsOnceUponPredicate))
-		for i, entry := range s.metricsOnceUponPredicate {
-			cachedMetricsPredicateResults[i] = entry.predicate(&toEdit)
-		}
-	}
 	var ret M
 	err = db.Transaction(func(tx *gorm.DB) error {
 		var chain = tx.Model(&toEdit)
@@ -293,7 +267,6 @@ func (s internalModelStore[M]) edit(db *gorm.DB, query M, editsToMake M, user *a
 		}
 		// We check permissions *again* to prevent a user from editing an entry in a way that makes it require
 		// permissions above theirs in the future.
-		// Note that we run this call using db, because we don't want to use the modified state of the database.
 		if err = s.wrappedErrorIfForbidden(db, &result, model_actions.EDIT, user); err != nil {
 			return err
 		}
@@ -305,14 +278,6 @@ func (s internalModelStore[M]) edit(db *gorm.DB, query M, editsToMake M, user *a
 		ret = result
 		return nil
 	})
-	if err == nil && s.metricsOnceUponPredicate != nil {
-		for i, entry := range s.metricsOnceUponPredicate {
-			// If the predicate has changed to true as a result of our edits
-			if !cachedMetricsPredicateResults[i] && entry.predicate(&ret) {
-				entry.sendMetrics(&ret)
-			}
-		}
-	}
 	return ret, err
 }
 

--- a/sherlock/internal/pagerduty/metrics.go
+++ b/sherlock/internal/pagerduty/metrics.go
@@ -23,5 +23,5 @@ func recordMetrics(ctx context.Context, requestType string, err error) {
 	} else {
 		ctx, _ = tag.New(ctx, tag.Upsert(v2metrics.PagerdutyResponseCodeKey, strconv.Itoa(http.StatusAccepted)))
 	}
-	stats.Record(ctx, v2metrics.PagerdutyRequestCountMeasure.M(1))
+	stats.Record(ctx, v2metrics.PagerdutyRequestCount.M(1))
 }


### PR DESCRIPTION
This reverts commit 8666c75a448432cc2a05a5c0292c987fa55ca268 per https://broadinstitute.slack.com/archives/CQ6SL4N5T/p1686576979386449. That commit made no changes to the database, so this should be safe to do.