### PR TITLE
[DDO-3020] Use a different port for the test Postgres

### DIFF
--- a/makefile
+++ b/makefile
@@ -8,21 +8,21 @@ local-down:
 	docker-compose -f dev/local-with-pg.yaml down --volumes
 
 test:
-	docker run --name test-postgres -e POSTGRES_PASSWORD=password -e POSTGRES_USER=sherlock -d -p 5432:5432 postgres:13 -c max_connections=200
+	docker run --name test-postgres -e POSTGRES_PASSWORD=password -e POSTGRES_USER=sherlock -d -p 5431:5432 postgres:13 -c max_connections=200
 	cd go-shared && go test -p 1 -v -race ./...
 	cd sherlock && go test -p 1 -v -race ./...
 	docker stop test-postgres
 	docker rm test-postgres
 
 test-with-coverage:
-	docker run --name test-postgres -e POSTGRES_PASSWORD=password -e POSTGRES_USER=sherlock -d -p 5432:5432 postgres:13 -c max_connections=200
+	docker run --name test-postgres -e POSTGRES_PASSWORD=password -e POSTGRES_USER=sherlock -d -p 5431:5432 postgres:13 -c max_connections=200
 	cd go-shared && go test -p 1 -v -race -coverprofile=cover.out -covermode=atomic ./...
 	cd sherlock && go test -p 1 -v -race -coverprofile=cover.out -covermode=atomic ./...
 	docker stop test-postgres
 	docker rm -f -v test-postgres
 
 make pg-up:
-	docker run --name test-postgres -e POSTGRES_PASSWORD=password -e POSTGRES_USER=sherlock -d -p 5432:5432 postgres:13 -c max_connections=200
+	docker run --name test-postgres -e POSTGRES_PASSWORD=password -e POSTGRES_USER=sherlock -d -p 5431:5432 postgres:13 -c max_connections=200
 
 pg-down:
 	docker stop test-postgres

--- a/sherlock/config/test_config.yaml
+++ b/sherlock/config/test_config.yaml
@@ -11,7 +11,7 @@ db:
   user: sherlock
   password: password
   name: sherlock
-  port: 5432
+  port: 5431
   ssl: disable
   init: true
 

--- a/sherlock/internal/db/connect_test.go
+++ b/sherlock/internal/db/connect_test.go
@@ -26,7 +26,7 @@ func TestConnectAndConfigure(t *testing.T) {
 func Test_dbConnectionString(t *testing.T) {
 	config.LoadTestConfig()
 	s := dbConnectionString()
-	testutils.AssertNoDiff(t, "postgres://sherlock:password@localhost:5432/sherlock?sslmode=disable", s)
+	testutils.AssertNoDiff(t, "postgres://sherlock:password@localhost:5431/sherlock?sslmode=disable", s)
 }
 
 func Test_parseGormLogLevel(t *testing.T) {


### PR DESCRIPTION
`make local-up` and `make pg-up` both use :5432 for the Postgres. That makes it possible to accidentally run tests against the (presumably data-filled) Postgres for `make local-up`.

This PR makes tests and the test Postgres use :5431. Seems like an easy tweak to improve the DX and make it harder to accidentally wipe the real local database. Also means you can have both running at once.