### PR TITLE
[DDO-2992] Run the "panic if cloud SQL" check earlier

### DIFF
--- a/sherlock/internal/deprecated_db/test_helpers.go
+++ b/sherlock/internal/deprecated_db/test_helpers.go
@@ -70,7 +70,11 @@ func Truncate(t *testing.T, gormDB *gorm.DB) {
 		t.Errorf("refusing to truncate database, mode is '%s' instead of 'debug'", mode)
 		return
 	}
-	db.PanicIfLooksLikeCloudSQL(gormDB)
+	if sqlDB, err := gormDB.DB(); err != nil {
+		log.Fatal().Msgf("refusing to truncate, failed to get sql.DB from gorm.DB: %v", err)
+	} else {
+		db.PanicIfLooksLikeCloudSQL(sqlDB)
+	}
 	var statements []string
 	dryRunDB := gormDB.Session(&gorm.Session{
 		// Performance boost, don't transact each delete individually


### PR DESCRIPTION
Run it during db.Connect() rather than db.Configure(). Noticed this possible improvement while doing #221.

## Testing

These codepaths are already tested.

## Risk

None