### PR TITLE
[DDO-2904] Precalculated metrics for CiRun, but better

### DIFF
--- a/sherlock/internal/models/v2models/metrics_updater.go
+++ b/sherlock/internal/models/v2models/metrics_updater.go
@@ -261,38 +261,47 @@ select v2_ci_runs.github_actions_owner,
        v2_ci_runs.github_actions_repo,
        v2_ci_runs.github_actions_workflow_path,
        v2_ci_runs.status,
-        count(1)
-           filter (where v2_ci_runs.github_actions_attempt_number = 1
-                             and v2_ci_runs.terminal_at >= current_timestamp - '1 hour'::interval)
+
+       count(1)
+       filter (where v2_ci_runs.github_actions_attempt_number = 1
+           and v2_ci_runs.terminal_at >= current_timestamp - '1 hour'::interval)
            as hourly_first_attempts,
-        coalesce(round(sum(extract(epoch from v2_ci_runs.terminal_at - v2_ci_runs.started_at))
-           filter (where v2_ci_runs.github_actions_attempt_number = 1
-                             and v2_ci_runs.terminal_at >= current_timestamp - '1 hour'::interval))::bigint, 0)
+
+       coalesce(round(sum(extract(epoch from v2_ci_runs.terminal_at - v2_ci_runs.started_at))
+                      filter (where v2_ci_runs.github_actions_attempt_number = 1
+                          and v2_ci_runs.terminal_at >= current_timestamp - '1 hour'::interval))::bigint, 0)
            as hourly_first_attempts_duration,
-        count(1)
-           filter (where v2_ci_runs.github_actions_attempt_number > 1
-                             and v2_ci_runs.terminal_at >= current_timestamp - '1 hour'::interval)
+
+       count(1)
+       filter (where v2_ci_runs.github_actions_attempt_number > 1
+           and v2_ci_runs.terminal_at >= current_timestamp - '1 hour'::interval)
            as hourly_retries,
-        coalesce(round(sum(extract(epoch from v2_ci_runs.terminal_at - v2_ci_runs.started_at))
-           filter (where v2_ci_runs.github_actions_attempt_number > 1
-                             and v2_ci_runs.terminal_at >= current_timestamp - '1 hour'::interval))::bigint, 0)
+
+       coalesce(round(sum(extract(epoch from v2_ci_runs.terminal_at - v2_ci_runs.started_at))
+                      filter (where v2_ci_runs.github_actions_attempt_number > 1
+                          and v2_ci_runs.terminal_at >= current_timestamp - '1 hour'::interval))::bigint, 0)
            as hourly_retries_duration,
-        count(1)
-           filter (where v2_ci_runs.github_actions_attempt_number = 1
-                             and v2_ci_runs.terminal_at >= current_timestamp - '7 days'::interval)
+
+       count(1)
+       filter (where v2_ci_runs.github_actions_attempt_number = 1
+           and v2_ci_runs.terminal_at >= current_timestamp - '7 days'::interval)
            as weekly_first_attempts,
-        coalesce(round(sum(extract(epoch from v2_ci_runs.terminal_at - v2_ci_runs.started_at))
-           filter (where v2_ci_runs.github_actions_attempt_number = 1
-                             and v2_ci_runs.terminal_at >= current_timestamp - '7 days'::interval))::bigint, 0)
+
+       coalesce(round(sum(extract(epoch from v2_ci_runs.terminal_at - v2_ci_runs.started_at))
+                      filter (where v2_ci_runs.github_actions_attempt_number = 1
+                          and v2_ci_runs.terminal_at >= current_timestamp - '7 days'::interval))::bigint, 0)
            as weekly_first_attempts_duration,
-        count(1)
-           filter (where v2_ci_runs.github_actions_attempt_number > 1
-                             and v2_ci_runs.terminal_at >= current_timestamp - '7 days'::interval)
+
+       count(1)
+       filter (where v2_ci_runs.github_actions_attempt_number > 1
+           and v2_ci_runs.terminal_at >= current_timestamp - '7 days'::interval)
            as weekly_retries,
-        coalesce(round(sum(extract(epoch from v2_ci_runs.terminal_at - v2_ci_runs.started_at))
-           filter (where v2_ci_runs.github_actions_attempt_number > 1
-                             and v2_ci_runs.terminal_at >= current_timestamp - '7 days'::interval))::bigint, 0)
+    
+       coalesce(round(sum(extract(epoch from v2_ci_runs.terminal_at - v2_ci_runs.started_at))
+                      filter (where v2_ci_runs.github_actions_attempt_number > 1
+                          and v2_ci_runs.terminal_at >= current_timestamp - '7 days'::interval))::bigint, 0)
            as weekly_retries_duration
+
 from v2_ci_runs
 where v2_ci_runs.platform = 'github-actions'
   -- After two weeks, let metrics drop off to null.

--- a/sherlock/internal/models/v2models/metrics_updater.go
+++ b/sherlock/internal/models/v2models/metrics_updater.go
@@ -251,100 +251,58 @@ func reportEnvironmentStateCounts(ctx context.Context, db *gorm.DB) error {
 }
 
 func reportGitHubActionMetrics(ctx context.Context, db *gorm.DB) error {
-	type CompletionCountResult struct {
+	type CompletionResult struct {
 		GithubActionsOwner, GithubActionsRepo, GithubActionsWorkflowPath, Status string
-		Count                                                                    int64
+		FirstAttempts, FirstAttemptsDuration, Retries, RetiresDuration           int64
 	}
-	for interval, measure := range map[string]*stats.Int64Measure{
-		"1 hour": v2metrics.GithubActions1HourCompletionCountMeasure,
-		"7 days": v2metrics.GithubActions7DayCompletionCountMeasure,
+	for interval, measures := range map[string]struct {
+		countMeasure    *stats.Int64Measure
+		durationMeasure *stats.Int64Measure
+	}{
+		"1 hour": {countMeasure: v2metrics.GithubActions1HourCompletionCountMeasure, durationMeasure: v2metrics.GithubActions1HourTotalDurationMeasure},
+		"7 days": {countMeasure: v2metrics.GithubActions7DayCompletionCountMeasure, durationMeasure: v2metrics.GithubActions7DayTotalDurationMeasure},
 	} {
-		for retryLabel, attemptCountQuery := range map[string]string{
-			"false": "= 1",
-			"true":  "> 1",
-		} {
-			var results []CompletionCountResult
-			if err := db.Raw(fmt.Sprintf(`
+		var results []CompletionResult
+		if err := db.Raw(fmt.Sprintf(`
 select v2_ci_runs.github_actions_owner,
        v2_ci_runs.github_actions_repo,
        v2_ci_runs.github_actions_workflow_path,
        v2_ci_runs.status,
-       count(*)
+       count(*) filter (where v2_ci_runs.github_actions_attempt_number = 1)                    as first_attempts,
+       coalesce(round(sum(extract(epoch from v2_ci_runs.terminal_at - v2_ci_runs.started_at))
+                      filter (where v2_ci_runs.github_actions_attempt_number = 1))::bigint, 0) as first_attempts_duration,
+       count(*) filter (where v2_ci_runs.github_actions_attempt_number > 1)                    as retries,
+       coalesce(round(sum(extract(epoch from v2_ci_runs.terminal_at - v2_ci_runs.started_at))
+                      filter (where v2_ci_runs.github_actions_attempt_number > 1))::bigint, 0) as retries_duration
 from v2_ci_runs
 where v2_ci_runs.platform = 'github-actions'
   and v2_ci_runs.terminal_at >= current_timestamp - '%s'::interval
   and v2_ci_runs.started_at is not null
-  and v2_ci_runs.github_actions_attempt_number %s
-group by v2_ci_runs.github_actions_owner, 
-         v2_ci_runs.github_actions_repo, 
-         v2_ci_runs.github_actions_workflow_path, 
-         v2_ci_runs.status
-`, interval, attemptCountQuery)).Scan(&results).Error; err != nil {
-				return err
-			}
-			ctx, err := tag.New(ctx,
-				tag.Upsert(v2metrics.GithubActionsRetryKey, retryLabel))
-			if err != nil {
-				return err
-			}
-			for _, result := range results {
-				ctx, err := tag.New(ctx,
-					tag.Upsert(v2metrics.GithubActionsRepoKey, fmt.Sprintf("%s/%s", result.GithubActionsOwner, result.GithubActionsRepo)),
-					tag.Upsert(v2metrics.GithubActionsWorkflowFileKey, result.GithubActionsWorkflowPath),
-					tag.Upsert(v2metrics.GithubActionsOutcomeKey, result.Status))
-				if err != nil {
-					return err
-				}
-				stats.Record(ctx, measure.M(result.Count))
-			}
-		}
-	}
-	type TotalDurationResult struct {
-		GithubActionsOwner, GithubActionsRepo, GithubActionsWorkflowPath, Status string
-		TotalDurationSeconds                                                     int64
-	}
-	for interval, measure := range map[string]*stats.Int64Measure{
-		"1 hour": v2metrics.GithubActions1HourTotalDurationMeasure,
-		"7 days": v2metrics.GithubActions7DayTotalDurationMeasure,
-	} {
-		for retryLabel, attemptCountQuery := range map[string]string{
-			"false": "= 1",
-			"true":  "> 1",
-		} {
-			var results []TotalDurationResult
-			if err := db.Raw(fmt.Sprintf(`
-select v2_ci_runs.github_actions_owner,
-       v2_ci_runs.github_actions_repo,
-       v2_ci_runs.github_actions_workflow_path,
-       v2_ci_runs.status,
-       round(sum(extract(epoch from v2_ci_runs.terminal_at - v2_ci_runs.started_at)))::bigint as total_duration_seconds
-from v2_ci_runs
-where v2_ci_runs.platform = 'github-actions'
-  and v2_ci_runs.terminal_at >= current_timestamp - '%s'::interval
-  and v2_ci_runs.started_at is not null
-  and v2_ci_runs.github_actions_attempt_number %s
 group by v2_ci_runs.github_actions_owner,
          v2_ci_runs.github_actions_repo,
          v2_ci_runs.github_actions_workflow_path,
          v2_ci_runs.status
-`, interval, attemptCountQuery)).Scan(&results).Error; err != nil {
-				return err
-			}
+`, interval)).Scan(&results).Error; err != nil {
+			return err
+		}
+		for _, result := range results {
 			ctx, err := tag.New(ctx,
-				tag.Upsert(v2metrics.GithubActionsRetryKey, retryLabel))
+				tag.Upsert(v2metrics.GithubActionsRepoKey, fmt.Sprintf("%s/%s", result.GithubActionsOwner, result.GithubActionsRepo)),
+				tag.Upsert(v2metrics.GithubActionsWorkflowFileKey, result.GithubActionsWorkflowPath),
+				tag.Upsert(v2metrics.GithubActionsOutcomeKey, result.Status),
+				tag.Upsert(v2metrics.GithubActionsRetryKey, "false"))
 			if err != nil {
 				return err
 			}
-			for _, result := range results {
-				ctx, err := tag.New(ctx,
-					tag.Upsert(v2metrics.GithubActionsRepoKey, fmt.Sprintf("%s/%s", result.GithubActionsOwner, result.GithubActionsRepo)),
-					tag.Upsert(v2metrics.GithubActionsWorkflowFileKey, result.GithubActionsWorkflowPath),
-					tag.Upsert(v2metrics.GithubActionsOutcomeKey, result.Status))
-				if err != nil {
-					return err
-				}
-				stats.Record(ctx, measure.M(result.TotalDurationSeconds))
+			stats.Record(ctx, measures.countMeasure.M(result.FirstAttempts))
+			stats.Record(ctx, measures.durationMeasure.M(result.FirstAttemptsDuration))
+			ctx, err = tag.New(ctx,
+				tag.Upsert(v2metrics.GithubActionsRetryKey, "true"))
+			if err != nil {
+				return err
 			}
+			stats.Record(ctx, measures.countMeasure.M(result.Retries))
+			stats.Record(ctx, measures.durationMeasure.M(result.RetiresDuration))
 		}
 	}
 	return nil

--- a/sherlock/internal/models/v2models/metrics_updater.go
+++ b/sherlock/internal/models/v2models/metrics_updater.go
@@ -302,7 +302,7 @@ group by v2_ci_runs.github_actions_owner,
 				return err
 			}
 			stats.Record(ctx, measures.countMeasure.M(result.Retries))
-			stats.Record(ctx, measures.durationMeasure.M(result.RetiresDuration))
+			stats.Record(ctx, measures.durationMeasure.M(result.RetriesDuration))
 		}
 	}
 	return nil

--- a/sherlock/internal/models/v2models/metrics_updater.go
+++ b/sherlock/internal/models/v2models/metrics_updater.go
@@ -261,7 +261,7 @@ select v2_ci_runs.github_actions_owner,
        v2_ci_runs.github_actions_repo,
        v2_ci_runs.github_actions_workflow_path,
        v2_ci_runs.status,
-        count(*)
+        count(1)
            filter (where v2_ci_runs.github_actions_attempt_number = 1
                              and v2_ci_runs.terminal_at >= current_timestamp - '1 hour'::interval)
            as hourly_first_attempts,
@@ -269,7 +269,7 @@ select v2_ci_runs.github_actions_owner,
            filter (where v2_ci_runs.github_actions_attempt_number = 1
                              and v2_ci_runs.terminal_at >= current_timestamp - '1 hour'::interval))::bigint, 0)
            as hourly_first_attempts_duration,
-        count(*)
+        count(1)
            filter (where v2_ci_runs.github_actions_attempt_number > 1
                              and v2_ci_runs.terminal_at >= current_timestamp - '1 hour'::interval)
            as hourly_retries,
@@ -277,7 +277,7 @@ select v2_ci_runs.github_actions_owner,
            filter (where v2_ci_runs.github_actions_attempt_number > 1
                              and v2_ci_runs.terminal_at >= current_timestamp - '1 hour'::interval))::bigint, 0)
            as hourly_retries_duration,
-        count(*)
+        count(1)
            filter (where v2_ci_runs.github_actions_attempt_number = 1
                              and v2_ci_runs.terminal_at >= current_timestamp - '7 days'::interval)
            as weekly_first_attempts,
@@ -285,7 +285,7 @@ select v2_ci_runs.github_actions_owner,
            filter (where v2_ci_runs.github_actions_attempt_number = 1
                              and v2_ci_runs.terminal_at >= current_timestamp - '7 days'::interval))::bigint, 0)
            as weekly_first_attempts_duration,
-        count(*)
+        count(1)
            filter (where v2_ci_runs.github_actions_attempt_number > 1
                              and v2_ci_runs.terminal_at >= current_timestamp - '7 days'::interval)
            as weekly_retries,

--- a/sherlock/internal/models/v2models/metrics_updater.go
+++ b/sherlock/internal/models/v2models/metrics_updater.go
@@ -253,7 +253,7 @@ func reportEnvironmentStateCounts(ctx context.Context, db *gorm.DB) error {
 func reportGitHubActionMetrics(ctx context.Context, db *gorm.DB) error {
 	type CompletionResult struct {
 		GithubActionsOwner, GithubActionsRepo, GithubActionsWorkflowPath, Status string
-		FirstAttempts, FirstAttemptsDuration, Retries, RetiresDuration           int64
+		FirstAttempts, FirstAttemptsDuration, Retries, RetriesDuration           int64
 	}
 	for interval, measures := range map[string]struct {
 		countMeasure    *stats.Int64Measure

--- a/sherlock/internal/models/v2models/metrics_updater.go
+++ b/sherlock/internal/models/v2models/metrics_updater.go
@@ -295,7 +295,9 @@ select v2_ci_runs.github_actions_owner,
            as weekly_retries_duration
 from v2_ci_runs
 where v2_ci_runs.platform = 'github-actions'
-  and v2_ci_runs.terminal_at is not null
+  -- After two weeks, let metrics drop off to null.
+  -- This strikes a balance between tracking seldom-run actions and cleaning up after a workflow file is renamed.
+  and v2_ci_runs.terminal_at >= current_timestamp - '14 days'::interval
   and v2_ci_runs.started_at is not null
 group by v2_ci_runs.github_actions_owner,
          v2_ci_runs.github_actions_repo,


### PR DESCRIPTION
Talking to Eno about SQL made me realize I could potentially do this all in one step. So this is one query rather than four, _and_ it reports 0 for things like "no retries in the time period" which becomes super useful for Prometheus down the line.

It's also just literally less code, no looping, and no string replacement inside SQL statements.

## Testing

Metrics that aren't 0 look the same, but there's way more zeros now (verified locally)

## Risk

None