### PR TITLE
[DDO-3045] Make Slack message sending more general

### DIFF
--- a/sherlock/config/default_config.yaml
+++ b/sherlock/config/default_config.yaml
@@ -97,6 +97,10 @@ slack:
   appToken: replace me with token starting with "xapp-"
   botToken: replace me with token starting with "xoxb-"
 
+  colors:
+    red: "#ef4444" # tailwind's red-500
+    green: "#22c55e" # tailwind's green-500
+
   behaviors:
 
     # slack.outgoing.deployHooks controls whether Sherlock
@@ -120,7 +124,6 @@ slack:
         - 407
       channels:
         - "#ap-k8s-monitor"
-      color: "#ef4444"
 
     reactToMentionsWithEmoji:
       enable: true

--- a/sherlock/internal/slack/link_helper.go
+++ b/sherlock/internal/slack/link_helper.go
@@ -1,0 +1,7 @@
+package slack
+
+import "fmt"
+
+func LinkHelper(url string, text string) string {
+	return fmt.Sprintf("<%s|%s>", url, text)
+}

--- a/sherlock/internal/slack/link_helper_test.go
+++ b/sherlock/internal/slack/link_helper_test.go
@@ -1,0 +1,34 @@
+package slack
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestLinkHelper(t *testing.T) {
+	type args struct {
+		url  string
+		text string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "1",
+			args: args{url: "https://example.com", text: "example"},
+			want: "<https://example.com|example>",
+		},
+		{
+			name: "2",
+			args: args{url: "https://example.com/path/to/page", text: "example with spaces and stuff!"},
+			want: "<https://example.com/path/to/page|example with spaces and stuff!>",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, LinkHelper(tt.args.url, tt.args.text), "LinkHelper(%v, %v)", tt.args.url, tt.args.text)
+		})
+	}
+}

--- a/sherlock/internal/slack/send_message.go
+++ b/sherlock/internal/slack/send_message.go
@@ -1,0 +1,52 @@
+package slack
+
+import (
+	"context"
+	"github.com/broadinstitute/sherlock/go-shared/pkg/utils"
+	"github.com/broadinstitute/sherlock/sherlock/internal/config"
+	"github.com/rs/zerolog/log"
+	"github.com/slack-go/slack"
+)
+
+type Attachment interface {
+	toSlackAttachment() slack.Attachment
+}
+
+type GreenBlock struct {
+	Text string
+}
+
+func (g GreenBlock) toSlackAttachment() slack.Attachment {
+	return slack.Attachment{
+		Color: config.Config.String("slack.colors.green"),
+		Text:  g.Text,
+	}
+}
+
+type RedBlock struct {
+	Text string
+}
+
+func (g RedBlock) toSlackAttachment() slack.Attachment {
+	return slack.Attachment{
+		Color: config.Config.String("slack.colors.red"),
+		Text:  g.Text,
+	}
+}
+
+func SendMessage(ctx context.Context, channel string, text string, attachments ...Attachment) {
+	if isEnabled() && (text != "" || len(attachments) > 0) {
+		var options []slack.MsgOption
+		if text != "" {
+			options = append(options, slack.MsgOptionText(text, true))
+		}
+		if len(attachments) > 0 {
+			options = append(options, slack.MsgOptionAttachments(
+				utils.Map(attachments, func(a Attachment) slack.Attachment { return a.toSlackAttachment() })...,
+			))
+		}
+		if _, _, _, err := client.SendMessageContext(ctx, channel, options...); err != nil {
+			log.Warn().Err(err).Msgf("SLCK | unable to send message to %s: %v", channel, err)
+		}
+	}
+}

--- a/sherlock/internal/slack/send_message_test.go
+++ b/sherlock/internal/slack/send_message_test.go
@@ -1,0 +1,81 @@
+package slack
+
+import (
+	"context"
+	"fmt"
+	"github.com/broadinstitute/sherlock/sherlock/internal/config"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/mock"
+	"testing"
+)
+
+func TestSendMessage(t *testing.T) {
+	config.LoadTestConfig()
+	zerolog.SetGlobalLevel(zerolog.Disabled)
+	ctx := context.Background()
+	type args struct {
+		channel     string
+		text        string
+		attachments []Attachment
+	}
+	tests := []struct {
+		name       string
+		args       args
+		mockConfig func(client *mockMockableClient)
+	}{
+		{
+			name:       "doesn't do anything when empty",
+			args:       args{channel: "foo"},
+			mockConfig: func(client *mockMockableClient) {},
+		},
+		{
+			name: "sends text when provided",
+			args: args{channel: "foo", text: "text"},
+			mockConfig: func(client *mockMockableClient) {
+				client.On("SendMessageContext", ctx, "foo",
+					mock.AnythingOfType("slack.MsgOption")).Return("", "", "", nil)
+			},
+		},
+		{
+			name: "sends attachments when provided",
+			args: args{channel: "foo", attachments: []Attachment{
+				GreenBlock{Text: "blah"}, RedBlock{"bleh"},
+			}},
+			mockConfig: func(client *mockMockableClient) {
+				client.On("SendMessageContext", ctx, "foo",
+					mock.AnythingOfType("slack.MsgOption")).Return("", "", "", nil)
+			},
+		},
+		{
+			name: "sends both when provided",
+			args: args{channel: "foo", text: "text", attachments: []Attachment{
+				GreenBlock{Text: "blah"}, RedBlock{"bleh"},
+			}},
+			mockConfig: func(client *mockMockableClient) {
+				client.On("SendMessageContext", ctx, "foo",
+					mock.AnythingOfType("slack.MsgOption"),
+					mock.AnythingOfType("slack.MsgOption")).Return("", "", "", nil)
+			},
+		},
+		{
+			name: "swallows errors",
+			args: args{channel: "foo", text: "text", attachments: []Attachment{
+				GreenBlock{Text: "blah"}, RedBlock{"bleh"},
+			}},
+			mockConfig: func(client *mockMockableClient) {
+				client.On("SendMessageContext", ctx, "foo",
+					mock.AnythingOfType("slack.MsgOption"),
+					mock.AnythingOfType("slack.MsgOption")).Return("", "", "", fmt.Errorf("some error"))
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := newMockMockableClient(t)
+			tt.mockConfig(c)
+			client = c
+			SendMessage(ctx, tt.args.channel, tt.args.text, tt.args.attachments...)
+			c.AssertExpectations(t)
+		})
+	}
+}


### PR DESCRIPTION
Extract out the core message sending from slack.ReportError, giving us a slack.SendMessage function too.

I made it so that creating/editing/deleting a SlackDeployHook will fire off a Slack message using it--not the most in-depth Slack message because I didn't want to spend a lot of time here, just something best-effort felt like it'd be enough.

I also made slack.ReportError accept a list of errors so you can dump multiple into it and it'll figure it out.

## Testing

Tests for all this stuff. Woohoo.

## Risk

Super low / none IMO