### PR TITLE
[DDO-3038] Make Sherlock middleware put errors in Gin ctx

### DIFF
--- a/sherlock/internal/errors/abort.go
+++ b/sherlock/internal/errors/abort.go
@@ -5,5 +5,5 @@ import "github.com/gin-gonic/gin"
 // AbortRequest abstracts the specific incantation needed to correctly return an errors.ErrorResponse
 // from a handler.
 func AbortRequest(ctx *gin.Context, err error) {
-	ctx.AbortWithStatusJSON(ErrorToApiResponse(ctx.Error(err)))
+	ctx.AbortWithStatusJSON(errorToApiResponse(ctx.Error(err)))
 }

--- a/sherlock/internal/errors/errors.go
+++ b/sherlock/internal/errors/errors.go
@@ -30,7 +30,7 @@ type ErrorResponse struct {
 	Message string `json:"message"`
 }
 
-func ErrorToApiResponse(err error) (int, ErrorResponse) {
+func errorToApiResponse(err error) (int, ErrorResponse) {
 	code, response := convert(err)
 	if response.ToBlame == "server" {
 		log.Error().Msgf("BODY | %3d | %s", code, response.Message)


### PR DESCRIPTION
Middleware wasn't using the right helper so errors weren't getting stored in the Gin context in a way that the Slack error reporting could read. This PR fixes that and makes the "shouldn't be called externally" helper private so that we'll avoid this oopsie in the future.

## Testing

Uses the same helper tested everywhere else (even though this is an IAP function that we can't directly test, we're removing a code path here)

## Risk

None