### PR TITLE
[DDO-3034] Make Swagger spec have a host when read statically

### DIFF
--- a/sherlock/internal/boot/router.go
+++ b/sherlock/internal/boot/router.go
@@ -28,6 +28,8 @@ import (
 //	@accept			json
 //	@produce		json
 
+//	@host	sherlock.dsp-devops.broadinstitute.org
+
 //	@contact.name	DSP DevOps
 //	@contact.email	dsp-devops@broadinstitute.org
 
@@ -38,6 +40,9 @@ func buildRouter(ctx context.Context, db *gorm.DB) *gin.Engine {
 	// gin.DebugMode spews console output but can help resolve routing issues
 	gin.SetMode(gin.ReleaseMode)
 
+	// At runtime, we want Sherlock's own hosted Swagger page to refer to itself, however/wherever it's deployed
+	// (setting the host to an empty string achieves that behavior, like if we didn't specify a host at all)
+	docs.SwaggerInfo.Host = ""
 	docs.SwaggerInfo.Version = version.BuildVersion
 	if config.Config.String("mode") == "debug" {
 		// When running locally, make the Swagger page have a scheme dropdown with http as the default


### PR DESCRIPTION
We don't want a host when Sherlock runs the Swagger page itself -- we want the page to loopback to whatever is hosting it -- but when read statically by something like Backstage, this helps the spec be properly understood by the Swagger javascript bundle.

## Testing

`make generate-docs` fills the host into the generated files, but `make local-up` makes it look exactly as before, _where it still connects to localhost:8080_

## Risk

None