### PR TITLE
[DDO-2989] v3 Users endpoints that expose suitability

### DIFF
--- a/sherlock/docs/docs.go
+++ b/sherlock/docs/docs.go
@@ -489,6 +489,277 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/users/v3": {
+            "get": {
+                "description": "List Users matching a filter. The results will include suitability and other information.\nNote that the suitability info can't directly be filtered for at this time.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Users"
+                ],
+                "summary": "List Users matching a filter.",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "date-time",
+                        "name": "createdAt",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "name": "email",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "name": "githubID",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "name": "githubUsername",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "name": "googleID",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "name": "id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "name": "name",
+                        "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Controls whether Sherlock should automatically update the user's name based on a connected GitHub identity.\nWill be set to true if the user account has no name and a GitHub account is linked.",
+                        "name": "nameInferredFromGithub",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Available only in responses; describes the user's production-suitability",
+                        "name": "suitabilityDescription",
+                        "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Available only in responses; indicates whether the user is production-suitable",
+                        "name": "suitable",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "format": "date-time",
+                        "name": "updatedAt",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Control how many Users are returned (default 0, no limit)",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Control the offset for the returned Users (default 0)",
+                        "name": "offset",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/sherlock.UserV3"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "407": {
+                        "description": "Proxy Authentication Required",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "description": "Update the calling User's information. As with all authenticated Sherlock endpoints,\nnewly-observed callers will have a User record added, meaning that this endpoint\nbehaves like an upsert.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Users"
+                ],
+                "summary": "Update the calling User's information",
+                "parameters": [
+                    {
+                        "description": "The User data to update",
+                        "name": "user",
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/sherlock.UserV3Upsert"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/sherlock.UserV3"
+                        }
+                    },
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/sherlock.UserV3"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "407": {
+                        "description": "Proxy Authentication Required",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/users/v3/{selector}": {
+            "get": {
+                "description": "Get an individual User. As a special case, \"me\" can be passed as the selector to get the current user.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Users"
+                ],
+                "summary": "Get an individual User",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "The selector of the User, which can be either a numeric ID, the email, 'google-id/{google subject ID}', 'github/{github username}', or 'github-id/{github numeric ID}'. As a special case, 'me' can be passed to get the calling user.",
+                        "name": "selector",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/sherlock.UserV3"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "407": {
+                        "description": "Proxy Authentication Required",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v2/app-versions": {
             "get": {
                 "description": "List existing AppVersion entries, ordered by most recently updated.",
@@ -7851,6 +8122,65 @@ const docTemplate = `{
                 },
                 "terminalAt": {
                     "type": "string"
+                }
+            }
+        },
+        "sherlock.UserV3": {
+            "type": "object",
+            "properties": {
+                "createdAt": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "email": {
+                    "type": "string"
+                },
+                "githubID": {
+                    "type": "string"
+                },
+                "githubUsername": {
+                    "type": "string"
+                },
+                "googleID": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "nameInferredFromGithub": {
+                    "description": "Controls whether Sherlock should automatically update the user's name based on a connected GitHub identity.\nWill be set to true if the user account has no name and a GitHub account is linked.",
+                    "type": "boolean"
+                },
+                "suitabilityDescription": {
+                    "description": "Available only in responses; describes the user's production-suitability",
+                    "type": "string"
+                },
+                "suitable": {
+                    "description": "Available only in responses; indicates whether the user is production-suitable",
+                    "type": "boolean"
+                },
+                "updatedAt": {
+                    "type": "string",
+                    "format": "date-time"
+                }
+            }
+        },
+        "sherlock.UserV3Upsert": {
+            "type": "object",
+            "properties": {
+                "githubAccessToken": {
+                    "description": "An access token for the GitHub account to associate with the calling user. The access token isn't stored.\nThe design here ensures that an association is only built when someone controls both accounts (Google via\nIAP and GitHub via this access token).",
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "nameInferredFromGithub": {
+                    "description": "Controls whether Sherlock should automatically update the user's name based on a connected GitHub identity.\nWill be set to true if the user account has no name and a GitHub account is linked.",
+                    "type": "boolean"
                 }
             }
         },

--- a/sherlock/docs/docs.go
+++ b/sherlock/docs/docs.go
@@ -498,7 +498,7 @@ const docTemplate = `{
                 "tags": [
                     "Users"
                 ],
-                "summary": "List Users matching a filter.",
+                "summary": "List Users matching a filter",
                 "parameters": [
                     {
                         "type": "string",
@@ -697,7 +697,7 @@ const docTemplate = `{
         },
         "/api/users/v3/{selector}": {
             "get": {
-                "description": "Get an individual User. As a special case, \"me\" can be passed as the selector to get the current user.",
+                "description": "Get an individual User. As a special case, \"me\" or \"self\" can be passed as the selector to get the current user.",
                 "produces": [
                     "application/json"
                 ],
@@ -708,7 +708,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "The selector of the User, which can be either a numeric ID, the email, 'google-id/{google subject ID}', 'github/{github username}', or 'github-id/{github numeric ID}'. As a special case, 'me' can be passed to get the calling user.",
+                        "description": "The selector of the User, which can be either a numeric ID, the email, 'google-id/{google subject ID}', 'github/{github username}', or 'github-id/{github numeric ID}'. As a special case, 'me' or 'self' can be passed to get the calling user.",
                         "name": "selector",
                         "in": "path",
                         "required": true

--- a/sherlock/docs/swagger.json
+++ b/sherlock/docs/swagger.json
@@ -492,7 +492,7 @@
                 "tags": [
                     "Users"
                 ],
-                "summary": "List Users matching a filter.",
+                "summary": "List Users matching a filter",
                 "parameters": [
                     {
                         "type": "string",
@@ -691,7 +691,7 @@
         },
         "/api/users/v3/{selector}": {
             "get": {
-                "description": "Get an individual User. As a special case, \"me\" can be passed as the selector to get the current user.",
+                "description": "Get an individual User. As a special case, \"me\" or \"self\" can be passed as the selector to get the current user.",
                 "produces": [
                     "application/json"
                 ],
@@ -702,7 +702,7 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "The selector of the User, which can be either a numeric ID, the email, 'google-id/{google subject ID}', 'github/{github username}', or 'github-id/{github numeric ID}'. As a special case, 'me' can be passed to get the calling user.",
+                        "description": "The selector of the User, which can be either a numeric ID, the email, 'google-id/{google subject ID}', 'github/{github username}', or 'github-id/{github numeric ID}'. As a special case, 'me' or 'self' can be passed to get the calling user.",
                         "name": "selector",
                         "in": "path",
                         "required": true

--- a/sherlock/docs/swagger.json
+++ b/sherlock/docs/swagger.json
@@ -483,6 +483,277 @@
                 }
             }
         },
+        "/api/users/v3": {
+            "get": {
+                "description": "List Users matching a filter. The results will include suitability and other information.\nNote that the suitability info can't directly be filtered for at this time.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Users"
+                ],
+                "summary": "List Users matching a filter.",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "date-time",
+                        "name": "createdAt",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "name": "email",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "name": "githubID",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "name": "githubUsername",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "name": "googleID",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "name": "id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "name": "name",
+                        "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Controls whether Sherlock should automatically update the user's name based on a connected GitHub identity.\nWill be set to true if the user account has no name and a GitHub account is linked.",
+                        "name": "nameInferredFromGithub",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Available only in responses; describes the user's production-suitability",
+                        "name": "suitabilityDescription",
+                        "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Available only in responses; indicates whether the user is production-suitable",
+                        "name": "suitable",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "format": "date-time",
+                        "name": "updatedAt",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Control how many Users are returned (default 0, no limit)",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Control the offset for the returned Users (default 0)",
+                        "name": "offset",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/sherlock.UserV3"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "407": {
+                        "description": "Proxy Authentication Required",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "description": "Update the calling User's information. As with all authenticated Sherlock endpoints,\nnewly-observed callers will have a User record added, meaning that this endpoint\nbehaves like an upsert.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Users"
+                ],
+                "summary": "Update the calling User's information",
+                "parameters": [
+                    {
+                        "description": "The User data to update",
+                        "name": "user",
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/sherlock.UserV3Upsert"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/sherlock.UserV3"
+                        }
+                    },
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/sherlock.UserV3"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "407": {
+                        "description": "Proxy Authentication Required",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/users/v3/{selector}": {
+            "get": {
+                "description": "Get an individual User. As a special case, \"me\" can be passed as the selector to get the current user.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Users"
+                ],
+                "summary": "Get an individual User",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "The selector of the User, which can be either a numeric ID, the email, 'google-id/{google subject ID}', 'github/{github username}', or 'github-id/{github numeric ID}'. As a special case, 'me' can be passed to get the calling user.",
+                        "name": "selector",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/sherlock.UserV3"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "407": {
+                        "description": "Proxy Authentication Required",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v2/app-versions": {
             "get": {
                 "description": "List existing AppVersion entries, ordered by most recently updated.",
@@ -7845,6 +8116,65 @@
                 },
                 "terminalAt": {
                     "type": "string"
+                }
+            }
+        },
+        "sherlock.UserV3": {
+            "type": "object",
+            "properties": {
+                "createdAt": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "email": {
+                    "type": "string"
+                },
+                "githubID": {
+                    "type": "string"
+                },
+                "githubUsername": {
+                    "type": "string"
+                },
+                "googleID": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "nameInferredFromGithub": {
+                    "description": "Controls whether Sherlock should automatically update the user's name based on a connected GitHub identity.\nWill be set to true if the user account has no name and a GitHub account is linked.",
+                    "type": "boolean"
+                },
+                "suitabilityDescription": {
+                    "description": "Available only in responses; describes the user's production-suitability",
+                    "type": "string"
+                },
+                "suitable": {
+                    "description": "Available only in responses; indicates whether the user is production-suitable",
+                    "type": "boolean"
+                },
+                "updatedAt": {
+                    "type": "string",
+                    "format": "date-time"
+                }
+            }
+        },
+        "sherlock.UserV3Upsert": {
+            "type": "object",
+            "properties": {
+                "githubAccessToken": {
+                    "description": "An access token for the GitHub account to associate with the calling user. The access token isn't stored.\nThe design here ensures that an association is only built when someone controls both accounts (Google via\nIAP and GitHub via this access token).",
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "nameInferredFromGithub": {
+                    "description": "Controls whether Sherlock should automatically update the user's name based on a connected GitHub identity.\nWill be set to true if the user account has no name and a GitHub account is linked.",
+                    "type": "boolean"
                 }
             }
         },

--- a/sherlock/docs/swagger.yaml
+++ b/sherlock/docs/swagger.yaml
@@ -188,6 +188,54 @@ definitions:
       terminalAt:
         type: string
     type: object
+  sherlock.UserV3:
+    properties:
+      createdAt:
+        format: date-time
+        type: string
+      email:
+        type: string
+      githubID:
+        type: string
+      githubUsername:
+        type: string
+      googleID:
+        type: string
+      id:
+        type: integer
+      name:
+        type: string
+      nameInferredFromGithub:
+        description: |-
+          Controls whether Sherlock should automatically update the user's name based on a connected GitHub identity.
+          Will be set to true if the user account has no name and a GitHub account is linked.
+        type: boolean
+      suitabilityDescription:
+        description: Available only in responses; describes the user's production-suitability
+        type: string
+      suitable:
+        description: Available only in responses; indicates whether the user is production-suitable
+        type: boolean
+      updatedAt:
+        format: date-time
+        type: string
+    type: object
+  sherlock.UserV3Upsert:
+    properties:
+      githubAccessToken:
+        description: |-
+          An access token for the GitHub account to associate with the calling user. The access token isn't stored.
+          The design here ensures that an association is only built when someone controls both accounts (Google via
+          IAP and GitHub via this access token).
+        type: string
+      name:
+        type: string
+      nameInferredFromGithub:
+        description: |-
+          Controls whether Sherlock should automatically update the user's name based on a connected GitHub identity.
+          Will be set to true if the user account has no name and a GitHub account is linked.
+        type: boolean
+    type: object
   v2controllers.AppVersion:
     properties:
       appVersion:
@@ -1748,6 +1796,193 @@ paths:
       summary: Get a CiRun, including CiIdentifiers for related resources
       tags:
       - CiRuns
+  /api/users/v3:
+    get:
+      description: |-
+        List Users matching a filter. The results will include suitability and other information.
+        Note that the suitability info can't directly be filtered for at this time.
+      parameters:
+      - format: date-time
+        in: query
+        name: createdAt
+        type: string
+      - in: query
+        name: email
+        type: string
+      - in: query
+        name: githubID
+        type: string
+      - in: query
+        name: githubUsername
+        type: string
+      - in: query
+        name: googleID
+        type: string
+      - in: query
+        name: id
+        type: integer
+      - in: query
+        name: name
+        type: string
+      - description: |-
+          Controls whether Sherlock should automatically update the user's name based on a connected GitHub identity.
+          Will be set to true if the user account has no name and a GitHub account is linked.
+        in: query
+        name: nameInferredFromGithub
+        type: boolean
+      - description: Available only in responses; describes the user's production-suitability
+        in: query
+        name: suitabilityDescription
+        type: string
+      - description: Available only in responses; indicates whether the user is production-suitable
+        in: query
+        name: suitable
+        type: boolean
+      - format: date-time
+        in: query
+        name: updatedAt
+        type: string
+      - description: Control how many Users are returned (default 0, no limit)
+        in: query
+        name: limit
+        type: integer
+      - description: Control the offset for the returned Users (default 0)
+        in: query
+        name: offset
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/sherlock.UserV3'
+            type: array
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/errors.ErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/errors.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/errors.ErrorResponse'
+        "407":
+          description: Proxy Authentication Required
+          schema:
+            $ref: '#/definitions/errors.ErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/errors.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/errors.ErrorResponse'
+      summary: List Users matching a filter.
+      tags:
+      - Users
+    put:
+      consumes:
+      - application/json
+      description: |-
+        Update the calling User's information. As with all authenticated Sherlock endpoints,
+        newly-observed callers will have a User record added, meaning that this endpoint
+        behaves like an upsert.
+      parameters:
+      - description: The User data to update
+        in: body
+        name: user
+        schema:
+          $ref: '#/definitions/sherlock.UserV3Upsert'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/sherlock.UserV3'
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/sherlock.UserV3'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/errors.ErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/errors.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/errors.ErrorResponse'
+        "407":
+          description: Proxy Authentication Required
+          schema:
+            $ref: '#/definitions/errors.ErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/errors.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/errors.ErrorResponse'
+      summary: Update the calling User's information
+      tags:
+      - Users
+  /api/users/v3/{selector}:
+    get:
+      description: Get an individual User. As a special case, "me" can be passed as
+        the selector to get the current user.
+      parameters:
+      - description: The selector of the User, which can be either a numeric ID, the
+          email, 'google-id/{google subject ID}', 'github/{github username}', or 'github-id/{github
+          numeric ID}'. As a special case, 'me' can be passed to get the calling user.
+        in: path
+        name: selector
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/sherlock.UserV3'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/errors.ErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/errors.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/errors.ErrorResponse'
+        "407":
+          description: Proxy Authentication Required
+          schema:
+            $ref: '#/definitions/errors.ErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/errors.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/errors.ErrorResponse'
+      summary: Get an individual User
+      tags:
+      - Users
   /api/v2/app-versions:
     get:
       description: List existing AppVersion entries, ordered by most recently updated.

--- a/sherlock/docs/swagger.yaml
+++ b/sherlock/docs/swagger.yaml
@@ -1883,7 +1883,7 @@ paths:
           description: Internal Server Error
           schema:
             $ref: '#/definitions/errors.ErrorResponse'
-      summary: List Users matching a filter.
+      summary: List Users matching a filter
       tags:
       - Users
     put:
@@ -1939,12 +1939,13 @@ paths:
       - Users
   /api/users/v3/{selector}:
     get:
-      description: Get an individual User. As a special case, "me" can be passed as
-        the selector to get the current user.
+      description: Get an individual User. As a special case, "me" or "self" can be
+        passed as the selector to get the current user.
       parameters:
       - description: The selector of the User, which can be either a numeric ID, the
           email, 'google-id/{google subject ID}', 'github/{github username}', or 'github-id/{github
-          numeric ID}'. As a special case, 'me' can be passed to get the calling user.
+          numeric ID}'. As a special case, 'me' or 'self' can be passed to get the
+          calling user.
         in: path
         name: selector
         required: true

--- a/sherlock/internal/api/sherlock/ci_identifiers_v3_list.go
+++ b/sherlock/internal/api/sherlock/ci_identifiers_v3_list.go
@@ -7,7 +7,6 @@ import (
 	"github.com/broadinstitute/sherlock/sherlock/internal/errors"
 	"github.com/broadinstitute/sherlock/sherlock/internal/models"
 	"github.com/gin-gonic/gin"
-	"github.com/gin-gonic/gin/binding"
 	"net/http"
 )
 
@@ -31,7 +30,8 @@ func ciIdentifiersV3List(ctx *gin.Context) {
 		return
 	}
 	var filter CiIdentifierV3
-	if err = ctx.MustBindWith(&filter, binding.Query); err != nil {
+	if err = ctx.ShouldBindQuery(&filter); err != nil {
+		errors.AbortRequest(ctx, err)
 		return
 	}
 	modelFilter := filter.toModel()

--- a/sherlock/internal/api/sherlock/ci_runs_v3_list.go
+++ b/sherlock/internal/api/sherlock/ci_runs_v3_list.go
@@ -7,7 +7,6 @@ import (
 	"github.com/broadinstitute/sherlock/sherlock/internal/errors"
 	"github.com/broadinstitute/sherlock/sherlock/internal/models"
 	"github.com/gin-gonic/gin"
-	"github.com/gin-gonic/gin/binding"
 	"net/http"
 )
 
@@ -30,7 +29,8 @@ func ciRunsV3List(ctx *gin.Context) {
 		return
 	}
 	var filter CiRunV3
-	if err = ctx.MustBindWith(&filter, binding.Query); err != nil {
+	if err = ctx.ShouldBindQuery(&filter); err != nil {
+		errors.AbortRequest(ctx, err)
 		return
 	}
 	modelFilter := filter.toModel()

--- a/sherlock/internal/api/sherlock/ci_runs_v3_upsert_test.go
+++ b/sherlock/internal/api/sherlock/ci_runs_v3_upsert_test.go
@@ -312,78 +312,75 @@ func (s *handlerSuite) TestCiRunsV3UpsertIdentifiers() {
 		})
 	})
 	s.Run("changeset spreading for non-static only when set to always", func() {
+		var got CiRunV3
+		code := s.HandleRequest(
+			s.NewRequest("PUT", "/api/ci-runs/v3", CiRunV3Upsert{
+				ciRunFields: ciRunFields{
+					Platform:                   "github-actions",
+					GithubActionsOwner:         "owner",
+					GithubActionsRepo:          "repo",
+					GithubActionsRunID:         1,
+					GithubActionsAttemptNumber: 200,
+					GithubActionsWorkflowPath:  "workflow",
+				},
+				Changesets:                   []string{utils.UintToString(templateChangeset.ID)},
+				RelateToChangesetNewVersions: "never",
+			}),
+			&got)
 		s.Run("never", func() {
-			var got CiRunV3
-			code := s.HandleRequest(
-				s.NewRequest("PUT", "/api/ci-runs/v3", CiRunV3Upsert{
-					ciRunFields: ciRunFields{
-						Platform:                   "github-actions",
-						GithubActionsOwner:         "owner",
-						GithubActionsRepo:          "repo",
-						GithubActionsRunID:         1,
-						GithubActionsAttemptNumber: 200,
-						GithubActionsWorkflowPath:  "workflow",
-					},
-					Changesets:                   []string{utils.UintToString(templateChangeset.ID)},
-					RelateToChangesetNewVersions: "never",
-				}),
-				&got)
 			s.Equal(http.StatusCreated, code)
 			s.Len(got.RelatedResources, 4)
 		})
+		code = s.HandleRequest(
+			s.NewRequest("PUT", "/api/ci-runs/v3", CiRunV3Upsert{
+				ciRunFields: ciRunFields{
+					Platform:                   "github-actions",
+					GithubActionsOwner:         "owner",
+					GithubActionsRepo:          "repo",
+					GithubActionsRunID:         1,
+					GithubActionsAttemptNumber: 200,
+					GithubActionsWorkflowPath:  "workflow",
+				},
+				Changesets: []string{utils.UintToString(templateChangeset.ID)},
+			}),
+			&got)
 		s.Run("default", func() {
-			var got CiRunV3
-			code := s.HandleRequest(
-				s.NewRequest("PUT", "/api/ci-runs/v3", CiRunV3Upsert{
-					ciRunFields: ciRunFields{
-						Platform:                   "github-actions",
-						GithubActionsOwner:         "owner",
-						GithubActionsRepo:          "repo",
-						GithubActionsRunID:         1,
-						GithubActionsAttemptNumber: 200,
-						GithubActionsWorkflowPath:  "workflow",
-					},
-					Changesets: []string{utils.UintToString(templateChangeset.ID)},
-				}),
-				&got)
 			s.Equal(http.StatusCreated, code)
 			s.Len(got.RelatedResources, 4)
 		})
+		code = s.HandleRequest(
+			s.NewRequest("PUT", "/api/ci-runs/v3", CiRunV3Upsert{
+				ciRunFields: ciRunFields{
+					Platform:                   "github-actions",
+					GithubActionsOwner:         "owner",
+					GithubActionsRepo:          "repo",
+					GithubActionsRunID:         1,
+					GithubActionsAttemptNumber: 200,
+					GithubActionsWorkflowPath:  "workflow",
+				},
+				Changesets:                   []string{utils.UintToString(templateChangeset.ID)},
+				RelateToChangesetNewVersions: "when-static",
+			}),
+			&got)
 		s.Run("explicit when-static", func() {
-			var got CiRunV3
-			code := s.HandleRequest(
-				s.NewRequest("PUT", "/api/ci-runs/v3", CiRunV3Upsert{
-					ciRunFields: ciRunFields{
-						Platform:                   "github-actions",
-						GithubActionsOwner:         "owner",
-						GithubActionsRepo:          "repo",
-						GithubActionsRunID:         1,
-						GithubActionsAttemptNumber: 200,
-						GithubActionsWorkflowPath:  "workflow",
-					},
-					Changesets:                   []string{utils.UintToString(templateChangeset.ID)},
-					RelateToChangesetNewVersions: "when-static",
-				}),
-				&got)
 			s.Equal(http.StatusCreated, code)
 			s.Len(got.RelatedResources, 4)
 		})
+		code = s.HandleRequest(
+			s.NewRequest("PUT", "/api/ci-runs/v3", CiRunV3Upsert{
+				ciRunFields: ciRunFields{
+					Platform:                   "github-actions",
+					GithubActionsOwner:         "owner",
+					GithubActionsRepo:          "repo",
+					GithubActionsRunID:         1,
+					GithubActionsAttemptNumber: 200,
+					GithubActionsWorkflowPath:  "workflow",
+				},
+				Changesets:                   []string{utils.UintToString(templateChangeset.ID)},
+				RelateToChangesetNewVersions: "always",
+			}),
+			&got)
 		s.Run("always", func() {
-			var got CiRunV3
-			code := s.HandleRequest(
-				s.NewRequest("PUT", "/api/ci-runs/v3", CiRunV3Upsert{
-					ciRunFields: ciRunFields{
-						Platform:                   "github-actions",
-						GithubActionsOwner:         "owner",
-						GithubActionsRepo:          "repo",
-						GithubActionsRunID:         1,
-						GithubActionsAttemptNumber: 200,
-						GithubActionsWorkflowPath:  "workflow",
-					},
-					Changesets:                   []string{utils.UintToString(templateChangeset.ID)},
-					RelateToChangesetNewVersions: "always",
-				}),
-				&got)
 			s.Equal(http.StatusCreated, code)
 			s.Len(got.RelatedResources, 6)
 		})

--- a/sherlock/internal/api/sherlock/routes.go
+++ b/sherlock/internal/api/sherlock/routes.go
@@ -14,4 +14,10 @@ func ConfigureRoutes(apiRouter *gin.RouterGroup) {
 		ciRunsV3.GET("*selector", ciRunsV3Get)
 		ciRunsV3.PUT("", ciRunsV3Upsert)
 	}
+	usersV3 := apiRouter.Group("users/v3")
+	{
+		usersV3.GET("", usersV3List)
+		usersV3.GET("*selector", usersV3Get)
+		usersV3.PUT("", usersV3Upsert)
+	}
 }

--- a/sherlock/internal/api/sherlock/users_v3.go
+++ b/sherlock/internal/api/sherlock/users_v3.go
@@ -1,0 +1,53 @@
+package sherlock
+
+import (
+	"github.com/broadinstitute/sherlock/sherlock/internal/models"
+)
+
+type UserV3 struct {
+	commonFields
+	Email                  string  `json:"email" form:"email"`
+	GoogleID               string  `json:"googleID" form:"googleID"`
+	GithubUsername         *string `json:"githubUsername,omitempty" form:"githubUsername"`
+	GithubID               *string `json:"githubID,omitempty" form:"githubID"`
+	Suitable               *bool   `json:"suitable,omitempty" form:"suitable"`                             // Available only in responses; indicates whether the user is production-suitable
+	SuitabilityDescription *string `json:"suitabilityDescription,omitempty" form:"suitabilityDescription"` // Available only in responses; describes the user's production-suitability
+	userDirectlyEditableFields
+}
+
+type userDirectlyEditableFields struct {
+	Name *string `json:"name,omitempty" form:"name"`
+	// Controls whether Sherlock should automatically update the user's name based on a connected GitHub identity.
+	// Will be set to true if the user account has no name and a GitHub account is linked.
+	NameInferredFromGithub *bool `json:"nameInferredFromGithub,omitempty" form:"nameInferredFromGithub"`
+}
+
+func (u UserV3) toModel() models.User {
+	return models.User{
+		Model:                  u.toGormModel(),
+		Email:                  u.Email,
+		GoogleID:               u.GoogleID,
+		GithubUsername:         u.GithubUsername,
+		GithubID:               u.GithubID,
+		Name:                   u.Name,
+		NameInferredFromGithub: u.NameInferredFromGithub,
+	}
+}
+
+func userFromModel(model models.User) UserV3 {
+	suitable := model.Suitability().Suitable()
+	suitabilityDescription := model.Suitability().Description()
+	return UserV3{
+		commonFields:           commonFieldsFromGormModel(model.Model),
+		Email:                  model.Email,
+		GoogleID:               model.GoogleID,
+		GithubUsername:         model.GithubUsername,
+		GithubID:               model.GithubID,
+		Suitable:               &suitable,
+		SuitabilityDescription: &suitabilityDescription,
+		userDirectlyEditableFields: userDirectlyEditableFields{
+			Name:                   model.Name,
+			NameInferredFromGithub: model.NameInferredFromGithub,
+		},
+	}
+}

--- a/sherlock/internal/api/sherlock/users_v3_get.go
+++ b/sherlock/internal/api/sherlock/users_v3_get.go
@@ -1,0 +1,75 @@
+package sherlock
+
+import (
+	"fmt"
+	"github.com/broadinstitute/sherlock/go-shared/pkg/utils"
+	"github.com/broadinstitute/sherlock/sherlock/internal/authentication"
+	"github.com/broadinstitute/sherlock/sherlock/internal/errors"
+	"github.com/broadinstitute/sherlock/sherlock/internal/models"
+	"github.com/gin-gonic/gin"
+	"net/http"
+	"strings"
+)
+
+// usersV3Get godoc
+//
+//	@summary		Get an individual User
+//	@description	Get an individual User. As a special case, "me" can be passed as the selector to get the current user.
+//	@tags			Users
+//	@produce		json
+//	@param			selector				path		string	true	"The selector of the User, which can be either a numeric ID, the email, 'google-id/{google subject ID}', 'github/{github username}', or 'github-id/{github numeric ID}'. As a special case, 'me' can be passed to get the calling user."
+//	@success		200						{object}	UserV3
+//	@failure		400,403,404,407,409,500	{object}	errors.ErrorResponse
+//	@router			/api/users/v3/{selector} [get]
+func usersV3Get(ctx *gin.Context) {
+	db, err := authentication.MustUseDB(ctx)
+	if err != nil {
+		return
+	}
+	selector := canonicalizeSelector(ctx.Param("selector"))
+
+	if selector == "me" {
+		user, err := authentication.MustUseUser(ctx)
+		if err != nil {
+			return
+		}
+		ctx.JSON(http.StatusOK, userFromModel(*user))
+	} else {
+		query, err := userModelFromSelector(selector)
+		if err != nil {
+			errors.AbortRequest(ctx, err)
+			return
+		}
+		var result models.User
+		if err = db.Where(&query).First(&result).Error; err != nil {
+			errors.AbortRequest(ctx, err)
+			return
+		}
+		ctx.JSON(http.StatusOK, userFromModel(result))
+	}
+}
+
+func userModelFromSelector(selector string) (query models.User, err error) {
+	if len(selector) == 0 {
+		return models.User{}, fmt.Errorf("(%s) selector cannot be empty", errors.BadRequest)
+	} else if utils.IsNumeric(selector) {
+		query.ID, err = utils.ParseUint(selector)
+		return query, err
+	} else if strings.Contains(selector, "@") {
+		query.Email = selector
+		return query, nil
+	} else if strings.HasPrefix(selector, "google-id/") {
+		query.GoogleID = strings.TrimPrefix(selector, "google-id/")
+		return query, nil
+	} else if strings.HasPrefix(selector, "github/") {
+		githubUsername := strings.TrimPrefix(selector, "github/")
+		query.GithubUsername = &githubUsername
+		return query, nil
+	} else if strings.HasPrefix(selector, "github-id/") {
+		githubID := strings.TrimPrefix(selector, "github-id/")
+		query.GithubID = &githubID
+		return query, nil
+	} else {
+		return models.User{}, fmt.Errorf("(%s) invalid user selector '%s'", errors.BadRequest, selector)
+	}
+}

--- a/sherlock/internal/api/sherlock/users_v3_get.go
+++ b/sherlock/internal/api/sherlock/users_v3_get.go
@@ -60,13 +60,22 @@ func userModelFromSelector(selector string) (query models.User, err error) {
 		return query, nil
 	} else if strings.HasPrefix(selector, "google-id/") {
 		query.GoogleID = strings.TrimPrefix(selector, "google-id/")
+		if len(query.GoogleID) == 0 {
+			return models.User{}, fmt.Errorf("(%s) google ID selector can't be empty", errors.BadRequest)
+		}
 		return query, nil
 	} else if strings.HasPrefix(selector, "github/") {
 		githubUsername := strings.TrimPrefix(selector, "github/")
+		if len(githubUsername) == 0 {
+			return models.User{}, fmt.Errorf("(%s) github username selector can't be empty", errors.BadRequest)
+		}
 		query.GithubUsername = &githubUsername
 		return query, nil
 	} else if strings.HasPrefix(selector, "github-id/") {
 		githubID := strings.TrimPrefix(selector, "github-id/")
+		if len(githubID) == 0 {
+			return models.User{}, fmt.Errorf("(%s) github ID selector can't be empty", errors.BadRequest)
+		}
 		query.GithubID = &githubID
 		return query, nil
 	} else {

--- a/sherlock/internal/api/sherlock/users_v3_get.go
+++ b/sherlock/internal/api/sherlock/users_v3_get.go
@@ -14,10 +14,10 @@ import (
 // usersV3Get godoc
 //
 //	@summary		Get an individual User
-//	@description	Get an individual User. As a special case, "me" can be passed as the selector to get the current user.
+//	@description	Get an individual User. As a special case, "me" or "self" can be passed as the selector to get the current user.
 //	@tags			Users
 //	@produce		json
-//	@param			selector				path		string	true	"The selector of the User, which can be either a numeric ID, the email, 'google-id/{google subject ID}', 'github/{github username}', or 'github-id/{github numeric ID}'. As a special case, 'me' can be passed to get the calling user."
+//	@param			selector				path		string	true	"The selector of the User, which can be either a numeric ID, the email, 'google-id/{google subject ID}', 'github/{github username}', or 'github-id/{github numeric ID}'. As a special case, 'me' or 'self' can be passed to get the calling user."
 //	@success		200						{object}	UserV3
 //	@failure		400,403,404,407,409,500	{object}	errors.ErrorResponse
 //	@router			/api/users/v3/{selector} [get]
@@ -28,7 +28,7 @@ func usersV3Get(ctx *gin.Context) {
 	}
 	selector := canonicalizeSelector(ctx.Param("selector"))
 
-	if selector == "me" {
+	if selector == "me" || selector == "self" {
 		user, err := authentication.MustUseUser(ctx)
 		if err != nil {
 			return

--- a/sherlock/internal/api/sherlock/users_v3_get_test.go
+++ b/sherlock/internal/api/sherlock/users_v3_get_test.go
@@ -1,0 +1,92 @@
+package sherlock
+
+import (
+	"fmt"
+	"github.com/broadinstitute/sherlock/go-shared/pkg/testutils"
+	"github.com/broadinstitute/sherlock/sherlock/internal/models"
+	"github.com/stretchr/testify/assert"
+	"gorm.io/gorm"
+	"testing"
+)
+
+func Test_userModelFromSelector(t *testing.T) {
+	type args struct {
+		selector string
+	}
+	tests := []struct {
+		name      string
+		args      args
+		wantQuery models.User
+		wantErr   assert.ErrorAssertionFunc
+	}{
+		{
+			name:    "empty",
+			args:    args{selector: ""},
+			wantErr: assert.Error,
+		},
+		{
+			name:      "id",
+			args:      args{selector: "123"},
+			wantQuery: models.User{Model: gorm.Model{ID: 123}},
+			wantErr:   assert.NoError,
+		},
+		{
+			name:    "invalid id",
+			args:    args{selector: testutils.StringNumberTooBigForInt},
+			wantErr: assert.Error,
+		},
+		{
+			name:      "email",
+			args:      args{selector: "foo@example.com"},
+			wantQuery: models.User{Email: "foo@example.com"},
+			wantErr:   assert.NoError,
+		},
+		{
+			name:      "google id",
+			args:      args{selector: "google-id/foo"},
+			wantQuery: models.User{GoogleID: "foo"},
+			wantErr:   assert.NoError,
+		},
+		{
+			name:    "empty google id",
+			args:    args{selector: "google-id/"},
+			wantErr: assert.Error,
+		},
+		{
+			name:      "github username",
+			args:      args{selector: "github/foo"},
+			wantQuery: models.User{GithubUsername: testutils.PointerTo("foo")},
+			wantErr:   assert.NoError,
+		},
+		{
+			name:    "empty github username",
+			args:    args{selector: "github/"},
+			wantErr: assert.Error,
+		},
+		{
+			name:      "github id",
+			args:      args{selector: "github-id/foo"},
+			wantQuery: models.User{GithubID: testutils.PointerTo("foo")},
+			wantErr:   assert.NoError,
+		},
+		{
+			name:    "empty github id",
+			args:    args{selector: "github-id/"},
+			wantErr: assert.Error,
+		},
+		{
+			name:    "invalid",
+			args:    args{selector: "foo"},
+			wantErr: assert.Error,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotQuery, err := userModelFromSelector(tt.args.selector)
+			if !tt.wantErr(t, err, fmt.Sprintf("userModelFromSelector(%v)", tt.args.selector)) {
+				return
+			}
+			assert.Equalf(t, tt.wantQuery, gotQuery, "userModelFromSelector(%v)", tt.args.selector)
+		})
+	}
+}

--- a/sherlock/internal/api/sherlock/users_v3_get_test.go
+++ b/sherlock/internal/api/sherlock/users_v3_get_test.go
@@ -40,6 +40,7 @@ func (s *handlerSuite) TestUsersV3GetSelf() {
 				&got)
 			s.Equal(http.StatusOK, code)
 			s.Equal(test_users.SuitableTestUserEmail, got.Email)
+			s.True(*got.Suitable)
 		})
 	}
 }
@@ -68,6 +69,7 @@ func (s *handlerSuite) TestUserV3GetOthers() {
 			s.Equal(http.StatusOK, code)
 			s.Equal(dummyUser.ID, got.ID)
 			s.Equal(dummyUser.Email, got.Email)
+			s.False(*got.Suitable)
 		})
 	}
 }

--- a/sherlock/internal/api/sherlock/users_v3_list.go
+++ b/sherlock/internal/api/sherlock/users_v3_list.go
@@ -12,7 +12,7 @@ import (
 
 // usersV3List godoc
 //
-//	@summary		List Users matching a filter.
+//	@summary		List Users matching a filter
 //	@description	List Users matching a filter. The results will include suitability and other information.
 //	@description	Note that the suitability info can't directly be filtered for at this time.
 //	@tags			Users

--- a/sherlock/internal/api/sherlock/users_v3_list.go
+++ b/sherlock/internal/api/sherlock/users_v3_list.go
@@ -1,0 +1,57 @@
+package sherlock
+
+import (
+	"fmt"
+	"github.com/broadinstitute/sherlock/go-shared/pkg/utils"
+	"github.com/broadinstitute/sherlock/sherlock/internal/authentication"
+	"github.com/broadinstitute/sherlock/sherlock/internal/errors"
+	"github.com/broadinstitute/sherlock/sherlock/internal/models"
+	"github.com/gin-gonic/gin"
+	"net/http"
+)
+
+// usersV3List godoc
+//
+//	@summary		List Users matching a filter.
+//	@description	List Users matching a filter. The results will include suitability and other information.
+//	@description	Note that the suitability info can't directly be filtered for at this time.
+//	@tags			Users
+//	@produce		json
+//	@param			filter					query		UserV3	false	"Filter the returned Users"
+//	@param			limit					query		int		false	"Control how many Users are returned (default 0, no limit)"
+//	@param			offset					query		int		false	"Control the offset for the returned Users (default 0)"
+//	@success		200						{array}		UserV3
+//	@failure		400,403,404,407,409,500	{object}	errors.ErrorResponse
+//	@router			/api/users/v3 [get]
+func usersV3List(ctx *gin.Context) {
+	db, err := authentication.MustUseDB(ctx)
+	if err != nil {
+		return
+	}
+	var filter UserV3
+	if err = ctx.ShouldBindQuery(&filter); err != nil {
+		errors.AbortRequest(ctx, err)
+		return
+	}
+	modelFilter := filter.toModel()
+	limit, err := utils.ParseInt(ctx.DefaultQuery("limit", "0"))
+	if err != nil {
+		errors.AbortRequest(ctx, fmt.Errorf("(%s) %v", errors.BadRequest, err))
+		return
+	}
+	offset, err := utils.ParseInt(ctx.DefaultQuery("offset", "0"))
+	if err != nil {
+		errors.AbortRequest(ctx, fmt.Errorf("(%s) %v", errors.BadRequest, err))
+		return
+	}
+	var results []models.User
+	chain := db.Where(&modelFilter)
+	if limit > 0 {
+		chain = chain.Limit(limit)
+	}
+	if err = chain.Offset(offset).Order("email asc").Find(&results).Error; err != nil {
+		errors.AbortRequest(ctx, err)
+		return
+	}
+	ctx.JSON(http.StatusOK, utils.Map(results, userFromModel))
+}

--- a/sherlock/internal/api/sherlock/users_v3_list_test.go
+++ b/sherlock/internal/api/sherlock/users_v3_list_test.go
@@ -1,0 +1,92 @@
+package sherlock
+
+import (
+	"github.com/broadinstitute/sherlock/go-shared/pkg/testutils"
+	"github.com/broadinstitute/sherlock/sherlock/internal/authentication/test_users"
+	"github.com/broadinstitute/sherlock/sherlock/internal/models"
+	"net/http"
+)
+
+func (s *handlerSuite) TestUsersV3ListMinimal() {
+	var got []UserV3
+	code := s.HandleRequest(
+		s.NewRequest("GET", "/api/users/v3", nil),
+		&got)
+	s.Equal(http.StatusOK, code)
+	s.Len(got, 1)
+	// This'll never return 0 because the calling user will be upserted, but
+	// we can check that the only entry here is ourselves
+	s.Run("inserted user is self", func() {
+		s.Equal(test_users.SuitableTestUserEmail, got[0].Email)
+	})
+}
+
+func (s *handlerSuite) TestUsersV3List() {
+	user1 := models.User{
+		Email:    "email1@example.com",
+		GoogleID: "google-id-1",
+	}
+	user2 := models.User{
+		Email:    "email2@example.com",
+		GoogleID: "google-id-2",
+		Name:     testutils.PointerTo("a name"),
+	}
+	user3 := models.User{
+		Email:                  "email3@example.com",
+		GoogleID:               "google-id-3",
+		Name:                   testutils.PointerTo("a name"),
+		NameInferredFromGithub: testutils.PointerTo(false),
+		GithubID:               testutils.PointerTo("github-id-3"),
+		GithubUsername:         testutils.PointerTo("github-username-3"),
+	}
+	for _, user := range []models.User{user1, user2, user3} {
+		s.NoError(s.DB.Create(&user).Error)
+		s.NotZero(user.ID)
+	}
+
+	s.Run("all", func() {
+		var got []UserV3
+		code := s.HandleRequest(
+			s.NewRequest("GET", "/api/users/v3", nil),
+			&got)
+		s.Equal(http.StatusOK, code)
+		s.Len(got, 4)
+		s.Run("each has suitability", func() {
+			for _, user := range got {
+				s.NotZero(user.Suitable)
+				s.NotZero(user.SuitabilityDescription)
+			}
+		})
+	})
+	s.Run("none", func() {
+		var got []UserV3
+		code := s.HandleRequest(
+			s.NewRequest("GET", "/api/users/v3?name=foo", nil),
+			&got)
+		s.Equal(http.StatusOK, code)
+		s.Len(got, 0)
+	})
+	s.Run("some", func() {
+		var got []UserV3
+		code := s.HandleRequest(
+			s.NewRequest("GET", "/api/users/v3?name=a%20name", nil),
+			&got)
+		s.Equal(http.StatusOK, code)
+		s.Len(got, 2)
+	})
+	s.Run("limit and offset", func() {
+		var got1 []UserV3
+		code := s.HandleRequest(
+			s.NewRequest("GET", "/api/users/v3?limit=1", nil),
+			&got1)
+		s.Equal(http.StatusOK, code)
+		s.Len(got1, 1)
+		var got2 []UserV3
+		code = s.HandleRequest(
+			s.NewRequest("GET", "/api/users/v3?limit=1&offset=1", nil),
+			&got2)
+		s.Equal(http.StatusOK, code)
+		s.Len(got2, 1)
+		s.NotEqual(got1[0].ID, got2[0].ID)
+	})
+}

--- a/sherlock/internal/api/sherlock/users_v3_upsert.go
+++ b/sherlock/internal/api/sherlock/users_v3_upsert.go
@@ -1,0 +1,149 @@
+package sherlock
+
+import (
+	"context"
+	"fmt"
+	"github.com/broadinstitute/sherlock/sherlock/internal/authentication"
+	"github.com/broadinstitute/sherlock/sherlock/internal/errors"
+	"github.com/broadinstitute/sherlock/sherlock/internal/models"
+	"github.com/gin-gonic/gin"
+	"github.com/google/go-github/v50/github"
+	"github.com/rs/zerolog/log"
+	"golang.org/x/oauth2"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+type UserV3Upsert struct {
+	userDirectlyEditableFields
+	// An access token for the GitHub account to associate with the calling user. The access token isn't stored.
+	// The design here ensures that an association is only built when someone controls both accounts (Google via
+	// IAP and GitHub via this access token).
+	GithubAccessToken *string `json:"githubAccessToken"`
+}
+
+// usersV3Upsert godoc
+//
+//	@summary		Update the calling User's information
+//	@description	Update the calling User's information. As with all authenticated Sherlock endpoints,
+//	@description	newly-observed callers will have a User record added, meaning that this endpoint
+//	@description	behaves like an upsert.
+//	@tags			Users
+//	@accept			json
+//	@produce		json
+//	@param			user					body		UserV3Upsert	false	"The User data to update"
+//	@success		200,201					{object}	UserV3
+//	@failure		400,403,404,407,409,500	{object}	errors.ErrorResponse
+//	@router			/api/users/v3 [put]
+func usersV3Upsert(ctx *gin.Context) {
+	db, err := authentication.MustUseDB(ctx)
+	if err != nil {
+		return
+	}
+	var body UserV3Upsert
+	if err = ctx.ShouldBindJSON(&body); err != nil {
+		errors.AbortRequest(ctx, fmt.Errorf("(%s) request validation error: %v", err))
+		return
+	}
+
+	var githubUser *github.User
+	if body.GithubAccessToken != nil {
+		tokenSource := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: *body.GithubAccessToken})
+		timeoutContext, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		githubClient := github.NewClient(oauth2.NewClient(timeoutContext, tokenSource))
+		githubUser, _, err = githubClient.Users.Get(timeoutContext, "")
+		cancel()
+		if err != nil {
+			errors.AbortRequest(ctx, fmt.Errorf("(%s) GitHub API responded to getting access token's identity with an error: %v", errors.BadRequest, err))
+			return
+		} else if githubUser == nil {
+			errors.AbortRequest(ctx, fmt.Errorf("(%s) GitHub API responded to getting access token's identity with an empty response but no error", errors.BadRequest))
+			return
+		} else if githubUser.ID == nil || githubUser.Login == nil {
+			errors.AbortRequest(ctx, fmt.Errorf("(%s) GitHub API responded to getting access token's identity without providing an ID and/or username", errors.InternalServerError))
+			return
+		}
+	}
+
+	callingUser, err := authentication.MustUseUser(ctx)
+	if err != nil {
+		return
+	}
+
+	callingUser, hasUpdates := processUserEdits(callingUser, githubUser, body.userDirectlyEditableFields)
+	if hasUpdates {
+		if err = db.Save(callingUser).Error; err != nil {
+			errors.AbortRequest(ctx, err)
+			return
+		}
+		ctx.JSON(http.StatusCreated, userFromModel(*callingUser))
+	} else {
+		ctx.JSON(http.StatusOK, userFromModel(*callingUser))
+	}
+}
+
+func processUserEdits(callingUser *models.User, githubUser *github.User, directEdits userDirectlyEditableFields) (*models.User, bool) {
+	hasUpdates := false
+
+	// If direct edits set NameInferredFromGithub and callingUser lacks it or has a different value, set it
+	if directEdits.NameInferredFromGithub != nil &&
+		(callingUser.NameInferredFromGithub == nil || *directEdits.NameInferredFromGithub != *callingUser.NameInferredFromGithub) {
+		callingUser.NameInferredFromGithub = directEdits.NameInferredFromGithub
+		hasUpdates = true
+	}
+
+	// If callingUser lacks NameInferredFromGithub or has it false, and direct edits set Name, and callingUser lacks it or has a different value, set it
+	if (callingUser.NameInferredFromGithub == nil || !*callingUser.NameInferredFromGithub) &&
+		directEdits.Name != nil &&
+		(callingUser.Name == nil || *directEdits.Name != *callingUser.Name) {
+		callingUser.Name = directEdits.Name
+		hasUpdates = true
+	}
+
+	// If we have a githubUser:
+	if githubUser != nil {
+
+		githubUserIdString := strconv.FormatInt(*githubUser.ID, 10)
+
+		// If callingUser lacks GitHub info, set it and log
+		if callingUser.GithubID == nil || callingUser.GithubUsername == nil {
+			callingUser.GithubID = &githubUserIdString
+			callingUser.GithubUsername = githubUser.Login
+			hasUpdates = true
+			log.Info().Msgf("GH   | first-time github account linking from %s to github account %s (ID: %s)", callingUser.Email, *githubUser.Login, githubUserIdString)
+		}
+
+		// If callingUser has different IDed GitHub info stored, update it and log
+		if *callingUser.GithubID != githubUserIdString {
+			callingUser.GithubID = &githubUserIdString
+			callingUser.GithubUsername = githubUser.Login
+			hasUpdates = true
+			log.Info().Msgf("GH   | github account linking from %s changing from github account %s (ID: %s) to %s (ID: %s)", callingUser.Email, *callingUser.GithubUsername, *callingUser.GithubID, *githubUser.Login, githubUserIdString)
+		}
+
+		// If callingUser has same IDed GitHub info stored but new name, update it and log
+		if *callingUser.GithubID == githubUserIdString && *callingUser.GithubUsername != *githubUser.Login {
+			callingUser.GithubUsername = githubUser.Login
+			hasUpdates = true
+			log.Info().Msgf("GH   | github account linking from %s had new username for same github account (ID: %s), %s to %s", callingUser.Email, githubUserIdString, *callingUser.GithubUsername, *githubUser.Login)
+		}
+
+		// If callingUser lacks NameInferredFromGithub, default it to true
+		if callingUser.NameInferredFromGithub == nil {
+			trueValue := true
+			callingUser.NameInferredFromGithub = &trueValue
+			hasUpdates = true
+		}
+
+		// If githubUser has Name, and callingUser has true NameInferredFromGithub, and callingUser lacks Name or has a different value, set it
+		if githubUser.Name != nil &&
+			callingUser.NameInferredFromGithub != nil && *callingUser.NameInferredFromGithub &&
+			(callingUser.Name == nil || *githubUser.Name != *callingUser.Name) {
+			callingUser.Name = githubUser.Name
+			hasUpdates = true
+		}
+	}
+	return callingUser, hasUpdates
+}

--- a/sherlock/internal/api/sherlock/users_v3_upsert.go
+++ b/sherlock/internal/api/sherlock/users_v3_upsert.go
@@ -130,10 +130,10 @@ func processUserEdits(callingUser *models.User, githubUser *github.User, directE
 			log.Info().Msgf("GH   | github account linking from %s had new username for same github account (ID: %s), %s to %s", callingUser.Email, githubUserIdString, *callingUser.GithubUsername, *githubUser.Login)
 		}
 
-		// If callingUser lacks NameInferredFromGithub, default it to true
+		// If callingUser lacks NameInferredFromGithub, default it to whether or not the callingUser already has a name
 		if callingUser.NameInferredFromGithub == nil {
-			trueValue := true
-			callingUser.NameInferredFromGithub = &trueValue
+			shouldInferFromGithub := callingUser.Name == nil
+			callingUser.NameInferredFromGithub = &shouldInferFromGithub
 			hasUpdates = true
 		}
 

--- a/sherlock/internal/api/sherlock/users_v3_upsert.go
+++ b/sherlock/internal/api/sherlock/users_v3_upsert.go
@@ -43,7 +43,7 @@ func usersV3Upsert(ctx *gin.Context) {
 	}
 	var body UserV3Upsert
 	if err = ctx.ShouldBindJSON(&body); err != nil {
-		errors.AbortRequest(ctx, fmt.Errorf("(%s) request validation error: %v", err))
+		errors.AbortRequest(ctx, fmt.Errorf("(%s) request validation error: %v", errors.BadRequest, err))
 		return
 	}
 

--- a/sherlock/internal/api/sherlock/users_v3_upsert.go
+++ b/sherlock/internal/api/sherlock/users_v3_upsert.go
@@ -100,6 +100,12 @@ func processUserEdits(callingUser *models.User, githubUser *github.User, directE
 		(callingUser.Name == nil || *directEdits.Name != *callingUser.Name) {
 		callingUser.Name = directEdits.Name
 		hasUpdates = true
+
+		// If callingUser lacks NameInferredFromGithub but we just set Name directly, set it to false
+		if callingUser.NameInferredFromGithub == nil {
+			falseValue := false
+			callingUser.NameInferredFromGithub = &falseValue
+		}
 	}
 
 	// If we have a githubUser:

--- a/sherlock/internal/api/sherlock/users_v3_upsert_test.go
+++ b/sherlock/internal/api/sherlock/users_v3_upsert_test.go
@@ -1,0 +1,296 @@
+package sherlock
+
+import (
+	"github.com/broadinstitute/sherlock/go-shared/pkg/testutils"
+	"github.com/broadinstitute/sherlock/sherlock/internal/config"
+	"github.com/broadinstitute/sherlock/sherlock/internal/models"
+	"github.com/google/go-github/v50/github"
+	"github.com/stretchr/testify/assert"
+	"gorm.io/gorm"
+	"testing"
+)
+
+func Test_processUserEdits(t *testing.T) {
+	// Load the test config to make sure we silence the log messages here
+	config.LoadTestConfig()
+	type args struct {
+		callingUser *models.User
+		githubUser  *github.User
+		directEdits userDirectlyEditableFields
+	}
+	tests := []struct {
+		name        string
+		args        args
+		want        *models.User
+		wantChanged bool
+	}{
+		{
+			name:        "keeps same model",
+			args:        args{callingUser: &models.User{Model: gorm.Model{ID: 123}, Email: "foo@bar.com"}},
+			want:        &models.User{Model: gorm.Model{ID: 123}, Email: "foo@bar.com"},
+			wantChanged: false,
+		},
+		{
+			name: "set name inferred from github when empty",
+			args: args{
+				callingUser: &models.User{},
+				directEdits: userDirectlyEditableFields{NameInferredFromGithub: testutils.PointerTo(true)},
+			},
+			want:        &models.User{NameInferredFromGithub: testutils.PointerTo(true)},
+			wantChanged: true,
+		},
+		{
+			name: "set name inferred from github when different value",
+			args: args{
+				callingUser: &models.User{NameInferredFromGithub: testutils.PointerTo(true)},
+				directEdits: userDirectlyEditableFields{NameInferredFromGithub: testutils.PointerTo(false)},
+			},
+			want:        &models.User{NameInferredFromGithub: testutils.PointerTo(false)},
+			wantChanged: true,
+		},
+		{
+			name: "keeps name inferred from github setting when same",
+			args: args{
+				callingUser: &models.User{NameInferredFromGithub: testutils.PointerTo(true)},
+				directEdits: userDirectlyEditableFields{NameInferredFromGithub: testutils.PointerTo(true)},
+			},
+			want:        &models.User{NameInferredFromGithub: testutils.PointerTo(true)},
+			wantChanged: false,
+		},
+		{
+			name: "set name when empty",
+			args: args{
+				callingUser: &models.User{},
+				directEdits: userDirectlyEditableFields{Name: testutils.PointerTo("name")},
+			},
+			want:        &models.User{Name: testutils.PointerTo("name")},
+			wantChanged: true,
+		},
+		{
+			name: "set name when different value",
+			args: args{
+				callingUser: &models.User{Name: testutils.PointerTo("different name")},
+				directEdits: userDirectlyEditableFields{Name: testutils.PointerTo("name")},
+			},
+			want:        &models.User{Name: testutils.PointerTo("name")},
+			wantChanged: true,
+		},
+		{
+			name: "keep name when same",
+			args: args{
+				callingUser: &models.User{Name: testutils.PointerTo("name")},
+				directEdits: userDirectlyEditableFields{Name: testutils.PointerTo("name")},
+			},
+			want:        &models.User{Name: testutils.PointerTo("name")},
+			wantChanged: false,
+		},
+		{
+			name: "ignores name change when inferred from github",
+			args: args{
+				callingUser: &models.User{
+					Name:                   testutils.PointerTo("different name"),
+					NameInferredFromGithub: testutils.PointerTo(true),
+				},
+				directEdits: userDirectlyEditableFields{Name: testutils.PointerTo("name")},
+			},
+			want: &models.User{
+				Name:                   testutils.PointerTo("different name"),
+				NameInferredFromGithub: testutils.PointerTo(true),
+			},
+			wantChanged: false,
+		},
+		{
+			name: "ignores name change when also setting inferred from github",
+			args: args{
+				callingUser: &models.User{
+					Name: testutils.PointerTo("different name"),
+				},
+				directEdits: userDirectlyEditableFields{
+					Name:                   testutils.PointerTo("name"),
+					NameInferredFromGithub: testutils.PointerTo(true),
+				},
+			},
+			want: &models.User{
+				Name:                   testutils.PointerTo("different name"),
+				NameInferredFromGithub: testutils.PointerTo(true),
+			},
+			wantChanged: true,
+		},
+		{
+			name: "respects name change when also setting inferred from github",
+			args: args{
+				callingUser: &models.User{
+					Name:                   testutils.PointerTo("different name"),
+					NameInferredFromGithub: testutils.PointerTo(true),
+				},
+				directEdits: userDirectlyEditableFields{
+					Name:                   testutils.PointerTo("name"),
+					NameInferredFromGithub: testutils.PointerTo(false),
+				},
+			},
+			want: &models.User{
+				Name:                   testutils.PointerTo("name"),
+				NameInferredFromGithub: testutils.PointerTo(false),
+			},
+			wantChanged: true,
+		},
+		{
+			name: "sets github info with name inference to true when name absent",
+			args: args{
+				callingUser: &models.User{},
+				githubUser: &github.User{
+					ID:    testutils.PointerTo[int64](123),
+					Login: testutils.PointerTo("username"),
+				},
+			},
+			want: &models.User{
+				GithubID:               testutils.PointerTo("123"),
+				GithubUsername:         testutils.PointerTo("username"),
+				NameInferredFromGithub: testutils.PointerTo(true),
+			},
+			wantChanged: true,
+		},
+		{
+			name: "sets github info with name inference to false when name present",
+			args: args{
+				callingUser: &models.User{
+					Name: testutils.PointerTo("name"),
+				},
+				githubUser: &github.User{
+					ID:    testutils.PointerTo[int64](123),
+					Login: testutils.PointerTo("username"),
+				},
+			},
+			want: &models.User{
+				Name:                   testutils.PointerTo("name"),
+				GithubID:               testutils.PointerTo("123"),
+				GithubUsername:         testutils.PointerTo("username"),
+				NameInferredFromGithub: testutils.PointerTo(false),
+			},
+			wantChanged: true,
+		},
+		{
+			name: "sets name from github",
+			args: args{
+				callingUser: &models.User{},
+				githubUser: &github.User{
+					ID:    testutils.PointerTo[int64](123),
+					Login: testutils.PointerTo("username"),
+					Name:  testutils.PointerTo("name"),
+				},
+			},
+			want: &models.User{
+				Name:                   testutils.PointerTo("name"),
+				GithubID:               testutils.PointerTo("123"),
+				GithubUsername:         testutils.PointerTo("username"),
+				NameInferredFromGithub: testutils.PointerTo(true),
+			},
+			wantChanged: true,
+		},
+		{
+			name: "ignores name from github if disabled",
+			args: args{
+				callingUser: &models.User{
+					NameInferredFromGithub: testutils.PointerTo(false),
+				},
+				githubUser: &github.User{
+					ID:    testutils.PointerTo[int64](123),
+					Login: testutils.PointerTo("username"),
+					Name:  testutils.PointerTo("name"),
+				},
+			},
+			want: &models.User{
+				GithubID:               testutils.PointerTo("123"),
+				GithubUsername:         testutils.PointerTo("username"),
+				NameInferredFromGithub: testutils.PointerTo(false),
+			},
+			wantChanged: true,
+		},
+		{
+			name: "updates name from github",
+			args: args{
+				callingUser: &models.User{
+					Name:                   testutils.PointerTo("different name"),
+					NameInferredFromGithub: testutils.PointerTo(true),
+				},
+				githubUser: &github.User{
+					ID:    testutils.PointerTo[int64](123),
+					Login: testutils.PointerTo("username"),
+					Name:  testutils.PointerTo("name"),
+				},
+			},
+			want: &models.User{
+				Name:                   testutils.PointerTo("name"),
+				GithubID:               testutils.PointerTo("123"),
+				GithubUsername:         testutils.PointerTo("username"),
+				NameInferredFromGithub: testutils.PointerTo(true),
+			},
+			wantChanged: true,
+		},
+		{
+			name: "updates github info if account changes",
+			args: args{
+				callingUser: &models.User{
+					GithubID:       testutils.PointerTo("old ID"),
+					GithubUsername: testutils.PointerTo("old username"),
+				},
+				githubUser: &github.User{
+					ID:    testutils.PointerTo[int64](123),
+					Login: testutils.PointerTo("username"),
+				},
+			},
+			want: &models.User{
+				GithubID:               testutils.PointerTo("123"),
+				GithubUsername:         testutils.PointerTo("username"),
+				NameInferredFromGithub: testutils.PointerTo(true),
+			},
+			wantChanged: true,
+		},
+		{
+			name: "updates github info if just username changes",
+			args: args{
+				callingUser: &models.User{
+					GithubID:       testutils.PointerTo("123"),
+					GithubUsername: testutils.PointerTo("old username"),
+				},
+				githubUser: &github.User{
+					ID:    testutils.PointerTo[int64](123),
+					Login: testutils.PointerTo("username"),
+				},
+			},
+			want: &models.User{
+				GithubID:               testutils.PointerTo("123"),
+				GithubUsername:         testutils.PointerTo("username"),
+				NameInferredFromGithub: testutils.PointerTo(true),
+			},
+			wantChanged: true,
+		},
+		{
+			name: "doesn't update if github info equivalent",
+			args: args{
+				callingUser: &models.User{
+					GithubID:               testutils.PointerTo("123"),
+					GithubUsername:         testutils.PointerTo("username"),
+					NameInferredFromGithub: testutils.PointerTo(true),
+				},
+				githubUser: &github.User{
+					ID:    testutils.PointerTo[int64](123),
+					Login: testutils.PointerTo("username"),
+				},
+			},
+			want: &models.User{
+				GithubID:               testutils.PointerTo("123"),
+				GithubUsername:         testutils.PointerTo("username"),
+				NameInferredFromGithub: testutils.PointerTo(true),
+			},
+			wantChanged: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, got1 := processUserEdits(tt.args.callingUser, tt.args.githubUser, tt.args.directEdits)
+			assert.Equalf(t, tt.want, got, "processUserEdits(%v, %v, %v)", tt.args.callingUser, tt.args.githubUser, tt.args.directEdits)
+			assert.Equalf(t, tt.wantChanged, got1, "processUserEdits(%v, %v, %v)", tt.args.callingUser, tt.args.githubUser, tt.args.directEdits)
+		})
+	}
+}

--- a/sherlock/internal/authentication/db_middleware.go
+++ b/sherlock/internal/authentication/db_middleware.go
@@ -40,7 +40,7 @@ func ShouldUseDB(ctx *gin.Context) (*gorm.DB, error) {
 func MustUseDB(ctx *gin.Context) (*gorm.DB, error) {
 	db, err := ShouldUseDB(ctx)
 	if err != nil {
-		ctx.AbortWithStatusJSON(errors.ErrorToApiResponse(err))
+		errors.AbortRequest(ctx, err)
 	}
 	return db, nil
 }

--- a/sherlock/internal/authentication/user_middleware.go
+++ b/sherlock/internal/authentication/user_middleware.go
@@ -108,7 +108,7 @@ func ShouldUseUser(ctx *gin.Context) (*models.User, error) {
 func MustUseUser(ctx *gin.Context) (*models.User, error) {
 	user, err := ShouldUseUser(ctx)
 	if err != nil {
-		ctx.AbortWithStatusJSON(errors.ErrorToApiResponse(err))
+		errors.AbortRequest(ctx, err)
 	}
 	return user, err
 }


### PR DESCRIPTION
Adds refactored v3 user endpoints that expose suitability. This is safe because the entire API is only accessible from internal users; there's not information leakage since the entire audience is allowed to know the info we're exposing.

The PUT endpoint now does the GitHub account linking instead of having a separate endpoint for it. It's a bit weird because we basically _need_ to proxy the GitHub API in order for the operation to be secure (we need to call the GitHub API with the user's token), but that's not new, that's existing behavior that I'm just replicating into the refactored world.

An important note here is that the model-level user stuff was already added in #202, I'm just going to the effort of exposing it in the API now.

## Testing

There's tests for everything I can test offline. The call to the github client library that returns the authenticated user user can't be tested offline and frankly I don't think it's worth the effort to figure out how -- I tested that part locally and it worked.

## Risk

Super low. Additional APIs that Beehive will have to opt-into using.