### PR TITLE
[DDO-2976] Improve Sherlock's liveness endpoint

### DIFF
--- a/sherlock/config/default_config.yaml
+++ b/sherlock/config/default_config.yaml
@@ -19,6 +19,8 @@ db:
   maxOpenConnections: 75
   init: true
 
+  livenessPingInterval: 10s
+
   # retryConnection will repeatedly try to connect to the database to allow it to come online.
   # Helpful to account for delay in either the Cloud SQL proxy (for release mode) or a local Postgres
   # (for debug mode) starting up simultaneously with Sherlock.

--- a/sherlock/internal/boot/application.go
+++ b/sherlock/internal/boot/application.go
@@ -127,7 +127,6 @@ func (a *Application) Stop() {
 		log.Info().Msgf("BOOT | making liveness endpoint not check database anymore...")
 		a.livenessServer.MakeAlwaysReturnOK()
 	} else {
-
 		log.Info().Msgf("BOOT | no liveness server reference, skipping making liveness endpoint not check database")
 	}
 

--- a/sherlock/internal/boot/application.go
+++ b/sherlock/internal/boot/application.go
@@ -17,10 +17,11 @@ import (
 )
 
 type Application struct {
-	sqlDB     *sql.DB
-	gormDB    *gorm.DB
-	cancelCtx context.CancelFunc
-	server    *http.Server
+	sqlDB          *sql.DB
+	livenessServer *liveness.Server
+	gormDB         *gorm.DB
+	cancelCtx      context.CancelFunc
+	server         *http.Server
 
 	// runInsideDatabaseTransaction begins a transaction on the gorm.DB after migration and rolls it back
 	// before closing the connection. This makes Start + Stop safe to run from tests, because they won't
@@ -37,7 +38,8 @@ func (a *Application) Start() {
 	}
 
 	log.Info().Msgf("BOOT | starting liveness endpoint...")
-	go liveness.Start()
+	a.livenessServer = &liveness.Server{}
+	go a.livenessServer.Start(a.sqlDB)
 
 	log.Info().Msgf("BOOT | migrating database and configuring Gorm...")
 	if gormDB, err := db.Configure(a.sqlDB); err != nil {
@@ -121,6 +123,14 @@ func (a *Application) Stop() {
 		a.gormDB.Rollback()
 	}
 
+	if a.livenessServer != nil {
+		log.Info().Msgf("BOOT | making liveness endpoint not check database anymore...")
+		a.livenessServer.MakeAlwaysReturnOK()
+	} else {
+
+		log.Info().Msgf("BOOT | no liveness server reference, skipping making liveness endpoint not check database")
+	}
+
 	if a.sqlDB != nil {
 		log.Info().Msgf("BOOT | closing database connections...")
 		if err := a.sqlDB.Close(); err != nil {
@@ -130,7 +140,12 @@ func (a *Application) Stop() {
 		log.Info().Msgf("BOOT | no SQL database reference, skipping closing database connections")
 	}
 
-	log.Info().Msgf("BOOT | stopping liveness endpoint...")
-	liveness.Stop()
+	if a.livenessServer != nil {
+		log.Info().Msgf("BOOT | stopping liveness endpoint...")
+		a.livenessServer.Stop()
+	} else {
+		log.Info().Msgf("BOOT | no liveness server reference, skipping stopping liveness endpoint")
+	}
+
 	log.Info().Msgf("BOOT | exiting...")
 }

--- a/sherlock/internal/boot/application_test.go
+++ b/sherlock/internal/boot/application_test.go
@@ -20,7 +20,7 @@ func TestApplication_StartStop(t *testing.T) {
 		attemptsRemaining := 4 * 20
 		for ; attemptsRemaining >= 0 && !livenessSucceeded; attemptsRemaining-- {
 			resp, err := http.Get("http://localhost:8081")
-			if err == nil && resp.StatusCode == 200 {
+			if err == nil && resp.StatusCode == http.StatusOK {
 				livenessSucceeded = true
 			} else {
 				time.Sleep(time.Second / 4)
@@ -28,7 +28,7 @@ func TestApplication_StartStop(t *testing.T) {
 		}
 		for ; attemptsRemaining >= 0 && !readinessSucceeded; attemptsRemaining-- {
 			resp, err := http.Get("http://localhost:8080/status")
-			if err == nil && resp.StatusCode == 200 {
+			if err == nil && resp.StatusCode == http.StatusOK {
 				readinessSucceeded = true
 			} else {
 				time.Sleep(time.Second / 4)
@@ -38,5 +38,4 @@ func TestApplication_StartStop(t *testing.T) {
 		assert.Truef(t, livenessSucceeded, ":8081 returned 200")
 		assert.Truef(t, readinessSucceeded, ":8080/status returned 200")
 	})
-
 }

--- a/sherlock/internal/boot/liveness/server.go
+++ b/sherlock/internal/boot/liveness/server.go
@@ -2,32 +2,91 @@ package liveness
 
 import (
 	"context"
+	"database/sql"
+	"github.com/broadinstitute/sherlock/sherlock/internal/config"
 	"github.com/rs/zerolog/log"
 	"net/http"
 	"time"
 )
 
-var livenessServer = &http.Server{
-	Addr:    ":8081",
-	Handler: livenessHandler{},
+type Server struct {
+	sqlDB         *sql.DB
+	handler       *handler
+	server        *http.Server
+	pingCtx       context.Context
+	cancelPingCtx context.CancelFunc
 }
 
-type livenessHandler struct{}
-
-func (h livenessHandler) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
-	_, _ = w.Write([]byte("OK"))
-}
-
-func Start() {
-	if err := livenessServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-		log.Fatal().Msgf("livenessServer.ListenAndServe() err: %v", err)
+func (s *Server) Start(sqlDB *sql.DB) {
+	s.sqlDB = sqlDB
+	s.pingCtx, s.cancelPingCtx = context.WithCancel(context.Background())
+	s.handler = &handler{
+		returnOK: s.sqlDB.PingContext(s.pingCtx) == nil,
+	}
+	s.server = &http.Server{
+		Addr:    ":8081",
+		Handler: s.handler,
+	}
+	go s.repeatedlyPingDatabase()
+	if err := s.server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		log.Fatal().Msgf("LIVE | liveness.Server.server.ListenAndServe() err: %v", err)
 	}
 }
 
-func Stop() {
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
-	if err := livenessServer.Shutdown(ctx); err != nil {
-		log.Fatal().Msgf("livenessServer.Shutdown() err: %v", err)
+func (s *Server) repeatedlyPingDatabase() {
+	interval := config.Config.MustDuration("db.livenessPingInterval")
+	for {
+		if err := s.sqlDB.PingContext(s.pingCtx); err == nil {
+			s.handler.returnOK = true
+		} else {
+			s.handler.returnOK = false
+			log.Error().Msgf("LIVE | liveness.Server.sqlDB.PingContext(liveness.Server.pingCtx) err: %v", err)
+		}
+		select {
+		case <-time.After(interval):
+		case <-s.pingCtx.Done():
+			return
+		}
+	}
+}
+
+// MakeAlwaysReturnOK exists to make the liveness Server suddenly not care about the database connection anymore.
+// This is to allow the database connection to be shut down without the liveness endpoint reporting that Sherlock
+// is unhealthy.
+// In other words, there's actually one time when we want Sherlock to report as "alive" even if its database
+// connection is offline: during shutdown. This function exists to facilitate that.
+func (s *Server) MakeAlwaysReturnOK() {
+	if s.cancelPingCtx != nil {
+		s.cancelPingCtx()
+	}
+	if s.handler != nil {
+		s.handler.returnOK = true
+	}
+}
+
+func (s *Server) Stop() {
+	if s.cancelPingCtx != nil {
+		s.cancelPingCtx()
+	}
+	if s.server != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		if err := s.server.Shutdown(ctx); err != nil {
+			log.Fatal().Msgf("LIVE | liveness.Server.server.Shutdown() err: %v", err)
+		}
+	}
+}
+
+type handler struct {
+	returnOK bool
+}
+
+func (h *handler) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
+	if h.returnOK {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("OK"))
+	} else {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("NOT OK"))
 	}
 }

--- a/sherlock/internal/boot/liveness/server_test.go
+++ b/sherlock/internal/boot/liveness/server_test.go
@@ -1,0 +1,82 @@
+package liveness
+
+import (
+	"github.com/broadinstitute/sherlock/sherlock/internal/config"
+	"github.com/broadinstitute/sherlock/sherlock/internal/db"
+	"github.com/stretchr/testify/assert"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestServer_Lifecycle(t *testing.T) {
+	config.LoadTestConfig()
+	sqlDB, err := db.Connect()
+	assert.NoError(t, err)
+	server := &Server{}
+	go server.Start(sqlDB)
+	t.Run("online probe", func(t *testing.T) {
+		var livenessSucceeded bool
+		attemptsRemaining := 4 * 20
+		for ; attemptsRemaining >= 0 && !livenessSucceeded; attemptsRemaining-- {
+			resp, err := http.Get("http://localhost:8081")
+			if err == nil && resp.StatusCode == http.StatusOK {
+				livenessSucceeded = true
+			} else {
+				time.Sleep(time.Second / 4)
+			}
+		}
+		assert.True(t, livenessSucceeded)
+	})
+	t.Run("offline probe", func(t *testing.T) {
+		server.MakeAlwaysReturnOK()
+		resp, err := http.Get("http://localhost:8081")
+		assert.NoError(t, err)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+	})
+	server.Stop()
+}
+
+func TestServer_MakeAlwaysReturnOK(t *testing.T) {
+	var cancelCalled bool
+	server := &Server{
+		cancelPingCtx: func() {
+			cancelCalled = true
+		},
+		handler: &handler{
+			returnOK: false,
+		},
+	}
+	server.MakeAlwaysReturnOK()
+	assert.True(t, cancelCalled)
+	assert.True(t, server.handler.returnOK)
+}
+
+func Test_handler_ServeHTTP(t *testing.T) {
+	t.Run("returns OK", func(t *testing.T) {
+		handlerInstance := &handler{}
+		handlerInstance.returnOK = true
+		req := httptest.NewRequest("GET", "/", nil)
+		w := httptest.NewRecorder()
+		handlerInstance.ServeHTTP(w, req)
+		resp := w.Result()
+		body, err := io.ReadAll(resp.Body)
+		assert.NoError(t, err)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.Equal(t, "OK", string(body))
+	})
+	t.Run("returns NOT OK", func(t *testing.T) {
+		handlerInstance := &handler{}
+		handlerInstance.returnOK = false
+		req := httptest.NewRequest("GET", "/", nil)
+		w := httptest.NewRecorder()
+		handlerInstance.ServeHTTP(w, req)
+		resp := w.Result()
+		body, err := io.ReadAll(resp.Body)
+		assert.NoError(t, err)
+		assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+		assert.Equal(t, "NOT OK", string(body))
+	})
+}

--- a/sherlock/internal/boot/liveness/server_test.go
+++ b/sherlock/internal/boot/liveness/server_test.go
@@ -30,6 +30,8 @@ func TestServer_Lifecycle(t *testing.T) {
 		}
 		assert.True(t, livenessSucceeded)
 	})
+	err = sqlDB.Close()
+	assert.NoError(t, err)
 	t.Run("offline probe", func(t *testing.T) {
 		server.MakeAlwaysReturnOK()
 		resp, err := http.Get("http://localhost:8081")


### PR DESCRIPTION
It now uses the sql package's Ping method to check that the database connection is healthy, on a configurable interval.

It doesn't try to preemptively exit, it just makes the liveness endpoint return differently so that Kubernetes handles it.

The lifecycle technically looks like this:

1. `Server.Start()`
2. `Server.MakeAlwaysReturnOK()`
3. `Server.Stop()`

That second step is a bit of a technicality. When we shut down Sherlock, we don't want the liveness probe evaluating the health of the database connection pool as we drain it--we want it to still consider Sherlock alive while it is shutting down, so Kubernetes doesn't get trigger-happy. We call `Server.MakeAlwaysReturnOK()` right before initiating the database disconnect during shutdown to get the behavior we want.

> **Note**
> In reality, this doesn't matter much. Kubernetes has but one terminationGracePeriodSeconds, so even if it notices Sherlock unhealthy during its shutdown... what is it going to do, send another SIGTERM with a longer deadline than the one we're already on?
>
> But I don't like writing technically incorrect code just because I happen to know how Kubernetes works, so here we are.

## Testing

I wrote tests for the entire liveness package to go along with this PR, though there's secondary coverage via the application start/stop test.

## Risk

Super low. If there's an issue, should rear its head in dev.