### PR TITLE
[DDO-2904] Precalculated CiRun metrics

### DIFF
--- a/sherlock/internal/metrics/v2metrics/metrics.go
+++ b/sherlock/internal/metrics/v2metrics/metrics.go
@@ -41,6 +41,22 @@ var (
 		"sherlock/v2_environment_state_count",
 		"count of environments",
 		"environments")
+	GithubActions1HourCompletionCountMeasure = stats.Int64(
+		"sherlock/v2_github_actions_1_hour_completion_count",
+		"count of GitHub Actions completions in the past hour",
+		"completions")
+	GithubActions7DayCompletionCountMeasure = stats.Int64(
+		"sherlock/v2_github_actions_7_day_completion_count",
+		"count of GitHub Actions completions in the past seven days",
+		"completions")
+	GithubActions1HourTotalDurationMeasure = stats.Int64(
+		"sherlock/v2_github_actions_1_hour_total_duration",
+		"total duration of GitHub Actions completed in the past hour",
+		"seconds")
+	GithubActions7DayTotalDurationMeasure = stats.Int64(
+		"sherlock/v2_github_actions_7_day_total_duration",
+		"total duration of GitHub Actions completed in the past seven days",
+		"seconds")
 )
 
 // Unique per replica
@@ -63,6 +79,10 @@ var (
 	DataTypeKey                   = tag.MustNewKey("data_type")
 	PagerdutyRequestTypeKey       = tag.MustNewKey("pd_request_type")
 	PagerdutyResponseCodeKey      = tag.MustNewKey("pd_response_code")
+	GithubActionsRepoKey          = tag.MustNewKey("gha_repo")
+	GithubActionsWorkflowFileKey  = tag.MustNewKey("gha_workflow_file")
+	GithubActionsOutcomeKey       = tag.MustNewKey("gha_outcome")
+	GithubActionsRetryKey         = tag.MustNewKey("gha_retry")
 
 	ChangesetCountView = &view.View{
 		Name:        "v2_changeset_count",
@@ -127,6 +147,34 @@ var (
 		Description: EnvironmentStateCountMeasure.Description(),
 		Aggregation: view.LastValue(),
 	}
+	GithubActions1HourCompletionCountView = &view.View{
+		Name:        "v2_github_actions_1_hour_completion_count",
+		Measure:     GithubActions1HourCompletionCountMeasure,
+		TagKeys:     []tag.Key{GithubActionsRepoKey, GithubActionsWorkflowFileKey, GithubActionsOutcomeKey, GithubActionsRetryKey},
+		Description: GithubActions1HourCompletionCountMeasure.Description(),
+		Aggregation: view.LastValue(),
+	}
+	GithubActions7DayCompletionCountView = &view.View{
+		Name:        "v2_github_actions_7_day_completion_count",
+		Measure:     GithubActions7DayCompletionCountMeasure,
+		TagKeys:     []tag.Key{GithubActionsRepoKey, GithubActionsWorkflowFileKey, GithubActionsOutcomeKey, GithubActionsRetryKey},
+		Description: GithubActions7DayCompletionCountMeasure.Description(),
+		Aggregation: view.LastValue(),
+	}
+	GithubActions1HourTotalDurationView = &view.View{
+		Name:        "v2_github_actions_1_hour_total_duration",
+		Measure:     GithubActions1HourTotalDurationMeasure,
+		TagKeys:     []tag.Key{GithubActionsRepoKey, GithubActionsWorkflowFileKey, GithubActionsOutcomeKey, GithubActionsRetryKey},
+		Description: GithubActions1HourTotalDurationMeasure.Description(),
+		Aggregation: view.LastValue(),
+	}
+	GithubActions7DayTotalDurationView = &view.View{
+		Name:        "v2_github_actions_7_day_total_duration",
+		Measure:     GithubActions7DayTotalDurationMeasure,
+		TagKeys:     []tag.Key{GithubActionsRepoKey, GithubActionsWorkflowFileKey, GithubActionsOutcomeKey, GithubActionsRetryKey},
+		Description: GithubActions7DayTotalDurationMeasure.Description(),
+		Aggregation: view.LastValue(),
+	}
 )
 
 func RegisterViews() error {
@@ -140,5 +188,9 @@ func RegisterViews() error {
 		DataTypeCountView,
 		PagerdutyRequestCountView,
 		EnvironmentStateCountView,
+		GithubActions1HourCompletionCountView,
+		GithubActions7DayCompletionCountView,
+		GithubActions1HourTotalDurationView,
+		GithubActions7DayTotalDurationView,
 	)
 }

--- a/sherlock/internal/models/v2models/metrics_updater.go
+++ b/sherlock/internal/models/v2models/metrics_updater.go
@@ -197,6 +197,8 @@ func reportDataTypeCounts(ctx context.Context, db *gorm.DB) error {
 		"chart_version": ChartVersion{},
 		"changeset":     Changeset{},
 		"chart_release": ChartRelease{},
+		"ci_identifier": CiIdentifier{},
+		"ci_run":        CiRun{},
 	} {
 		var count int64
 		if err := db.
@@ -242,6 +244,111 @@ func reportEnvironmentStateCounts(ctx context.Context, db *gorm.DB) error {
 					return err
 				}
 				stats.Record(ctx, v2metrics.EnvironmentStateCountMeasure.M(count))
+			}
+		}
+	}
+	return nil
+}
+
+func reportGitHubActionMetrics(ctx context.Context, db *gorm.DB) error {
+	type CompletionCountResult struct {
+		GithubActionsOwner, GithubActionsRepo, GithubActionsWorkflowPath, Status string
+		Count                                                                    int64
+	}
+	for interval, measure := range map[string]*stats.Int64Measure{
+		"1 hour": v2metrics.GithubActions1HourCompletionCountMeasure,
+		"7 days": v2metrics.GithubActions7DayCompletionCountMeasure,
+	} {
+		for retryLabel, attemptCountQuery := range map[string]string{
+			"false": "= 1",
+			"true":  "> 1",
+		} {
+			var results []CompletionCountResult
+			if err := db.Raw(fmt.Sprintf(`
+select v2_ci_runs.github_actions_owner,
+       v2_ci_runs.github_actions_repo,
+       v2_ci_runs.github_actions_workflow_path,
+       v2_ci_runs.status,
+       count(*)
+from v2_ci_runs
+where v2_ci_runs.platform = 'github-actions'
+  and v2_ci_runs.terminal_at >= current_timestamp - '%s'::interval
+  and v2_ci_runs.started_at is not null
+  and v2_ci_runs.github_actions_attempt_number %s
+group by v2_ci_runs.github_actions_owner, 
+         v2_ci_runs.github_actions_repo, 
+         v2_ci_runs.github_actions_workflow_path, 
+         v2_ci_runs.status
+`, interval, attemptCountQuery)).Scan(&results).Error; err != nil {
+				return err
+			}
+			ctx, err := tag.New(ctx,
+				tag.Upsert(v2metrics.GithubActionsRetryKey, retryLabel))
+			if err != nil {
+				return err
+			}
+			for _, result := range results {
+				ctx, err := tag.New(ctx,
+					tag.Upsert(v2metrics.GithubActionsRepoKey, fmt.Sprintf("%s/%s", result.GithubActionsOwner, result.GithubActionsRepo)),
+					tag.Upsert(v2metrics.GithubActionsWorkflowFileKey, result.GithubActionsWorkflowPath),
+					tag.Upsert(v2metrics.GithubActionsOutcomeKey, result.Status))
+				if err != nil {
+					return err
+				}
+				stats.Record(ctx, measure.M(result.Count))
+			}
+		}
+	}
+	type TotalDurationResult struct {
+		GithubActionsOwner, GithubActionsRepo, GithubActionsWorkflowPath, Status string
+		TotalDurationSeconds                                                     int64
+	}
+	for interval, measure := range map[string]*stats.Int64Measure{
+		"1 hour": v2metrics.GithubActions1HourTotalDurationMeasure,
+		"7 days": v2metrics.GithubActions7DayTotalDurationMeasure,
+	} {
+		for retryLabel, attemptCountQuery := range map[string]string{
+			"false": "= 1",
+			"true":  "> 1",
+		} {
+			var results []TotalDurationResult
+			if err := db.Raw(fmt.Sprintf(`
+select v2_ci_runs_with_duration.github_actions_owner,
+       v2_ci_runs_with_duration.github_actions_repo,
+       v2_ci_runs_with_duration.github_actions_workflow_path,
+       v2_ci_runs_with_duration.status,
+       round(sum(v2_ci_runs_with_duration.duration_seconds))::bigint as total_duration_seconds
+from (select v2_ci_runs.github_actions_owner,
+             v2_ci_runs.github_actions_repo,
+             v2_ci_runs.github_actions_workflow_path,
+             v2_ci_runs.status,
+             extract(epoch from v2_ci_runs.terminal_at - v2_ci_runs.started_at) as duration_seconds
+      from v2_ci_runs
+      where v2_ci_runs.platform = 'github-actions'
+        and v2_ci_runs.terminal_at >= current_timestamp - '%s'::interval
+        and v2_ci_runs.started_at is not null
+        and v2_ci_runs.github_actions_attempt_number %s) as v2_ci_runs_with_duration
+group by v2_ci_runs_with_duration.github_actions_owner, 
+         v2_ci_runs_with_duration.github_actions_repo,
+         v2_ci_runs_with_duration.github_actions_workflow_path, 
+         v2_ci_runs_with_duration.status
+`, interval, attemptCountQuery)).Scan(&results).Error; err != nil {
+				return err
+			}
+			ctx, err := tag.New(ctx,
+				tag.Upsert(v2metrics.GithubActionsRetryKey, retryLabel))
+			if err != nil {
+				return err
+			}
+			for _, result := range results {
+				ctx, err := tag.New(ctx,
+					tag.Upsert(v2metrics.GithubActionsRepoKey, fmt.Sprintf("%s/%s", result.GithubActionsOwner, result.GithubActionsRepo)),
+					tag.Upsert(v2metrics.GithubActionsWorkflowFileKey, result.GithubActionsWorkflowPath),
+					tag.Upsert(v2metrics.GithubActionsOutcomeKey, result.Status))
+				if err != nil {
+					return err
+				}
+				stats.Record(ctx, measure.M(result.TotalDurationSeconds))
 			}
 		}
 	}
@@ -361,6 +468,10 @@ func UpdateMetrics(ctx context.Context, db *gorm.DB) error {
 	}
 
 	if err = reportEnvironmentStateCounts(ctx, db); err != nil {
+		return err
+	}
+
+	if err = reportGitHubActionMetrics(ctx, db); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Take-two on #180.

It exposes four metrics:
- `v2_github_actions_1_hour_completion_count`
- `v2_github_actions_7_day_completion_count`
- `v2_github_actions_1_hour_total_duration`
- `v2_github_actions_7_day_total_duration`

Each has four labels associated to it:
- `gha_repo` like `broadinstitute/beehive`
- `gha_workflow_file` like `.github/workflows/build.yaml`
- `gha_outcome` like `success`
- `gha_retry` like `true` or `false`

Unlike #180, these metrics are fully-calculated by Sherlock. It exposes graphable values directly, instead of counts. This behavior is similar to how accelerate metrics work. The benefit is that Sherlock can, y'know, calculate these things _correctly_, with SQL, rather than relying on Prometheus's ability to add numbers.

## Testing

I developed the SQL against a local copy of the prod database, so I visited localhost:8080/metrics and checked that the values match up with what my SQL returned. There's also a test already written for the entire metrics updater that checks that all the SQL it runs is valid and won't blow stuff up.

## Risk

Similar to #180 -- super low but if it doesn't work we can just revert