### PR TITLE
[DDO-3036] Let Sherlock use case-sensitive env vars

### DIFF
--- a/dev/local-with-pg.yaml
+++ b/dev/local-with-pg.yaml
@@ -13,8 +13,8 @@ services:
       - "8080:8080"
       - "8081:8081"
     environment:
-      SHERLOCK_DB_HOST: postgres
-      SHERLOCK_DB_PASSWORD: password
+      SHERLOCK_db_host: postgres
+      SHERLOCK_db_password: password
     depends_on:
       - database
     networks: 

--- a/sherlock/internal/config/config.go
+++ b/sherlock/internal/config/config.go
@@ -35,6 +35,15 @@ func init() {
 		panic(fmt.Sprintf("failed to load config from environment, panicking due to likely runtime issue: %v", err))
 	}
 
+	// We handle environment variables both case-insensitively (transformed to lowercase) and case-sensitively.
+	// Case-sensitive environment variables are ugly, but Koanf is case-sensitive and otherwise we can't set
+	// camelCase properties from the environment.
+	if err := Config.Load(env.Provider("SHERLOCK_", ".", func(s string) string {
+		return strings.Replace(strings.TrimPrefix(s, "SHERLOCK_"), "_", ".", -1)
+	}), nil); err != nil {
+		panic(fmt.Sprintf("failed to load config from environment, panicking due to likely runtime issue: %v", err))
+	}
+
 	if Config.MustString("mode") != "debug" && Config.MustString("mode") != "release" {
 		panic(fmt.Sprintf("mode was %s instead of either 'debug' or 'release'", Config.MustString("mode")))
 	}
@@ -54,6 +63,13 @@ func LoadTestConfig() {
 	if err := Config.Load(env.Provider("TEST_SHERLOCK", ".", func(s string) string {
 		return strings.Replace(strings.ToLower(
 			strings.TrimPrefix(s, "TEST_SHERLOCK_")), "_", ".", -1)
+	}), nil); err != nil {
+		panic(fmt.Errorf("failed to load test configuration environment variables: %v", err))
+	}
+
+	// We handle environment variables both case-insensitively (transformed to lowercase) and -sensitively.
+	if err := Config.Load(env.Provider("TEST_SHERLOCK", ".", func(s string) string {
+		return strings.Replace(strings.TrimPrefix(s, "TEST_SHERLOCK_"), "_", ".", -1)
 	}), nil); err != nil {
 		panic(fmt.Errorf("failed to load test configuration environment variables: %v", err))
 	}


### PR DESCRIPTION
Found out that Koanf is case-sensitive and the example "how to parse env" code they give is wholly unable to handle camel-cased keys... like `slack.appToken`. Great.

This PR now parses environment variables twice: once where it lowercases (just the existing behavior) and once where it doesn't (so that `SHERLOCK_slack_appToken`, while ugly, will work).

## Testing

I toyed with the docker-compose config, mixing and matching the environment variable formats to check that Sherlock was reading both simultaneously.

## Risk

If this doesn't work, Sherlock won't start and we'll sit at one replica -- no big deal.