### PR TITLE
Fix cloudfunction Name: oops

### DIFF
--- a/foundation.yaml
+++ b/foundation.yaml
@@ -126,7 +126,7 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Resource
 metadata:
-  name: sherlock-cloudsql
+  name: sherlock-webhook-proxy
   description: |
     GCP cloudfunction used by sherlock to track github actions runs across all DSP repositories
   tags:


### PR DESCRIPTION
Accidentally duplicated a resource name, apparently backstage silently ignores this.