### PR TITLE
[DDO-3019] Add more refactored read-only models

### DIFF
--- a/sherlock/internal/models/app_version.go
+++ b/sherlock/internal/models/app_version.go
@@ -1,0 +1,28 @@
+package models
+
+import "gorm.io/gorm"
+
+type AppVersion struct {
+	gorm.Model
+	CiIdentifier       *CiIdentifier `gorm:"polymorphic:Resource; polymorphicValue:app-version"`
+	Chart              *Chart
+	ChartID            uint
+	AppVersion         string
+	GitCommit          string
+	GitBranch          string
+	Description        string
+	ParentAppVersion   *AppVersion
+	ParentAppVersionID *uint
+}
+
+func (a AppVersion) TableName() string {
+	return "v2_app_versions"
+}
+
+func (a AppVersion) GetCiIdentifier() *CiIdentifier {
+	if a.CiIdentifier != nil {
+		return a.CiIdentifier
+	} else {
+		return &CiIdentifier{ResourceType: "app-version", ResourceID: a.ID}
+	}
+}

--- a/sherlock/internal/models/chart_release.go
+++ b/sherlock/internal/models/chart_release.go
@@ -1,0 +1,36 @@
+package models
+
+import "gorm.io/gorm"
+
+type ChartRelease struct {
+	gorm.Model
+	CiIdentifier    *CiIdentifier `gorm:"polymorphic:Resource; polymorphicValue:chart-release"`
+	Chart           *Chart
+	ChartID         uint
+	Cluster         *Cluster
+	ClusterID       *uint
+	DestinationType string
+	Environment     *Environment
+	EnvironmentID   *uint
+	Name            string
+	Namespace       string
+	ChartReleaseVersion
+	Subdomain               *string
+	Protocol                *string
+	Port                    *uint
+	PagerdutyIntegration    *PagerdutyIntegration
+	PagerdutyIntegrationID  *uint
+	IncludeInBulkChangesets *bool
+}
+
+func (c ChartRelease) TableName() string {
+	return "v2_chart_releases"
+}
+
+func (c ChartRelease) GetCiIdentifier() *CiIdentifier {
+	if c.CiIdentifier != nil {
+		return c.CiIdentifier
+	} else {
+		return &CiIdentifier{ResourceType: "chart-release", ResourceID: c.ID}
+	}
+}

--- a/sherlock/internal/models/chart_release_version.go
+++ b/sherlock/internal/models/chart_release_version.go
@@ -1,0 +1,29 @@
+package models
+
+import "time"
+
+// ChartReleaseVersion isn't stored in the database on its own, it is included as a part of a ChartRelease or
+// Changeset. It has especially strict validation that requires it being fully loaded from the database. The resolve
+// method will help "load" it fully from the database so it can survive validation.
+type ChartReleaseVersion struct {
+	ResolvedAt *time.Time
+
+	AppVersionResolver             *string
+	AppVersionExact                *string
+	AppVersionBranch               *string
+	AppVersionCommit               *string
+	AppVersionFollowChartRelease   *ChartRelease
+	AppVersionFollowChartReleaseID *uint
+	AppVersion                     *AppVersion
+	AppVersionID                   *uint
+
+	ChartVersionResolver             *string
+	ChartVersionExact                *string
+	ChartVersionFollowChartRelease   *ChartRelease
+	ChartVersionFollowChartReleaseID *uint
+	ChartVersion                     *ChartVersion
+	ChartVersionID                   *uint
+
+	HelmfileRef         *string
+	FirecloudDevelopRef *string
+}

--- a/sherlock/internal/models/chart_version.go
+++ b/sherlock/internal/models/chart_version.go
@@ -1,0 +1,26 @@
+package models
+
+import "gorm.io/gorm"
+
+type ChartVersion struct {
+	gorm.Model
+	CiIdentifier         *CiIdentifier `gorm:"polymorphic:Resource; polymorphicValue:chart-version"`
+	Chart                *Chart
+	ChartID              uint
+	ChartVersion         string
+	Description          string
+	ParentChartVersion   *ChartVersion
+	ParentChartVersionID *uint
+}
+
+func (c ChartVersion) TableName() string {
+	return "v2_chart_versions"
+}
+
+func (c ChartVersion) GetCiIdentifier() *CiIdentifier {
+	if c.CiIdentifier != nil {
+		return c.CiIdentifier
+	} else {
+		return &CiIdentifier{ResourceType: "chart-version", ResourceID: c.ID}
+	}
+}

--- a/sherlock/internal/models/cluster.go
+++ b/sherlock/internal/models/cluster.go
@@ -1,0 +1,30 @@
+package models
+
+import "gorm.io/gorm"
+
+type Cluster struct {
+	gorm.Model
+	CiIdentifier      *CiIdentifier `gorm:"polymorphic:Resource; polymorphicValue:cluster"`
+	Name              string
+	Provider          string
+	GoogleProject     string
+	AzureSubscription string
+	Location          string
+	// Mutable
+	Base                *string
+	Address             *string
+	RequiresSuitability *bool
+	HelmfileRef         *string
+}
+
+func (c Cluster) TableName() string {
+	return "v2_clusters"
+}
+
+func (c Cluster) GetCiIdentifier() *CiIdentifier {
+	if c.CiIdentifier != nil {
+		return c.CiIdentifier
+	} else {
+		return &CiIdentifier{ResourceType: "cluster", ResourceID: c.ID}
+	}
+}

--- a/sherlock/internal/models/environment.go
+++ b/sherlock/internal/models/environment.go
@@ -1,0 +1,55 @@
+package models
+
+import (
+	"database/sql"
+	"gorm.io/gorm"
+)
+
+type Environment struct {
+	gorm.Model
+	CiIdentifier              *CiIdentifier `gorm:"polymorphic:Resource; polymorphicValue:environment"`
+	Base                      string
+	Lifecycle                 string
+	Name                      string
+	NamePrefix                string
+	TemplateEnvironment       *Environment
+	TemplateEnvironmentID     *uint
+	ValuesName                string
+	AutoPopulateChartReleases *bool
+	UniqueResourcePrefix      string
+	DefaultNamespace          string
+	// Mutable
+	DefaultCluster              *Cluster
+	DefaultClusterID            *uint
+	DefaultFirecloudDevelopRef  *string
+	Owner                       *User
+	OwnerID                     *uint
+	LegacyOwner                 *string
+	RequiresSuitability         *bool
+	BaseDomain                  *string
+	NamePrefixesDomain          *bool
+	HelmfileRef                 *string
+	PreventDeletion             *bool
+	AutoDelete                  sql.NullTime
+	Description                 *string
+	PagerdutyIntegration        *PagerdutyIntegration
+	PagerdutyIntegrationID      *uint
+	Offline                     *bool
+	OfflineScheduleBeginEnabled *bool
+	OfflineScheduleBeginTime    *string
+	OfflineScheduleEndEnabled   *bool
+	OfflineScheduleEndTime      *string
+	OfflineScheduleEndWeekends  *bool
+}
+
+func (e Environment) TableName() string {
+	return "v2_environments"
+}
+
+func (e Environment) GetCiIdentifier() *CiIdentifier {
+	if e.CiIdentifier != nil {
+		return e.CiIdentifier
+	} else {
+		return &CiIdentifier{ResourceType: "environment", ResourceID: e.ID}
+	}
+}

--- a/sherlock/internal/models/pagerduty_integration.go
+++ b/sherlock/internal/models/pagerduty_integration.go
@@ -1,0 +1,15 @@
+package models
+
+import "gorm.io/gorm"
+
+type PagerdutyIntegration struct {
+	gorm.Model
+	PagerdutyID string
+	Name        *string
+	Key         *string
+	Type        *string
+}
+
+func (p PagerdutyIntegration) TableName() string {
+	return "v2_pagerduty_integrations"
+}


### PR DESCRIPTION
To support me adding post-deploy hook stuff to Sherlock's database, I want to be able to reference these data types directly in the new models. Rather than going the effort of adding refactored APIs for all these types as a blocker, this PR just adds the structs themselves. It's suitable for reading but not for writes--luckily,reading is all I need.

## Testing

Not tested but not used either, this is dead code as written. These are just struct definitions that I just copied, I'm not going to the effort of unit testing that right now.

## Risk

None, I'm adding some dead code.