### PR TITLE
[DDO-2944] Fix type

### DIFF
--- a/sherlock/internal/api/sherlock/ci_runs_v3.go
+++ b/sherlock/internal/api/sherlock/ci_runs_v3.go
@@ -21,8 +21,8 @@ type ciRunFields struct {
 	ArgoWorkflowsNamespace     string     `json:"argoWorkflowsNamespace" form:"argoWorkflowsNamespace"`
 	ArgoWorkflowsName          string     `json:"argoWorkflowsName" form:"argoWorkflowsName"`
 	ArgoWorkflowsTemplate      string     `json:"argoWorkflowsTemplate" form:"argoWorkflowsTemplate"`
-	StartedAt                  *time.Time `json:"startedAt,omitempty" form:"-"`
-	TerminalAt                 *time.Time `json:"terminalAt,omitempty" form:"-"`
+	StartedAt                  *time.Time `json:"startedAt,omitempty" form:"startedAt"`
+	TerminalAt                 *time.Time `json:"terminalAt,omitempty" form:"terminalAt"`
 	Status                     *string    `json:"status,omitempty" form:"status"`
 }
 


### PR DESCRIPTION
Turns out the Go client library generator is pickier about the Swagger spec than the Swagger spec generator is. Whatever -- these two fields need to be available from the query parameters even if there's not much practical use for specifying a time in milliseconds from query parameters.