### PR TITLE
[DDO-2982] Block introduction of vulnerable packages into Sherlock's codebase

### DIFF
--- a/.github/workflows/sherlock-dependency-review.yml
+++ b/.github/workflows/sherlock-dependency-review.yml
@@ -1,0 +1,20 @@
+# Dependency Review Action
+#
+# This Action will scan dependency manifest files that change as part of a Pull Request, surfacing known-vulnerable versions of the packages declared or updated in the PR. Once installed, if the workflow run is marked as required, PRs introducing known-vulnerable packages will be blocked from merging.
+#
+# Source repository: https://github.com/actions/dependency-review-action
+# Public documentation: https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/about-dependency-review#dependency-review-enforcement
+name: 'Dependency Review'
+on: [pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Checkout Repository'
+        uses: actions/checkout@v3
+      - name: 'Dependency Review'
+        uses: actions/dependency-review-action@v3


### PR DESCRIPTION
"Dependency Review" is a first-party workflow offered directly by GitHub at https://github.com/broadinstitute/sherlock/actions/new. It's backed by GitHub's API, I tried it and it works even though we're in a monorepo. Seems like an easy win to add, I didn't touch the workflow file.