### PR TITLE
Experimenting with Software Catalog for Foundation - Add foundation.yaml

### DIFF
--- a/foundation.yaml
+++ b/foundation.yaml
@@ -1,0 +1,16 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: sherlock
+  description: |
+    Sherlock stores information about our Kubernetes-based deployments, including Helm Chart versions and application versions. 
+    Sherlock doesn't do the deploying itself--it offers an API that other tools can use to understand our infrastructure.
+  tags:
+    - go
+    - sherlock
+    - kubernetes
+    - dsp-devops
+spec:
+  type: service
+  lifecycle: production
+  owner: dsp-devops


### PR DESCRIPTION
I'm experimenting with [backstage](https://backstage.spotify.com/) for Foundation purposes and need some real services to be able to try features out on my dev instance so I'm using sherlock and beehive. This metadata file is what enables services to be registered in the foundation service catalog

This is a 0 zero risk PR, functional change just adds a project metadata file for foundation to consume.