### PR TITLE
[DDO-2991] Block shutdown during migrations

### DIFF
--- a/sherlock/internal/api/sherlock/ci_runs_v3_upsert_test.go
+++ b/sherlock/internal/api/sherlock/ci_runs_v3_upsert_test.go
@@ -312,78 +312,75 @@ func (s *handlerSuite) TestCiRunsV3UpsertIdentifiers() {
 		})
 	})
 	s.Run("changeset spreading for non-static only when set to always", func() {
+		var got CiRunV3
+		code := s.HandleRequest(
+			s.NewRequest("PUT", "/api/ci-runs/v3", CiRunV3Upsert{
+				ciRunFields: ciRunFields{
+					Platform:                   "github-actions",
+					GithubActionsOwner:         "owner",
+					GithubActionsRepo:          "repo",
+					GithubActionsRunID:         1,
+					GithubActionsAttemptNumber: 200,
+					GithubActionsWorkflowPath:  "workflow",
+				},
+				Changesets:                   []string{utils.UintToString(templateChangeset.ID)},
+				RelateToChangesetNewVersions: "never",
+			}),
+			&got)
 		s.Run("never", func() {
-			var got CiRunV3
-			code := s.HandleRequest(
-				s.NewRequest("PUT", "/api/ci-runs/v3", CiRunV3Upsert{
-					ciRunFields: ciRunFields{
-						Platform:                   "github-actions",
-						GithubActionsOwner:         "owner",
-						GithubActionsRepo:          "repo",
-						GithubActionsRunID:         1,
-						GithubActionsAttemptNumber: 200,
-						GithubActionsWorkflowPath:  "workflow",
-					},
-					Changesets:                   []string{utils.UintToString(templateChangeset.ID)},
-					RelateToChangesetNewVersions: "never",
-				}),
-				&got)
 			s.Equal(http.StatusCreated, code)
 			s.Len(got.RelatedResources, 4)
 		})
+		code = s.HandleRequest(
+			s.NewRequest("PUT", "/api/ci-runs/v3", CiRunV3Upsert{
+				ciRunFields: ciRunFields{
+					Platform:                   "github-actions",
+					GithubActionsOwner:         "owner",
+					GithubActionsRepo:          "repo",
+					GithubActionsRunID:         1,
+					GithubActionsAttemptNumber: 200,
+					GithubActionsWorkflowPath:  "workflow",
+				},
+				Changesets: []string{utils.UintToString(templateChangeset.ID)},
+			}),
+			&got)
 		s.Run("default", func() {
-			var got CiRunV3
-			code := s.HandleRequest(
-				s.NewRequest("PUT", "/api/ci-runs/v3", CiRunV3Upsert{
-					ciRunFields: ciRunFields{
-						Platform:                   "github-actions",
-						GithubActionsOwner:         "owner",
-						GithubActionsRepo:          "repo",
-						GithubActionsRunID:         1,
-						GithubActionsAttemptNumber: 200,
-						GithubActionsWorkflowPath:  "workflow",
-					},
-					Changesets: []string{utils.UintToString(templateChangeset.ID)},
-				}),
-				&got)
 			s.Equal(http.StatusCreated, code)
 			s.Len(got.RelatedResources, 4)
 		})
+		code = s.HandleRequest(
+			s.NewRequest("PUT", "/api/ci-runs/v3", CiRunV3Upsert{
+				ciRunFields: ciRunFields{
+					Platform:                   "github-actions",
+					GithubActionsOwner:         "owner",
+					GithubActionsRepo:          "repo",
+					GithubActionsRunID:         1,
+					GithubActionsAttemptNumber: 200,
+					GithubActionsWorkflowPath:  "workflow",
+				},
+				Changesets:                   []string{utils.UintToString(templateChangeset.ID)},
+				RelateToChangesetNewVersions: "when-static",
+			}),
+			&got)
 		s.Run("explicit when-static", func() {
-			var got CiRunV3
-			code := s.HandleRequest(
-				s.NewRequest("PUT", "/api/ci-runs/v3", CiRunV3Upsert{
-					ciRunFields: ciRunFields{
-						Platform:                   "github-actions",
-						GithubActionsOwner:         "owner",
-						GithubActionsRepo:          "repo",
-						GithubActionsRunID:         1,
-						GithubActionsAttemptNumber: 200,
-						GithubActionsWorkflowPath:  "workflow",
-					},
-					Changesets:                   []string{utils.UintToString(templateChangeset.ID)},
-					RelateToChangesetNewVersions: "when-static",
-				}),
-				&got)
 			s.Equal(http.StatusCreated, code)
 			s.Len(got.RelatedResources, 4)
 		})
+		code = s.HandleRequest(
+			s.NewRequest("PUT", "/api/ci-runs/v3", CiRunV3Upsert{
+				ciRunFields: ciRunFields{
+					Platform:                   "github-actions",
+					GithubActionsOwner:         "owner",
+					GithubActionsRepo:          "repo",
+					GithubActionsRunID:         1,
+					GithubActionsAttemptNumber: 200,
+					GithubActionsWorkflowPath:  "workflow",
+				},
+				Changesets:                   []string{utils.UintToString(templateChangeset.ID)},
+				RelateToChangesetNewVersions: "always",
+			}),
+			&got)
 		s.Run("always", func() {
-			var got CiRunV3
-			code := s.HandleRequest(
-				s.NewRequest("PUT", "/api/ci-runs/v3", CiRunV3Upsert{
-					ciRunFields: ciRunFields{
-						Platform:                   "github-actions",
-						GithubActionsOwner:         "owner",
-						GithubActionsRepo:          "repo",
-						GithubActionsRunID:         1,
-						GithubActionsAttemptNumber: 200,
-						GithubActionsWorkflowPath:  "workflow",
-					},
-					Changesets:                   []string{utils.UintToString(templateChangeset.ID)},
-					RelateToChangesetNewVersions: "always",
-				}),
-				&got)
 			s.Equal(http.StatusCreated, code)
 			s.Len(got.RelatedResources, 6)
 		})

--- a/sherlock/internal/boot/application.go
+++ b/sherlock/internal/boot/application.go
@@ -141,7 +141,7 @@ func (a *Application) Stop() {
 	if a.sqlDB != nil {
 		log.Info().Msgf("BOOT | closing database connections...")
 		if wasUnlocked := a.dbMigrationLock.TryLock(); !wasUnlocked {
-			log.Warn().Msgf("BOOT | detected database migration underway, attempting to wait until it completes...")
+			log.Info().Msgf("BOOT | detected database migration underway, attempting to wait until it completes...")
 			a.dbMigrationLock.Lock()
 			log.Info().Msgf("BOOT | database migration complete, proceeding with connection close...")
 		}

--- a/sherlock/internal/boot/application_test.go
+++ b/sherlock/internal/boot/application_test.go
@@ -23,7 +23,6 @@ func (s *applicationSuite) SetupSuite() {
 }
 
 func (s *applicationSuite) TestApplication_StartStop() {
-	config.LoadTestConfig()
 	application := &Application{
 		runInsideDatabaseTransaction: true,
 	}
@@ -55,7 +54,6 @@ func (s *applicationSuite) TestApplication_StartStop() {
 }
 
 func (s *applicationSuite) TestApplication_dbMigrationLock() {
-	config.LoadTestConfig()
 	sqlDB, err := db.Connect()
 	s.NoError(err)
 	application := &Application{

--- a/sherlock/internal/boot/application_test.go
+++ b/sherlock/internal/boot/application_test.go
@@ -2,8 +2,10 @@ package boot
 
 import (
 	"github.com/broadinstitute/sherlock/sherlock/internal/config"
+	"github.com/broadinstitute/sherlock/sherlock/internal/db"
 	"github.com/stretchr/testify/assert"
 	"net/http"
+	"sync"
 	"testing"
 	"time"
 )
@@ -38,4 +40,47 @@ func TestApplication_StartStop(t *testing.T) {
 		assert.Truef(t, livenessSucceeded, ":8081 returned 200")
 		assert.Truef(t, readinessSucceeded, ":8080/status returned 200")
 	})
+}
+
+func TestApplication_dbMigrationLock(t *testing.T) {
+	config.LoadTestConfig()
+	sqlDB, err := db.Connect()
+	assert.NoError(t, err)
+	application := &Application{
+		sqlDB: sqlDB,
+	}
+	// Pretend that a migration is ongoing
+	application.dbMigrationLock.Lock()
+
+	// We want to block until the Stop() goroutine finishes, so we'll have it unlock this mutex
+	completedMarker := sync.Mutex{}
+	completedMarker.Lock()
+
+	// We want to know that the Stop() call blocks until it shouldn't, so we have a boolean
+	// with a mutex around it so that we can change whether the assertion passes or fails from
+	// outside.
+	completionDesired := false
+	completionDesiredMutex := sync.Mutex{}
+	go func() {
+		application.Stop()
+		completionDesiredMutex.Lock()
+		assert.True(t, completionDesired)
+		completionDesiredMutex.Unlock()
+
+		// Unlock this to indicate that the test can exit
+		completedMarker.Unlock()
+	}()
+
+	// Sleep so that we make sure the goroutine should be blocking on Stop()
+	time.Sleep(time.Second)
+
+	// Pretend that the migration just completed
+	completionDesiredMutex.Lock()
+	application.dbMigrationLock.Unlock()
+	completionDesired = true
+	completionDesiredMutex.Unlock()
+
+	// Block for completion of the goroutine
+	completedMarker.Lock()
+	completedMarker.Unlock()
 }

--- a/sherlock/internal/boot/application_test.go
+++ b/sherlock/internal/boot/application_test.go
@@ -82,5 +82,8 @@ func TestApplication_dbMigrationLock(t *testing.T) {
 
 	// Block for completion of the goroutine
 	completedMarker.Lock()
+
+	// Have to make the linter stand down
+	//nolint:staticcheck
 	completedMarker.Unlock()
 }


### PR DESCRIPTION
An improved bit of resilience based on my idea here https://broadinstitute.slack.com/archives/C029LTN5L80/p1690468925684809?thread_ts=1690468008.475729&cid=C029LTN5L80

An application-level mutex lock is actually a bit easier for us to work with than trying to repeatedly query the actual database lock table, and it solves the issue here equally well.

Also fixing a flakey test here, just borrowing my fix from #220 because that PR won't be ready for a bit.

## Testing

I think this case is basically impossible to hit. But I wrote a test that hits it anyway.

## Risk

None