### PR TITLE
[DDO-2981] Improve app/chart version CI reporting based on changesets

### DIFF
--- a/sherlock/go.mod
+++ b/sherlock/go.mod
@@ -53,7 +53,7 @@ require (
 	github.com/go-openapi/swag v0.22.3 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
-	github.com/go-playground/validator/v10 v10.14.0 // indirect
+	github.com/go-playground/validator/v10 v10.14.1 // indirect
 	github.com/goccy/go-json v0.10.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.3 // indirect

--- a/sherlock/go.sum
+++ b/sherlock/go.sum
@@ -177,8 +177,6 @@ github.com/go-playground/locales v0.14.1 h1:EWaQ/wswjilfKLTECiXz7Rh+3BjFhfDFKv/o
 github.com/go-playground/locales v0.14.1/go.mod h1:hxrqLVvrK65+Rwrd5Fc6F2O76J/NuW9t0sjnWqG1slY=
 github.com/go-playground/universal-translator v0.18.1 h1:Bcnm0ZwsGyWbCzImXv+pAJnYK9S473LQFuzCbDbfSFY=
 github.com/go-playground/universal-translator v0.18.1/go.mod h1:xekY+UJKNuX9WP91TpwSH2VMlDf28Uj24BCp08ZFTUY=
-github.com/go-playground/validator/v10 v10.14.0 h1:vgvQWe3XCz3gIeFDm/HnTIbj6UGmg/+t63MyGU2n5js=
-github.com/go-playground/validator/v10 v10.14.0/go.mod h1:9iXMNT7sEkjXb0I+enO7QXmzG6QCsPWY4zveKFVRSyU=
 github.com/go-playground/validator/v10 v10.14.1 h1:9c50NUPC30zyuKprjL3vNZ0m5oG+jU0zvx4AqHGnv4k=
 github.com/go-playground/validator/v10 v10.14.1/go.mod h1:9iXMNT7sEkjXb0I+enO7QXmzG6QCsPWY4zveKFVRSyU=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=

--- a/sherlock/go.sum
+++ b/sherlock/go.sum
@@ -179,6 +179,8 @@ github.com/go-playground/universal-translator v0.18.1 h1:Bcnm0ZwsGyWbCzImXv+pAJn
 github.com/go-playground/universal-translator v0.18.1/go.mod h1:xekY+UJKNuX9WP91TpwSH2VMlDf28Uj24BCp08ZFTUY=
 github.com/go-playground/validator/v10 v10.14.0 h1:vgvQWe3XCz3gIeFDm/HnTIbj6UGmg/+t63MyGU2n5js=
 github.com/go-playground/validator/v10 v10.14.0/go.mod h1:9iXMNT7sEkjXb0I+enO7QXmzG6QCsPWY4zveKFVRSyU=
+github.com/go-playground/validator/v10 v10.14.1 h1:9c50NUPC30zyuKprjL3vNZ0m5oG+jU0zvx4AqHGnv4k=
+github.com/go-playground/validator/v10 v10.14.1/go.mod h1:9iXMNT7sEkjXb0I+enO7QXmzG6QCsPWY4zveKFVRSyU=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-test/deep v1.0.2-0.20181118220953-042da051cf31/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/goccy/go-json v0.10.2 h1:CrxCmQqYDkv1z7lO7Wbh2HN93uovUHgrECaO5ZrCXAU=

--- a/sherlock/internal/api/sherlock/ci_identifiers_v3_get.go
+++ b/sherlock/internal/api/sherlock/ci_identifiers_v3_get.go
@@ -32,24 +32,24 @@ func ciIdentifiersV3Get(ctx *gin.Context) {
 	}
 	query, err := ciIdentifierModelFromSelector(db, canonicalizeSelector(ctx.Param("selector")))
 	if err != nil {
-		ctx.AbortWithStatusJSON(errors.ErrorToApiResponse(err))
+		errors.AbortRequest(ctx, err)
 		return
 	}
 	limitCiRuns, err := utils.ParseInt(ctx.DefaultQuery("limitCiRuns", "10"))
 	if err != nil {
-		ctx.AbortWithStatusJSON(errors.ErrorToApiResponse(fmt.Errorf("(%s) %v", errors.BadRequest, err)))
+		errors.AbortRequest(ctx, fmt.Errorf("(%s) %v", errors.BadRequest, err))
 		return
 	}
 	offsetCiRuns, err := utils.ParseInt(ctx.DefaultQuery("offsetCiRuns", "0"))
 	if err != nil {
-		ctx.AbortWithStatusJSON(errors.ErrorToApiResponse(fmt.Errorf("(%s) %v", errors.BadRequest, err)))
+		errors.AbortRequest(ctx, fmt.Errorf("(%s) %v", errors.BadRequest, err))
 		return
 	}
 	var result models.CiIdentifier
 	if err = db.Preload("CiRuns", func(tx *gorm.DB) *gorm.DB {
 		return tx.Limit(limitCiRuns).Offset(offsetCiRuns).Order("started_at desc")
 	}).Where(&query).First(&result).Error; err != nil {
-		ctx.AbortWithStatusJSON(errors.ErrorToApiResponse(err))
+		errors.AbortRequest(ctx, err)
 		return
 	}
 	ctx.JSON(http.StatusOK, ciIdentifierFromModel(result))

--- a/sherlock/internal/api/sherlock/ci_identifiers_v3_list.go
+++ b/sherlock/internal/api/sherlock/ci_identifiers_v3_list.go
@@ -37,17 +37,17 @@ func ciIdentifiersV3List(ctx *gin.Context) {
 	modelFilter := filter.toModel()
 	limit, err := utils.ParseInt(ctx.DefaultQuery("limit", "100"))
 	if err != nil {
-		ctx.AbortWithStatusJSON(errors.ErrorToApiResponse(fmt.Errorf("(%s) %v", errors.BadRequest, err)))
+		errors.AbortRequest(ctx, fmt.Errorf("(%s) %v", errors.BadRequest, err))
 		return
 	}
 	offset, err := utils.ParseInt(ctx.DefaultQuery("offset", "0"))
 	if err != nil {
-		ctx.AbortWithStatusJSON(errors.ErrorToApiResponse(fmt.Errorf("(%s) %v", errors.BadRequest, err)))
+		errors.AbortRequest(ctx, fmt.Errorf("(%s) %v", errors.BadRequest, err))
 		return
 	}
 	var results []models.CiIdentifier
 	if err = db.Where(&modelFilter).Limit(limit).Offset(offset).Order("created_at desc").Find(&results).Error; err != nil {
-		ctx.AbortWithStatusJSON(errors.ErrorToApiResponse(err))
+		errors.AbortRequest(ctx, err)
 		return
 	}
 	ctx.JSON(http.StatusOK, utils.Map(results, ciIdentifierFromModel))

--- a/sherlock/internal/api/sherlock/ci_runs_v3_get.go
+++ b/sherlock/internal/api/sherlock/ci_runs_v3_get.go
@@ -29,12 +29,12 @@ func ciRunsV3Get(ctx *gin.Context) {
 	}
 	query, err := ciRunModelFromSelector(canonicalizeSelector(ctx.Param("selector")))
 	if err != nil {
-		ctx.AbortWithStatusJSON(errors.ErrorToApiResponse(err))
+		errors.AbortRequest(ctx, err)
 		return
 	}
 	var result models.CiRun
 	if err = db.Preload(clause.Associations).Where(&query).First(&result).Error; err != nil {
-		ctx.AbortWithStatusJSON(errors.ErrorToApiResponse(err))
+		errors.AbortRequest(ctx, err)
 		return
 	}
 	ctx.JSON(http.StatusOK, ciRunFromModel(result))

--- a/sherlock/internal/api/sherlock/ci_runs_v3_list.go
+++ b/sherlock/internal/api/sherlock/ci_runs_v3_list.go
@@ -36,17 +36,17 @@ func ciRunsV3List(ctx *gin.Context) {
 	modelFilter := filter.toModel()
 	limit, err := utils.ParseInt(ctx.DefaultQuery("limit", "100"))
 	if err != nil {
-		ctx.AbortWithStatusJSON(errors.ErrorToApiResponse(fmt.Errorf("(%s) %v", errors.BadRequest, err)))
+		errors.AbortRequest(ctx, fmt.Errorf("(%s) %v", errors.BadRequest, err))
 		return
 	}
 	offset, err := utils.ParseInt(ctx.DefaultQuery("offset", "0"))
 	if err != nil {
-		ctx.AbortWithStatusJSON(errors.ErrorToApiResponse(fmt.Errorf("(%s) %v", errors.BadRequest, err)))
+		errors.AbortRequest(ctx, fmt.Errorf("(%s) %v", errors.BadRequest, err))
 		return
 	}
 	var results []models.CiRun
 	if err = db.Where(&modelFilter).Limit(limit).Offset(offset).Order("started_at desc").Find(&results).Error; err != nil {
-		ctx.AbortWithStatusJSON(errors.ErrorToApiResponse(err))
+		errors.AbortRequest(ctx, err)
 		return
 	}
 	ctx.JSON(http.StatusOK, utils.Map(results, ciRunFromModel))

--- a/sherlock/internal/api/sherlock/ci_runs_v3_upsert.go
+++ b/sherlock/internal/api/sherlock/ci_runs_v3_upsert.go
@@ -24,7 +24,7 @@ type CiRunV3Upsert struct {
 	Environments  []string `json:"environments"`  // Always appends; will eliminate duplicates. Spreads to contained chart releases and their clusters.
 	ChartReleases []string `json:"chartReleases"` // Always appends; will eliminate duplicates. Spreads to associated environments and clusters.
 	Changesets    []string `json:"changesets"`    // Always appends; will eliminate duplicates. Spreads to associated chart releases, environments, and clusters.
-	// Makes entries in the changesets field also spread to new app versions and chart versions deployed by the changeset. 'when-static' is the default and spreads when the chart release is in a static environment.
+	// Makes entries in the changesets field also spread to new app versions and chart versions deployed by the changeset. 'when-static' is the default and does this spreading only when the chart release is in a static environment.
 	RelateToChangesetNewVersions string `json:"relateToChangesetNewVersions" enums:"always,when-static,never" default:"when-static" binding:"oneof=always when-static never ''"`
 }
 

--- a/sherlock/internal/api/sherlock/ci_runs_v3_upsert_test.go
+++ b/sherlock/internal/api/sherlock/ci_runs_v3_upsert_test.go
@@ -178,6 +178,8 @@ func (s *handlerSuite) TestCiRunsV3UpsertIdentifiers() {
 			FirecloudDevelopRef:  testutils.PointerTo("dev"),
 		},
 	}, user)
+	s.NoError(err)
+	s.True(created)
 	templateChartRelease, created, err := v2models.InternalChartReleaseStore.Create(s.DB, v2models.ChartRelease{
 		Name:          "leonardo-bee-template",
 		ChartID:       chart.ID,

--- a/sherlock/internal/api/sherlock/ci_runs_v3_upsert_test.go
+++ b/sherlock/internal/api/sherlock/ci_runs_v3_upsert_test.go
@@ -197,6 +197,26 @@ func (s *handlerSuite) TestCiRunsV3UpsertIdentifiers() {
 	}, user)
 	s.NoError(err)
 	s.True(created)
+
+	s.Run("chart release identifiers", func() {
+		var got CiRunV3
+		code := s.HandleRequest(
+			s.NewRequest("PUT", "/api/ci-runs/v3", CiRunV3Upsert{
+				ciRunFields: ciRunFields{
+					Platform:                   "github-actions",
+					GithubActionsOwner:         "owner",
+					GithubActionsRepo:          "repo",
+					GithubActionsRunID:         123123,
+					GithubActionsAttemptNumber: 1,
+					GithubActionsWorkflowPath:  "workflow",
+				},
+				ChartReleases: []string{chartRelease.Name},
+			}),
+			&got)
+		s.Equal(http.StatusCreated, code)
+		s.Len(got.RelatedResources, 3)
+	})
+
 	controllerChangesets, err := v2controllers.NewControllerSet(v2models.NewStoreSet(s.DB)).ChangesetController.PlanAndApply(v2controllers.ChangesetPlanRequest{
 		ChartReleases: []v2controllers.ChangesetPlanRequestChartReleaseEntry{
 			{

--- a/sherlock/internal/api/sherlock/ci_runs_v3_upsert_test.go
+++ b/sherlock/internal/api/sherlock/ci_runs_v3_upsert_test.go
@@ -60,6 +60,25 @@ func (s *handlerSuite) TestCiRunsV3Upsert() {
 	s.NotEqual(got1.UpdatedAt, got2.UpdatedAt)
 }
 
+func (s *handlerSuite) TestCiRunsV3UpsertFieldValidation() {
+	var got errors.ErrorResponse
+	code := s.HandleRequest(
+		s.NewRequest("PUT", "/api/ci-runs/v3", CiRunV3Upsert{
+			ciRunFields: ciRunFields{
+				Platform:                   "github-actions",
+				GithubActionsOwner:         "owner",
+				GithubActionsRepo:          "repo",
+				GithubActionsRunID:         1,
+				GithubActionsAttemptNumber: 1,
+				GithubActionsWorkflowPath:  "workflow",
+			},
+			RelateToChangesetNewVersions: "some invalid value",
+		}),
+		&got)
+	s.Equal(http.StatusBadRequest, code)
+	s.Contains(got.Message, "RelateToChangesetNewVersions")
+}
+
 func (s *handlerSuite) TestCiRunsV3UpsertIdentifiers() {
 	user := s.SetSuitableTestUserForDB()
 
@@ -129,12 +148,42 @@ func (s *handlerSuite) TestCiRunsV3UpsertIdentifiers() {
 	}, user)
 	s.NoError(err)
 	s.True(created)
+	templateEnvironment, created, err := v2models.InternalEnvironmentStore.Create(s.DB, v2models.Environment{
+		Name:                       "bee-template",
+		Lifecycle:                  "template",
+		UniqueResourcePrefix:       "a1b3",
+		Base:                       "bee",
+		DefaultClusterID:           &cluster.ID,
+		DefaultNamespace:           "terra-bee-template",
+		OwnerID:                    &user.ID,
+		RequiresSuitability:        testutils.PointerTo(false),
+		HelmfileRef:                testutils.PointerTo("HEAD"),
+		DefaultFirecloudDevelopRef: testutils.PointerTo("dev"),
+		PreventDeletion:            testutils.PointerTo(false),
+	}, user)
+	s.NoError(err)
+	s.True(created)
 	chartRelease, created, err := v2models.InternalChartReleaseStore.Create(s.DB, v2models.ChartRelease{
 		Name:          "leonardo-dev",
 		ChartID:       chart.ID,
 		ClusterID:     &cluster.ID,
 		EnvironmentID: &environment.ID,
 		Namespace:     environment.DefaultNamespace,
+		ChartReleaseVersion: v2models.ChartReleaseVersion{
+			AppVersionResolver:   testutils.PointerTo("exact"),
+			AppVersionExact:      testutils.PointerTo("app version blah"),
+			ChartVersionResolver: testutils.PointerTo("exact"),
+			ChartVersionExact:    testutils.PointerTo("chart version blah"),
+			HelmfileRef:          testutils.PointerTo("HEAD"),
+			FirecloudDevelopRef:  testutils.PointerTo("dev"),
+		},
+	}, user)
+	templateChartRelease, created, err := v2models.InternalChartReleaseStore.Create(s.DB, v2models.ChartRelease{
+		Name:          "leonardo-bee-template",
+		ChartID:       chart.ID,
+		ClusterID:     &cluster.ID,
+		EnvironmentID: &templateEnvironment.ID,
+		Namespace:     templateEnvironment.DefaultNamespace,
 		ChartReleaseVersion: v2models.ChartReleaseVersion{
 			AppVersionResolver:   testutils.PointerTo("exact"),
 			AppVersionExact:      testutils.PointerTo("app version blah"),
@@ -155,14 +204,27 @@ func (s *handlerSuite) TestCiRunsV3UpsertIdentifiers() {
 					ToChartVersionExact: &chartVersion.ChartVersion,
 				},
 			},
+			{
+				CreatableChangeset: v2controllers.CreatableChangeset{
+					ChartRelease:        templateChartRelease.Name,
+					ToAppVersionExact:   &appVersion.AppVersion,
+					ToChartVersionExact: &chartVersion.ChartVersion,
+				},
+			},
 		},
 	}, user)
 	s.NoError(err)
-	s.Len(controllerChangesets, 1)
+	s.Len(controllerChangesets, 2)
 	changeset, err := v2models.InternalChangesetStore.Get(s.DB, v2models.Changeset{Model: gorm.Model{ID: controllerChangesets[0].ID}})
 	s.NoError(err)
+	s.Equal(chartRelease.ID, changeset.ChartReleaseID)
 	s.Len(changeset.NewAppVersions, 1)
 	s.Len(changeset.NewChartVersions, 1)
+	templateChangeset, err := v2models.InternalChangesetStore.Get(s.DB, v2models.Changeset{Model: gorm.Model{ID: controllerChangesets[1].ID}})
+	s.NoError(err)
+	s.Equal(templateChartRelease.ID, templateChangeset.ChartReleaseID)
+	s.Len(templateChangeset.NewAppVersions, 1)
+	s.Len(templateChangeset.NewChartVersions, 1)
 
 	s.Run("more advanced upsert of identifiers", func() {
 		var got CiRunV3
@@ -176,7 +238,8 @@ func (s *handlerSuite) TestCiRunsV3UpsertIdentifiers() {
 					GithubActionsAttemptNumber: 2,
 					GithubActionsWorkflowPath:  "workflow",
 				},
-				Changesets: []string{utils.UintToString(changeset.ID)},
+				Changesets:                   []string{utils.UintToString(changeset.ID)},
+				RelateToChangesetNewVersions: "never",
 			}),
 			&got)
 		s.Equal(http.StatusCreated, code)
@@ -194,8 +257,8 @@ func (s *handlerSuite) TestCiRunsV3UpsertIdentifiers() {
 					GithubActionsAttemptNumber: 2,
 					GithubActionsWorkflowPath:  "workflow",
 				},
-				Changesets:                   []string{utils.UintToString(changeset.ID)},
-				RelateToChangesetNewVersions: true,
+				Changesets: []string{utils.UintToString(changeset.ID)},
+				// Use default for RelateToChangesetNewVersions, which spreads for static environments
 			}),
 			&got)
 		s.Equal(http.StatusCreated, code)
@@ -224,6 +287,83 @@ func (s *handlerSuite) TestCiRunsV3UpsertIdentifiers() {
 				&gotAgain)
 			s.Equal(http.StatusOK, code)
 			s.Len(gotAgain.RelatedResources, 6)
+		})
+	})
+	s.Run("changeset spreading for non-static only when set to always", func() {
+		s.Run("never", func() {
+			var got CiRunV3
+			code := s.HandleRequest(
+				s.NewRequest("PUT", "/api/ci-runs/v3", CiRunV3Upsert{
+					ciRunFields: ciRunFields{
+						Platform:                   "github-actions",
+						GithubActionsOwner:         "owner",
+						GithubActionsRepo:          "repo",
+						GithubActionsRunID:         1,
+						GithubActionsAttemptNumber: 200,
+						GithubActionsWorkflowPath:  "workflow",
+					},
+					Changesets:                   []string{utils.UintToString(templateChangeset.ID)},
+					RelateToChangesetNewVersions: "never",
+				}),
+				&got)
+			s.Equal(http.StatusCreated, code)
+			s.Len(got.RelatedResources, 4)
+		})
+		s.Run("default", func() {
+			var got CiRunV3
+			code := s.HandleRequest(
+				s.NewRequest("PUT", "/api/ci-runs/v3", CiRunV3Upsert{
+					ciRunFields: ciRunFields{
+						Platform:                   "github-actions",
+						GithubActionsOwner:         "owner",
+						GithubActionsRepo:          "repo",
+						GithubActionsRunID:         1,
+						GithubActionsAttemptNumber: 200,
+						GithubActionsWorkflowPath:  "workflow",
+					},
+					Changesets: []string{utils.UintToString(templateChangeset.ID)},
+				}),
+				&got)
+			s.Equal(http.StatusCreated, code)
+			s.Len(got.RelatedResources, 4)
+		})
+		s.Run("explicit when-static", func() {
+			var got CiRunV3
+			code := s.HandleRequest(
+				s.NewRequest("PUT", "/api/ci-runs/v3", CiRunV3Upsert{
+					ciRunFields: ciRunFields{
+						Platform:                   "github-actions",
+						GithubActionsOwner:         "owner",
+						GithubActionsRepo:          "repo",
+						GithubActionsRunID:         1,
+						GithubActionsAttemptNumber: 200,
+						GithubActionsWorkflowPath:  "workflow",
+					},
+					Changesets:                   []string{utils.UintToString(templateChangeset.ID)},
+					RelateToChangesetNewVersions: "when-static",
+				}),
+				&got)
+			s.Equal(http.StatusCreated, code)
+			s.Len(got.RelatedResources, 4)
+		})
+		s.Run("always", func() {
+			var got CiRunV3
+			code := s.HandleRequest(
+				s.NewRequest("PUT", "/api/ci-runs/v3", CiRunV3Upsert{
+					ciRunFields: ciRunFields{
+						Platform:                   "github-actions",
+						GithubActionsOwner:         "owner",
+						GithubActionsRepo:          "repo",
+						GithubActionsRunID:         1,
+						GithubActionsAttemptNumber: 200,
+						GithubActionsWorkflowPath:  "workflow",
+					},
+					Changesets:                   []string{utils.UintToString(templateChangeset.ID)},
+					RelateToChangesetNewVersions: "always",
+				}),
+				&got)
+			s.Equal(http.StatusCreated, code)
+			s.Len(got.RelatedResources, 6)
 		})
 	})
 	s.Run("eliminates duplicates and spreads downwards", func() {

--- a/sherlock/internal/api/sherlock/handler_test.go
+++ b/sherlock/internal/api/sherlock/handler_test.go
@@ -77,7 +77,7 @@ func (s *handlerSuite) HandleRequest(req *http.Request, fromJsonBodyPointer any)
 				s.FailNowf("unexpected error response", "%s blamed on %s: %s", errorResponse.Type, errorResponse.ToBlame, errorResponse.Message)
 			} else {
 				// If those assertions didn't hold, that means there was a totally unexpected type in the response. We'll fail the test with the body to help debug.
-				s.FailNow("fully unexpected response type", "%s", string(body))
+				s.FailNowf("fully unexpected response type", "body: %s", string(body))
 			}
 		}
 	}

--- a/sherlock/internal/errors/abort.go
+++ b/sherlock/internal/errors/abort.go
@@ -1,0 +1,9 @@
+package errors
+
+import "github.com/gin-gonic/gin"
+
+// AbortRequest abstracts the specific incantation needed to correctly return an errors.ErrorResponse
+// from a handler.
+func AbortRequest(ctx *gin.Context, err error) {
+	ctx.AbortWithStatusJSON(ErrorToApiResponse(ctx.Error(err)))
+}

--- a/sherlock/internal/errors/abort_test.go
+++ b/sherlock/internal/errors/abort_test.go
@@ -1,0 +1,30 @@
+package errors
+
+import (
+	"fmt"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestAbortRequest(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.GET("/", func(ctx *gin.Context) {
+		err := fmt.Errorf("some error (%s)", BadRequest)
+		AbortRequest(ctx, err)
+
+		assert.True(t, ctx.IsAborted())
+		assert.Len(t, ctx.Errors.Errors(), 1)
+		assert.Equal(t, http.StatusBadRequest, ctx.Writer.Status())
+	})
+
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest("GET", "/", nil)
+	router.ServeHTTP(recorder, request)
+
+	assert.Equal(t, http.StatusBadRequest, recorder.Code)
+	assert.Contains(t, recorder.Body.String(), "some error")
+}


### PR DESCRIPTION
The old CiRun PUT endpoint had this gimmick where when you report that a GHA relates to a Changeset, it also records that the GHA relates to any new app or chart versions that Changeset deployed.

That works fine, but it would get spammy if we use it more, because BEE deployments would then show up when you look at an app or chart version's CiRuns.

So the v3 one I added has that behavior behind a flag in the request. It's disabled by default. No more spam.

Except... what we really want is "enable this for deployments to static environments, disable it otherwise." We _want_ deployments to dev/alpha/staging/prod to show up if you look at the CiRuns for an app version.

Rather than requiring clients to figure that out and control the flag, this PR turns the boolean flag into an enum that accepts `always`, `when-static`, and `never`. `when-static` is the default and Sherlock figures it out for you.

## Testing

Added tests for validation of the enum and for its behavior across static and non-static environments. Because I split the code paths for changeset and chart release handling by this endpoint, I also added another test for the chart release part so we aren't losing coverage we used to have.

## Risk

None, this endpoint field isn't currently being used by anyone/anything.