### PR TITLE
[DDO-2914] Reusable workflow for reporting related resources

### DIFF
--- a/.github/workflows/client-get-chart-release.yaml
+++ b/.github/workflows/client-get-chart-release.yaml
@@ -35,16 +35,6 @@ on:
         type: string
         description: "The name or selector of the chart release (chart instance) to get"
 
-      ##
-      ## Sherlock configuration:
-      ##
-
-      use-sherlock-dev:
-        required: false
-        type: boolean
-        default: false
-        description: "If the environment should be gotten from the DevOps-use development Sherlock instance instead of the general-use production instance"
-
     outputs:
       name:
         description: "The name of the chart release"
@@ -58,11 +48,8 @@ on:
 
 env:
   SHERLOCK_PROD_URL: 'https://sherlock.dsp-devops.broadinstitute.org'
-  SHERLOCK_DEV_URL: 'https://sherlock-dev.dsp-devops.broadinstitute.org'
   BEEHIVE_PROD_URL: 'https://beehive.dsp-devops.broadinsitute.org'
-  BEEHIVE_DEV_URL: 'https://beehive-dev.dsp-devops.broadinstitute.org'
   BEEHIVE_PROD_VANITY_URL: 'https://broad.io/beehive'
-  BEEHIVE_DEV_VANITY_URL: 'https://broad.io/beehive-dev'
 
 jobs:
   get-chart-release:
@@ -92,20 +79,7 @@ jobs:
         with:
           script: core.setOutput('id_token', await core.getIDToken())
 
-      - name: "Get from Sherlock Dev"
-        if: ${{ inputs.use-sherlock-dev == true }}
-        shell: bash
-        run: |
-          set -ex
-          curl --fail-with-body \
-            "$SHERLOCK_DEV_URL/api/v2/chart-releases/${{ inputs.chart-release-name }}" \
-            -H 'Content-Type: application/json' \
-            -H 'Authorization: Bearer ${{ steps.iap_auth.outputs.id_token }}' \
-            -H 'X-GHA-OIDC-JWT: ${{ steps.gha_auth.outputs.id_token }}' \
-            -o "$RUNNER_TEMP/response.json"
-
-      - name: "Get from Sherlock Prod"
-        if: ${{ inputs.use-sherlock-dev == false }}
+      - name: "Get from Sherlock"
         shell: bash
         run: |
           set -ex

--- a/.github/workflows/client-get-environment.yaml
+++ b/.github/workflows/client-get-environment.yaml
@@ -35,16 +35,6 @@ on:
         type: string
         description: "The name of the environment to get"
 
-      ##
-      ## Sherlock configuration:
-      ##
-
-      use-sherlock-dev:
-        required: false
-        type: boolean
-        default: false
-        description: "If the environment should be gotten from the DevOps-use development Sherlock instance instead of the general-use production instance"
-
     outputs:
       lifecycle:
         description: "The lifecycle of the environment"
@@ -55,11 +45,8 @@ on:
 
 env:
   SHERLOCK_PROD_URL: 'https://sherlock.dsp-devops.broadinstitute.org'
-  SHERLOCK_DEV_URL: 'https://sherlock-dev.dsp-devops.broadinstitute.org'
   BEEHIVE_PROD_URL: 'https://beehive.dsp-devops.broadinsitute.org'
-  BEEHIVE_DEV_URL: 'https://beehive-dev.dsp-devops.broadinstitute.org'
   BEEHIVE_PROD_VANITY_URL: 'https://broad.io/beehive'
-  BEEHIVE_DEV_VANITY_URL: 'https://broad.io/beehive-dev'
 
 jobs:
   get-environment:
@@ -88,20 +75,7 @@ jobs:
         with:
           script: core.setOutput('id_token', await core.getIDToken())
 
-      - name: "Get from Sherlock Dev"
-        if: ${{ inputs.use-sherlock-dev == true }}
-        shell: bash
-        run: |
-          set -ex
-          curl --fail-with-body \
-            "$SHERLOCK_DEV_URL/api/v2/environments/${{ inputs.environment-name }}" \
-            -H 'Content-Type: application/json' \
-            -H 'Authorization: Bearer ${{ steps.iap_auth.outputs.id_token }}' \
-            -H 'X-GHA-OIDC-JWT: ${{ steps.gha_auth.outputs.id_token }}' \
-            -o "$RUNNER_TEMP/response.json"
-
-      - name: "Get from Sherlock Prod"
-        if: ${{ inputs.use-sherlock-dev == false }}
+      - name: "Get from Sherlock"
         shell: bash
         run: |
           set -ex

--- a/.github/workflows/client-refresh-environment.yaml
+++ b/.github/workflows/client-refresh-environment.yaml
@@ -67,40 +67,11 @@ on:
         required: true
         type: string
         description: "The name of the environment to update"
-      
-      ##
-      ## Sherlock configuration:
-      ##
-
-      use-sherlock-prod:
-        required: false
-        type: boolean
-        default: true
-        description: "If the version should be reported to the general-use production Sherlock instance"
-      fail-on-prod-failure:
-        required: false
-        type: boolean
-        default: true
-        description: "If an issue communicating with production Sherlock should cause an overall failure"
-
-      use-sherlock-dev:
-        required: false
-        type: boolean
-        default: true
-        description: "If the version should be reported to the DevOps-use development Sherlock instance"
-      fail-on-dev-failure:
-        required: false
-        type: boolean
-        default: false
-        description: "If an issue communicating with development Sherlock should cause an overall failure"
 
 env:
   SHERLOCK_PROD_URL: 'https://sherlock.dsp-devops.broadinstitute.org'
-  SHERLOCK_DEV_URL: 'https://sherlock-dev.dsp-devops.broadinstitute.org'
   BEEHIVE_PROD_URL: 'https://beehive.dsp-devops.broadinsitute.org'
-  BEEHIVE_DEV_URL: 'https://beehive-dev.dsp-devops.broadinstitute.org'
   BEEHIVE_PROD_VANITY_URL: 'https://broad.io/beehive'
-  BEEHIVE_DEV_VANITY_URL: 'https://broad.io/beehive-dev'
 
 jobs:
   refresh:
@@ -153,27 +124,12 @@ jobs:
         with:
           script: core.setOutput('id_token', await core.getIDToken())
       
-      - name: "Send to Sherlock Prod"
-        if: ${{ inputs.use-sherlock-prod }}
-        continue-on-error: ${{ !inputs.fail-on-prod-failure }}
+      - name: "Send to Sherlock"
         shell: bash
         run: |
           set -ex
           curl --fail-with-body -X 'POST' \
             "$SHERLOCK_PROD_URL/api/v2/procedures/changesets/plan-and-apply" \
-            -H 'Content-Type: application/json' \
-            -H 'Authorization: Bearer ${{ steps.iap_auth.outputs.id_token }}' \
-            -H 'X-GHA-OIDC-JWT: ${{ steps.gha_auth.outputs.id_token }}' \
-            -d "@$RUNNER_TEMP/body.json" | jq
-
-      - name: "Send to Sherlock Dev"
-        if: ${{ inputs.use-sherlock-dev }}
-        continue-on-error: ${{ !inputs.fail-on-dev-failure }}
-        shell: bash
-        run: |
-          set -ex
-          curl --fail-with-body -X 'POST' \
-            "$SHERLOCK_DEV_URL/api/v2/procedures/changesets/plan-and-apply" \
             -H 'Content-Type: application/json' \
             -H 'Authorization: Bearer ${{ steps.iap_auth.outputs.id_token }}' \
             -H 'X-GHA-OIDC-JWT: ${{ steps.gha_auth.outputs.id_token }}' \
@@ -222,3 +178,11 @@ jobs:
           ref: refs/heads/main
           token: ${{ secrets.sync-git-token }}
           inputs: '{ "environment-names": "${{ inputs.environment-name }}", "refresh-only": "false" }'
+
+  report-workflow-relation:
+    uses: ./.github/workflows/client-report-workflow-related-resources.yaml
+    needs: refresh
+    with:
+      environments: ${{ inputs.environment-name }}
+    permissions:
+      id-token: write

--- a/.github/workflows/client-report-app-version.yaml
+++ b/.github/workflows/client-report-app-version.yaml
@@ -268,7 +268,20 @@ jobs:
         uses: actions/github-script@v6
         with:
           script: core.setOutput('id_token', await core.getIDToken())
-      
+
+      - name: "Send to Sherlock Dev"
+        if: ${{ inputs.use-sherlock-dev }}
+        continue-on-error: ${{ !inputs.fail-on-dev-failure }}
+        shell: bash
+        run: |
+          set -ex
+          curl --fail-with-body -X 'POST' \
+            "$SHERLOCK_DEV_URL/api/v2/app-versions" \
+            -H 'Content-Type: application/json' \
+            -H 'Authorization: Bearer ${{ steps.iap_auth.outputs.id_token }}' \
+            -H 'X-GHA-OIDC-JWT: ${{ steps.gha_auth.outputs.id_token }}' \
+            -d "@$RUNNER_TEMP/body.json" | jq
+
       - name: "Send to Sherlock Prod"
         if: ${{ inputs.use-sherlock-prod }}
         continue-on-error: ${{ !inputs.fail-on-prod-failure }}
@@ -283,15 +296,10 @@ jobs:
             -d "@$RUNNER_TEMP/body.json" | jq
           echo "### Available in Beehive at $BEEHIVE_PROD_VANITY_URL/r/app-version/${{ inputs.chart-name }}/${{ inputs.new-version }}" >> $GITHUB_STEP_SUMMARY
 
-      - name: "Send to Sherlock Dev"
-        if: ${{ inputs.use-sherlock-dev }}
-        continue-on-error: ${{ !inputs.fail-on-dev-failure }}
-        shell: bash
-        run: |
-          set -ex
-          curl --fail-with-body -X 'POST' \
-            "$SHERLOCK_DEV_URL/api/v2/app-versions" \
-            -H 'Content-Type: application/json' \
-            -H 'Authorization: Bearer ${{ steps.iap_auth.outputs.id_token }}' \
-            -H 'X-GHA-OIDC-JWT: ${{ steps.gha_auth.outputs.id_token }}' \
-            -d "@$RUNNER_TEMP/body.json" | jq
+  report-workflow-relation:
+    uses: ./.github/workflows/client-report-workflow-related-resources.yaml
+    needs: report-new-version
+    with:
+      app-versions: ${{ inputs.chart-name }}/${{ inputs.new-version }}
+    permissions:
+      id-token: write

--- a/.github/workflows/client-report-app-version.yaml
+++ b/.github/workflows/client-report-app-version.yaml
@@ -88,40 +88,11 @@ on:
         required: false
         type: string
         description: "Entirely omit the parent field, useful when the repository doesn't tag versions"
-      
-      ##
-      ## Sherlock configuration:
-      ##
-
-      use-sherlock-prod:
-        required: false
-        type: boolean
-        default: true
-        description: "If the version should be reported to the general-use production Sherlock instance"
-      fail-on-prod-failure:
-        required: false
-        type: boolean
-        default: true
-        description: "If an issue communicating with production Sherlock should cause an overall failure"
-
-      use-sherlock-dev:
-        required: false
-        type: boolean
-        default: true
-        description: "If the version should be reported to the DevOps-use development Sherlock instance"
-      fail-on-dev-failure:
-        required: false
-        type: boolean
-        default: false
-        description: "If an issue communicating with development Sherlock should cause an overall failure"
 
 env:
   SHERLOCK_PROD_URL: 'https://sherlock.dsp-devops.broadinstitute.org'
-  SHERLOCK_DEV_URL: 'https://sherlock-dev.dsp-devops.broadinstitute.org'
   BEEHIVE_PROD_URL: 'https://beehive.dsp-devops.broadinsitute.org'
-  BEEHIVE_DEV_URL: 'https://beehive-dev.dsp-devops.broadinstitute.org'
   BEEHIVE_PROD_VANITY_URL: 'https://broad.io/beehive'
-  BEEHIVE_DEV_VANITY_URL: 'https://broad.io/beehive-dev'
 
 jobs:
   report-new-version:
@@ -269,22 +240,7 @@ jobs:
         with:
           script: core.setOutput('id_token', await core.getIDToken())
 
-      - name: "Send to Sherlock Dev"
-        if: ${{ inputs.use-sherlock-dev }}
-        continue-on-error: ${{ !inputs.fail-on-dev-failure }}
-        shell: bash
-        run: |
-          set -ex
-          curl --fail-with-body -X 'POST' \
-            "$SHERLOCK_DEV_URL/api/v2/app-versions" \
-            -H 'Content-Type: application/json' \
-            -H 'Authorization: Bearer ${{ steps.iap_auth.outputs.id_token }}' \
-            -H 'X-GHA-OIDC-JWT: ${{ steps.gha_auth.outputs.id_token }}' \
-            -d "@$RUNNER_TEMP/body.json" | jq
-
-      - name: "Send to Sherlock Prod"
-        if: ${{ inputs.use-sherlock-prod }}
-        continue-on-error: ${{ !inputs.fail-on-prod-failure }}
+      - name: "Send to Sherlock"
         shell: bash
         run: |
           set -ex

--- a/.github/workflows/client-report-chart-version.yaml
+++ b/.github/workflows/client-report-chart-version.yaml
@@ -93,39 +93,10 @@ on:
         type: string
         description: "Optionally provide a custom description for the version instead of the commit message"
 
-      ##
-      ## Sherlock configuration:
-      ##
-
-      use-sherlock-prod:
-        required: false
-        type: boolean
-        default: true
-        description: "If the version should be reported to the general-use production Sherlock instance"
-      fail-on-prod-failure:
-        required: false
-        type: boolean
-        default: true
-        description: "If an issue communicating with production Sherlock should cause an overall failure"
-
-      use-sherlock-dev:
-        required: false
-        type: boolean
-        default: true
-        description: "If the version should be reported to the DevOps-use development Sherlock instance"
-      fail-on-dev-failure:
-        required: false
-        type: boolean
-        default: false
-        description: "If an issue communicating with development Sherlock should cause an overall failure"
-
 env:
   SHERLOCK_PROD_URL: 'https://sherlock.dsp-devops.broadinstitute.org'
-  SHERLOCK_DEV_URL: 'https://sherlock-dev.dsp-devops.broadinstitute.org'
   BEEHIVE_PROD_URL: 'https://beehive.dsp-devops.broadinsitute.org'
-  BEEHIVE_DEV_URL: 'https://beehive-dev.dsp-devops.broadinstitute.org'
   BEEHIVE_PROD_VANITY_URL: 'https://broad.io/beehive'
-  BEEHIVE_DEV_VANITY_URL: 'https://broad.io/beehive-dev'
 
 jobs:
   report-new-version:
@@ -260,9 +231,7 @@ jobs:
         with:
           script: core.setOutput('id_token', await core.getIDToken())
       
-      - name: "Send to Sherlock Prod"
-        if: ${{ inputs.use-sherlock-prod }}
-        continue-on-error: ${{ !inputs.fail-on-prod-failure }}
+      - name: "Send to Sherlock"
         shell: bash
         run: |
           set -ex
@@ -274,15 +243,10 @@ jobs:
             -d "@$RUNNER_TEMP/body.json" | jq
           echo "### Available in Beehive at $BEEHIVE_PROD_VANITY_URL/r/chart-version/${{ inputs.chart-name }}/${{ inputs.new-version }}" >> $GITHUB_STEP_SUMMARY
 
-      - name: "Send to Sherlock Dev"
-        if: ${{ inputs.use-sherlock-dev }}
-        continue-on-error: ${{ !inputs.fail-on-dev-failure }}
-        shell: bash
-        run: |
-          set -ex
-          curl --fail-with-body -X 'POST' \
-            "$SHERLOCK_DEV_URL/api/v2/chart-versions" \
-            -H 'Content-Type: application/json' \
-            -H 'Authorization: Bearer ${{ steps.iap_auth.outputs.id_token }}' \
-            -H 'X-GHA-OIDC-JWT: ${{ steps.gha_auth.outputs.id_token }}' \
-            -d "@$RUNNER_TEMP/body.json" | jq
+  report-workflow-relation:
+    uses: ./.github/workflows/client-report-workflow-related-resources.yaml
+    needs: report-new-version
+    with:
+      chart-versions: ${{ inputs.chart-name }}/${{ inputs.new-version }}
+    permissions:
+      id-token: write

--- a/.github/workflows/client-report-workflow-related-resources.yaml
+++ b/.github/workflows/client-report-workflow-related-resources.yaml
@@ -131,9 +131,11 @@ jobs:
           CHARTS: ${{ inputs.charts }}
           CHANGESETS: ${{ inputs.changesets }}
         with:
-          # The bash to do this is hard but the JS is trivial.
+          # Bash action steps are usually easier to work with, but here it's easier to assemble this JSON object
+          # in JS rather than doing lots of string work with Bash.
           script: |
             core.setOutput("body", JSON.stringify({
+              // Split on commas/whitespace and filter to non-empty values
               appVersions: process.env.APP_VERSIONS.split(/[\s,]+/).filter(Boolean),
               chartVersions: process.env.CHART_VERSIONS.split(/[\s,]+/).filter(Boolean),
               chartReleases: process.env.CHART_RELEASES.split(/[\s,]+/).filter(Boolean),
@@ -141,18 +143,21 @@ jobs:
               clusters: process.env.CLUSTERS.split(/[\s,]+/).filter(Boolean),
               charts: process.env.CHARTS.split(/[\s,]+/).filter(Boolean),
               changesets: process.env.CHANGESETS.split(/[\s,]+/).filter(Boolean),
+              
+              // Supply required creation fields in case webhook deliveries are delayed and we hit first
+              platform: "github-actions",
               githubActionsAttemptNumber: ${{ github.run_attempt }},
               githubActionsOwner: "${{ github.repository }}".split("/")[0],
               githubActionsRepo: "${{ github.repository }}".split("/")[1],
               githubActionsRunID: ${{ github.run_id }},
-              githubActionsWorkflowPath: "${{ github.workflow_ref }}".slice("${{ github.repository }}".length).split("@")[0],
-              platform: "github-actions"
+              // Path is prefixed by "<owner>/<repo>/" and suffixed by "@<ref>" so strip those
+              githubActionsWorkflowPath: "${{ github.workflow_ref }}".slice("${{ github.repository }}".length+1).split("@")[0]
             }))
 
       - name: "Write Request Body"
         shell: bash
         run: |
-          echo '${{ steps.parse.outputs.body }}' > "$RUNNER_TEMP/body.json"
+          echo '${{ steps.parse.outputs.body }}' | jq > "$RUNNER_TEMP/body.json"
 
       - name: "Log Request Body"
         shell: bash

--- a/.github/workflows/client-report-workflow-related-resources.yaml
+++ b/.github/workflows/client-report-workflow-related-resources.yaml
@@ -126,7 +126,7 @@ jobs:
           # The bash to do this is hard but the JS is trivial.
           script: |
             ["app-versions", "chart-versions", "chart-releases", "environments", "clusters", "charts", "changesets"].forEach((input) => {
-              core.setOutput(input, JSON.stringify(core.getInput(input).split(/[\s,]+/))))
+              core.setOutput(input, JSON.stringify(core.getInput(input).split(/[\s,]+/)))
             })
 
       - name: "Write Request Body"

--- a/.github/workflows/client-report-workflow-related-resources.yaml
+++ b/.github/workflows/client-report-workflow-related-resources.yaml
@@ -1,0 +1,177 @@
+name: Report Related Resources
+
+# This workflow is meant to be called from other repositories' workflows to report that the
+# workflow impacts or is related to some resource in Sherlock.
+#
+# The caller repository must have Workload Identity Federation configured to allow impersonation of the
+# "dsp-tools-iap-access@dsp-tools-k8s.iam.gserviceaccount.com" service account; steps 1 and 2 of the documentation:
+# https://docs.google.com/document/d/1bnhDmWQHAMat_Saoa_z28FHwXmGWw6kywjdbKf208h4/edit
+#
+# With that configured, here's an example of how you can call this workflow:
+# ```yaml
+# jobs:
+#
+#   report-related-resources:
+#     uses: broadinstitute/sherlock/.github/workflows/client-report-workflow-related-resources.yaml@main
+#     needs: <your-existing-job-id>
+#     with:
+#       chart-releases: leonardo-dev
+#     permissions:
+#       id-token: write
+# ```
+
+on:
+  workflow_call:
+    inputs:
+      app-versions:
+        required: false
+        type: string
+        description: |
+          App versions affected by the calling workflow.
+          The app versions must have already been reported to Sherlock.
+          
+          App versions should be specified by an app version selector. Some different examples:
+            - <id-integer> (`456`)
+            - <chart-selector>/<version-string> (`leonardo/v1.2.3`)
+          Multiple app versions can be reported by separating them with whitespace and/or commas.
+      chart-versions:
+        required: false
+        type: string
+        description: |
+          Chart versions affected by the calling workflow.
+          The chart versions must have already been reported to Sherlock.
+          
+          Chart versions should be specified by a chart version selector. Some different examples:
+            - <id-integer> (`456`)
+            - <chart-selector>/<version-string> (`leonardo/v1.2.3`)
+          Multiple chart versions can be reported by separating them with whitespace and/or commas.
+      chart-releases:
+        required: false
+        type: string
+        description: |
+          Chart releases (chart instances) affected by the calling workflow.
+          The chart releases must already exist in Sherlock.
+          
+          Impacting a chart release will automatically also be recorded as impacting the chart release's
+          Kubernetes cluster and/or environment, where applicable. You don't need to specify them too.
+          
+          Chart releases should be specified by a chart release selector. Some different examples:
+            - <id-integer> (`456`)
+            - <name-string> (`leonardo-dev`)
+            - <environment-selector>/<chart-selector> (`dev/leonardo`)
+            - <cluster-selector>/<namespace-string>/<chart-selector> (`terra-dev/terra-dev/leonardo`)
+          Multiple chart releases can be reported by separating them with whitespace and/or commas.
+      environments:
+        required: false
+        type: string
+        description: |
+          Environments affected by the calling workflow.
+          The environments must already exist in Sherlock.
+          
+          Environments should be specified by an environment selector. Some different examples:
+            - <id-integer> (`456`)
+            - <name-string> (`dev`)
+            - resource-prefix/<unique-resource-prefix-string> (`resource-prefix/z123`)
+          Multiple environments can be reported by separating them with whitespace and/or commas.
+      clusters:
+        required: false
+        type: string
+        description: |
+          Kubernetes clusters affected by the calling workflow.
+          The clusters must already exist in Sherlock.
+          
+          Clusters should be specified by a cluster selector. Some different examples:
+            - <id-integer> (`456`)
+            - <name-string> (`terra-dev`)
+          Multiple clusters can be reported by separating them with whitespace and/or commas.
+      charts:
+        required: false
+        type: string
+        description: |
+          Helm Charts affected by the calling workflow.
+          The charts must already exist in Sherlock.
+          
+          Charts should be specified by a chart selector. Some different examples:
+            - <id-integer> (`456`)
+            - <name-string> (`leonardo`)
+          Multiple charts can be reported by separating them with whitespace and/or commas.
+      changesets:
+        required: false
+        type: string
+        description: |
+          Changesets (chart release version change) affected or used by the calling workflow.
+          The changesets must already exist in Sherlock.
+          
+          Impacting a changeset will automatically be recorded as impacting any newly-deployed app and/or
+          chart versions and as impacting the chart release. Impacting the chart release will in turn be
+          recorded as impacting its Kubernetes cluster and/or environment, where applicable. You don't
+          need to specify those other resources.
+          
+          Changesets must be specified by their integer ID (`456`), there aren't other selectors available.
+          Multiple changesets can be reported by separating them with whitespace and/or commas.
+
+env:
+  SHERLOCK_PROD_URL: "https://sherlock.dsp-devops.broadinstitute.org"
+
+jobs:
+  report-workflow-impacts:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - name: "Parse Inputs"
+        id: parse
+        uses: actions/github-script@v6
+        with:
+          # The bash to do this is hard but the JS is trivial.
+          script: |
+            ["app-versions", "chart-versions", "chart-releases", "environments", "clusters", "charts", "changesets"].forEach((input) => {
+              core.setOutput(input, JSON.stringify(core.getInput(input).split(/[\s,]+/))))
+            })
+
+      - name: "Write Request Body"
+        shell: bash
+        run: |
+          echo '{
+            "appVersions": ${{ steps.parse.outputs.app-versions }},
+            "chartVersions": ${{ steps.parse.outputs.chart-versions }},
+            "chartReleases": ${{ steps.parse.outputs.chart-releases }},
+            "environments": ${{ steps.parse.outputs.environments }},
+            "clusters": ${{ steps.parse.outputs.clusters }},
+            "charts": ${{ steps.parse.outputs.charts }},
+            "changesets": ${{ steps.parse.outputs.changesets }}
+          }' > "$RUNNER_TEMP/body.json"
+
+      - name: "Log Request Body"
+        shell: bash
+        run: |
+          cat "$RUNNER_TEMP/body.json"
+
+      - name: "Authenticate to GCP"
+        id: iap_auth
+        uses: google-github-actions/auth@v1
+        with:
+          workload_identity_provider: "projects/1038484894585/locations/global/workloadIdentityPools/github-wi-pool/providers/github-wi-provider"
+          service_account: "dsp-tools-iap-access@dsp-tools-k8s.iam.gserviceaccount.com"
+          token_format: "id_token"
+          id_token_audience: "1038484894585-k8qvf7l876733laev0lm8kenfa2lj6bn.apps.googleusercontent.com"
+          id_token_include_email: true
+          create_credentials_file: false
+          export_environment_variables: false
+
+      - name: "Generate GHA OIDC Token"
+        id: gha_auth
+        uses: actions/github-script@v6
+        with:
+          script: core.setOutput('id_token', await core.getIDToken())
+
+      - name: "Send to Sherlock"
+        shell: bash
+        run: |
+          set -ex
+          curl --fail-with-body -X 'PATCH' \
+            "$SHERLOCK_PROD_URL/api/v2/ci-runs/github-actions/${{ github.repository }}/${{ github.run_id }}/${{ github.run_attempt }}" \
+            -H 'Content-Type: application/json' \
+            -H 'Authorization: Bearer ${{ steps.iap_auth.outputs.id_token }}' \
+            -H 'X-GHA-OIDC-JWT: ${{ steps.gha_auth.outputs.id_token }}' \
+            -d "@$RUNNER_TEMP/body.json" | jq

--- a/.github/workflows/client-report-workflow-related-resources.yaml
+++ b/.github/workflows/client-report-workflow-related-resources.yaml
@@ -114,7 +114,7 @@ env:
   SHERLOCK_PROD_URL: "https://sherlock.dsp-devops.broadinstitute.org"
 
 jobs:
-  report-workflow-impacts:
+  report-workflow-relations:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -122,25 +122,37 @@ jobs:
       - name: "Parse Inputs"
         id: parse
         uses: actions/github-script@v6
+        env:
+          APP_VERSIONS: ${{ inputs.app-versions }}
+          CHART_VERSIONS: ${{ inputs.chart-versions }}
+          CHART_RELEASES: ${{ inputs.chart-releases }}
+          ENVIRONMENTS: ${{ inputs.environments }}
+          CLUSTERS: ${{ inputs.clusters }}
+          CHARTS: ${{ inputs.charts }}
+          CHANGESETS: ${{ inputs.changesets }}
         with:
           # The bash to do this is hard but the JS is trivial.
           script: |
-            ["app-versions", "chart-versions", "chart-releases", "environments", "clusters", "charts", "changesets"].forEach((input) => {
-              core.setOutput(input, JSON.stringify(core.getInput(input).split(/[\s,]+/)))
-            })
+            core.setOutput("body", JSON.stringify({
+              appVersions: process.env.APP_VERSIONS.split(/[\s,]+/).filter(Boolean),
+              chartVersions: process.env.CHART_VERSIONS.split(/[\s,]+/).filter(Boolean),
+              chartReleases: process.env.CHART_RELEASES.split(/[\s,]+/).filter(Boolean),
+              environments: process.env.ENVIRONMENTS.split(/[\s,]+/).filter(Boolean),
+              clusters: process.env.CLUSTERS.split(/[\s,]+/).filter(Boolean),
+              charts: process.env.CHARTS.split(/[\s,]+/).filter(Boolean),
+              changesets: process.env.CHANGESETS.split(/[\s,]+/).filter(Boolean),
+              githubActionsAttemptNumber: ${{ github.run_attempt }},
+              githubActionsOwner: "${{ github.repository }}".split("/")[0],
+              githubActionsRepo: "${{ github.repository }}".split("/")[1],
+              githubActionsRunID: ${{ github.run_id }},
+              githubActionsWorkflowPath: "${{ github.workflow_ref }}".slice("${{ github.repository }}".length).split("@")[0],
+              platform: "github-actions"
+            }))
 
       - name: "Write Request Body"
         shell: bash
         run: |
-          echo '{
-            "appVersions": ${{ steps.parse.outputs.app-versions }},
-            "chartVersions": ${{ steps.parse.outputs.chart-versions }},
-            "chartReleases": ${{ steps.parse.outputs.chart-releases }},
-            "environments": ${{ steps.parse.outputs.environments }},
-            "clusters": ${{ steps.parse.outputs.clusters }},
-            "charts": ${{ steps.parse.outputs.charts }},
-            "changesets": ${{ steps.parse.outputs.changesets }}
-          }' > "$RUNNER_TEMP/body.json"
+          echo '${{ steps.parse.outputs.body }}' > "$RUNNER_TEMP/body.json"
 
       - name: "Log Request Body"
         shell: bash
@@ -163,13 +175,13 @@ jobs:
         id: gha_auth
         uses: actions/github-script@v6
         with:
-          script: core.setOutput('id_token', await core.getIDToken())
+          script: core.setOutput("id_token", await core.getIDToken())
 
       - name: "Send to Sherlock"
         shell: bash
         run: |
           set -ex
-          curl --fail-with-body -X 'PATCH' \
+          curl --fail-with-body -X 'PUT' \
             "$SHERLOCK_PROD_URL/api/v2/ci-runs/github-actions/${{ github.repository }}/${{ github.run_id }}/${{ github.run_attempt }}" \
             -H 'Content-Type: application/json' \
             -H 'Authorization: Bearer ${{ steps.iap_auth.outputs.id_token }}' \

--- a/.github/workflows/client-set-environment-app-version.yaml
+++ b/.github/workflows/client-set-environment-app-version.yaml
@@ -86,40 +86,11 @@ on:
         required: true
         type: string
         description: "The name of the environment to update"
-      
-      ##
-      ## Sherlock configuration:
-      ##
-
-      use-sherlock-prod:
-        required: false
-        type: boolean
-        default: true
-        description: "If the version should be reported to the general-use production Sherlock instance"
-      fail-on-prod-failure:
-        required: false
-        type: boolean
-        default: true
-        description: "If an issue communicating with production Sherlock should cause an overall failure"
-
-      use-sherlock-dev:
-        required: false
-        type: boolean
-        default: true
-        description: "If the version should be reported to the DevOps-use development Sherlock instance"
-      fail-on-dev-failure:
-        required: false
-        type: boolean
-        default: false
-        description: "If an issue communicating with development Sherlock should cause an overall failure"
 
 env:
   SHERLOCK_PROD_URL: 'https://sherlock.dsp-devops.broadinstitute.org'
-  SHERLOCK_DEV_URL: 'https://sherlock-dev.dsp-devops.broadinstitute.org'
   BEEHIVE_PROD_URL: 'https://beehive.dsp-devops.broadinsitute.org'
-  BEEHIVE_DEV_URL: 'https://beehive-dev.dsp-devops.broadinstitute.org'
   BEEHIVE_PROD_VANITY_URL: 'https://broad.io/beehive'
-  BEEHIVE_DEV_VANITY_URL: 'https://broad.io/beehive-dev'
 
 jobs:
   get-chart-release:
@@ -132,6 +103,8 @@ jobs:
   set-version:
     needs: get-chart-release
     runs-on: ubuntu-22.04
+    outputs:
+      changesets: ${{ steps.changesets.outputs.changesets }}
     permissions:
       id-token: 'write'
     
@@ -182,9 +155,7 @@ jobs:
         with:
           script: core.setOutput('id_token', await core.getIDToken())
       
-      - name: "Send to Sherlock Prod"
-        if: ${{ inputs.use-sherlock-prod }}
-        continue-on-error: ${{ !inputs.fail-on-prod-failure }}
+      - name: "Send to Sherlock"
         shell: bash
         run: |
           set -ex
@@ -193,21 +164,24 @@ jobs:
             -H 'Content-Type: application/json' \
             -H 'Authorization: Bearer ${{ steps.iap_auth.outputs.id_token }}' \
             -H 'X-GHA-OIDC-JWT: ${{ steps.gha_auth.outputs.id_token }}' \
-            -d "@$RUNNER_TEMP/body.json" | jq
+            -d "@$RUNNER_TEMP/body.json" | jq > $RUNNER_TEMP/response.json
+          cat $RUNNER_TEMP/response.json
           echo "### Available in Beehive at $BEEHIVE_PROD_VANITY_URL/r/chart-release/${{ inputs.environment-name }}/${{ inputs.chart-name }}" >> $GITHUB_STEP_SUMMARY
 
-      - name: "Send to Sherlock Dev"
-        if: ${{ inputs.use-sherlock-dev }}
-        continue-on-error: ${{ !inputs.fail-on-dev-failure }}
+      - name: "Parse changesets"
+        id: changesets
         shell: bash
         run: |
           set -ex
-          curl --fail-with-body -X 'POST' \
-            "$SHERLOCK_DEV_URL/api/v2/procedures/changesets/plan-and-apply" \
-            -H 'Content-Type: application/json' \
-            -H 'Authorization: Bearer ${{ steps.iap_auth.outputs.id_token }}' \
-            -H 'X-GHA-OIDC-JWT: ${{ steps.gha_auth.outputs.id_token }}' \
-            -d "@$RUNNER_TEMP/body.json" | jq
+          echo "changesets=$(cat $RUNNER_TEMP/response.json | jq -r 'map(.id) | join(",")')" >> $GITHUB_OUTPUT
+
+  report-workflow-relation:
+    uses: ./.github/workflows/client-report-workflow-related-resources.yaml
+    needs: set-version
+    with:
+      changesets: ${{ needs.set-version.outputs.changesets }}
+    permissions:
+      id-token: write
 
   can-sync:
     runs-on: ubuntu-22.04

--- a/.github/workflows/client-set-environment-chart-version.yaml
+++ b/.github/workflows/client-set-environment-chart-version.yaml
@@ -88,40 +88,11 @@ on:
         required: true
         type: string
         description: "The name of the environment to update"
-      
-      ##
-      ## Sherlock configuration:
-      ##
-
-      use-sherlock-prod:
-        required: false
-        type: boolean
-        default: true
-        description: "If the version should be reported to the general-use production Sherlock instance"
-      fail-on-prod-failure:
-        required: false
-        type: boolean
-        default: true
-        description: "If an issue communicating with production Sherlock should cause an overall failure"
-
-      use-sherlock-dev:
-        required: false
-        type: boolean
-        default: true
-        description: "If the version should be reported to the DevOps-use development Sherlock instance"
-      fail-on-dev-failure:
-        required: false
-        type: boolean
-        default: false
-        description: "If an issue communicating with development Sherlock should cause an overall failure"
 
 env:
   SHERLOCK_PROD_URL: 'https://sherlock.dsp-devops.broadinstitute.org'
-  SHERLOCK_DEV_URL: 'https://sherlock-dev.dsp-devops.broadinstitute.org'
   BEEHIVE_PROD_URL: 'https://beehive.dsp-devops.broadinsitute.org'
-  BEEHIVE_DEV_URL: 'https://beehive-dev.dsp-devops.broadinstitute.org'
   BEEHIVE_PROD_VANITY_URL: 'https://broad.io/beehive'
-  BEEHIVE_DEV_VANITY_URL: 'https://broad.io/beehive-dev'
 
 jobs:
   get-chart-release:
@@ -134,6 +105,8 @@ jobs:
   set-version:
     needs: get-chart-release
     runs-on: ubuntu-22.04
+    outputs:
+      changesets: ${{ steps.changesets.outputs.changesets }}
     permissions:
       id-token: 'write'
     
@@ -184,9 +157,7 @@ jobs:
         with:
           script: core.setOutput('id_token', await core.getIDToken())
       
-      - name: "Send to Sherlock Prod"
-        if: ${{ inputs.use-sherlock-prod }}
-        continue-on-error: ${{ !inputs.fail-on-prod-failure }}
+      - name: "Send to Sherlock"
         shell: bash
         run: |
           set -ex
@@ -195,21 +166,24 @@ jobs:
             -H 'Content-Type: application/json' \
             -H 'Authorization: Bearer ${{ steps.iap_auth.outputs.id_token }}' \
             -H 'X-GHA-OIDC-JWT: ${{ steps.gha_auth.outputs.id_token }}' \
-            -d "@$RUNNER_TEMP/body.json" | jq
+            -d "@$RUNNER_TEMP/body.json" | jq > $RUNNER_TEMP/response.json
+          cat $RUNNER_TEMP/response.json
           echo "### Available in Beehive at $BEEHIVE_PROD_VANITY_URL/r/chart-release/${{ inputs.environment-name }}/${{ inputs.chart-name }}" >> $GITHUB_STEP_SUMMARY
 
-      - name: "Send to Sherlock Dev"
-        if: ${{ inputs.use-sherlock-dev }}
-        continue-on-error: ${{ !inputs.fail-on-dev-failure }}
+      - name: "Parse changesets"
+        id: changesets
         shell: bash
         run: |
           set -ex
-          curl --fail-with-body -X 'POST' \
-            "$SHERLOCK_DEV_URL/api/v2/procedures/changesets/plan-and-apply" \
-            -H 'Content-Type: application/json' \
-            -H 'Authorization: Bearer ${{ steps.iap_auth.outputs.id_token }}' \
-            -H 'X-GHA-OIDC-JWT: ${{ steps.gha_auth.outputs.id_token }}' \
-            -d "@$RUNNER_TEMP/body.json" | jq
+          echo "changesets=$(cat $RUNNER_TEMP/response.json | jq -r 'map(.id) | join(",")')" >> $GITHUB_OUTPUT
+
+  report-workflow-relation:
+    uses: ./.github/workflows/client-report-workflow-related-resources.yaml
+    needs: set-version
+    with:
+      changesets: ${{ needs.set-version.outputs.changesets }}
+    permissions:
+      id-token: write
 
   can-sync:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
This PR does three things, all related to the "client" workflows that Sherlock's repo offers.
1. Remove calls to sherlock-dev (hundreds lines of complexity and confusing error codes for no reason)
2. Add a workflow that hits [this endpoint](https://sherlock.dsp-devops.broadinstitute.org/swagger/index.html#/CiRuns/put_api_v2_ci_runs__selector_) to tell Sherlock "this action affected X" (this is the same endpoint that webhooks hit, and the selectors line up, so this is editing the same CiRun that the webhook created. There's no race condition here, it's okay if one or the other gets delayed -- they're upsert operations.)
3. Add said workflow to the other client workflows. So if you report a new app version, automatically your GHA will be flagged as being related to that app version. If you set an app version in an environment, the impacted chart release, cluster, environment, app version will all be considered related to the GHA.

## Testing

I made a branch in Beehive and have been lobbing spurious commits at the report-app-version mechanism since last week. I also testing the "set app version in an environment" mechanism by making some spurious commits to the java template's main branch. I've verified in Sherlock's API that it works.

[Here's an example of the reporting happening from creating a new app version.](https://github.com/broadinstitute/beehive/actions/runs/5325460335/jobs/9646235278)

[Here's an example of the reporting happening when putting a new app version into an environment.](https://github.com/DataBiosphere/terra-java-project-template/actions/runs/5326807594/jobs/9649496146)

## Risk

If there's an issue, the workflow will fail but it'll have had the correct effect with Sherlock already, so remedial effort will be minimal.