### PR TITLE
[DDO-3046] Slack Deploy Hooks

### DIFF
--- a/sherlock/config/default_config.yaml
+++ b/sherlock/config/default_config.yaml
@@ -145,8 +145,18 @@ model:
       # Uses appVersionResolver = "none", chartVersionResolver = "latest", and helmfileRef = "HEAD"
       autoPopulateCharts:
         - name: honeycomb
+  ciRuns:
+    # A list of partial CiRuns where if any has a match on all non-zero fields with an actual CiRun,
+    # the actual CiRun should be considered a deploy (and should dispatch deploy hooks upon completion).
+    # The schema here is defined from models.CiRun (the database type) instead of the API type.
+    deployMatchers:
+      - platform: github-actions
+        githubActionsOwner: broadinstitute
+        githubActionsRepo: terra-github-workflows
+        githubActionsWorkflowPath: .github/workflows/sync-release.yaml
 
 beehive:
     chartReleaseUrlFormatString: https://beehive.dsp-devops.broadinstitute.org/r/chart-release/%s
     environmentUrlFormatString: https://beehive.dsp-devops.broadinstitute.org/r/environment/%s
     pagerdutyIntegrationUrlFormatString: https://beehive.dsp-devops.broadinstitute.org/r/pagerduty-integration/%s
+    reviewChangesetsUrl: https://beehive.dsp-devops.broadinstitute.org/review-changesets

--- a/sherlock/internal/api/sherlock/ci_runs_v3.go
+++ b/sherlock/internal/api/sherlock/ci_runs_v3.go
@@ -8,7 +8,8 @@ import (
 type CiRunV3 struct {
 	CommonFields
 	ciRunFields
-	RelatedResources []CiIdentifierV3 `json:"relatedResources" form:"-"`
+	DeployHooksDispatchedAt *string          `json:"deployHooksDispatchedAt,omitempty" form:"deployHooksDispatchedAt" format:"date-time"`
+	RelatedResources        []CiIdentifierV3 `json:"relatedResources" form:"-"`
 }
 
 type ciRunFields struct {
@@ -38,6 +39,7 @@ func (c CiRunV3) toModel() models.CiRun {
 		ArgoWorkflowsNamespace:     c.ArgoWorkflowsNamespace,
 		ArgoWorkflowsName:          c.ArgoWorkflowsName,
 		ArgoWorkflowsTemplate:      c.ArgoWorkflowsTemplate,
+		DeployHooksDispatchedAt:    c.DeployHooksDispatchedAt,
 		StartedAt:                  c.StartedAt,
 		TerminalAt:                 c.TerminalAt,
 		Status:                     c.Status,
@@ -68,6 +70,7 @@ func ciRunFromModel(model models.CiRun) CiRunV3 {
 			TerminalAt:                 model.TerminalAt,
 			Status:                     model.Status,
 		},
-		RelatedResources: relatedResources,
+		DeployHooksDispatchedAt: model.DeployHooksDispatchedAt,
+		RelatedResources:        relatedResources,
 	}
 }

--- a/sherlock/internal/deployhooks/ci_run_is_deploy.go
+++ b/sherlock/internal/deployhooks/ci_run_is_deploy.go
@@ -1,0 +1,48 @@
+package deployhooks
+
+import (
+	"fmt"
+	"github.com/broadinstitute/sherlock/sherlock/internal/config"
+	"github.com/broadinstitute/sherlock/sherlock/internal/models"
+	"github.com/knadh/koanf"
+	"github.com/rs/zerolog/log"
+)
+
+// matchers are partial models.CiRun structs, read out of config when Sherlock starts.
+// When determining if an actual models.CiRun should be considered a deploy, it will
+// check if any of the matchers models.CiRun structs have all of their nonzero fields
+// equal to the actual models.CiRun. If so, it'll be considered a deploy.
+var matchers []models.CiRun
+
+func Init() error {
+	matchers = []models.CiRun{}
+	for index, k := range config.Config.Slices("model.ciRuns.deployMatchers") {
+		var partial models.CiRun
+		if err := k.UnmarshalWithConf("", &partial, koanf.UnmarshalConf{Tag: "koanf"}); err != nil {
+			return fmt.Errorf("error parsing model.ciRuns.deployMatchers[%d]: %v", index+1, err)
+		} else {
+			matchers = append(matchers, partial)
+		}
+	}
+	if len(matchers) == 0 {
+		log.Info().Msg("HOOK | no deploy matchers, no deploy hooks will be run")
+	} else if len(matchers) == 1 {
+		log.Info().Msg("HOOK | 1 deploy matcher, deploy hooks will be run when a matching CiRun completes")
+	} else {
+		log.Info().Msgf("HOOK | %d deploy matchers, deploy hooks will be run when a matching CiRun completes", len(matchers))
+	}
+	return nil
+}
+
+func CiRunIsDeploy(ciRun models.CiRun) bool {
+	for _, matcher := range matchers {
+		if (matcher.Platform == "" || matcher.Platform == ciRun.Platform) &&
+			(matcher.GithubActionsOwner == "" || matcher.GithubActionsOwner == ciRun.GithubActionsOwner) &&
+			(matcher.GithubActionsRepo == "" || matcher.GithubActionsRepo == ciRun.GithubActionsRepo) &&
+			(matcher.GithubActionsWorkflowPath == "" || matcher.GithubActionsWorkflowPath == ciRun.GithubActionsWorkflowPath) &&
+			(matcher.ArgoWorkflowsTemplate == "" || matcher.ArgoWorkflowsTemplate == ciRun.ArgoWorkflowsTemplate) {
+			return true
+		}
+	}
+	return false
+}

--- a/sherlock/internal/deployhooks/ci_run_is_deploy_test.go
+++ b/sherlock/internal/deployhooks/ci_run_is_deploy_test.go
@@ -1,0 +1,95 @@
+package deployhooks
+
+import (
+	"github.com/broadinstitute/sherlock/sherlock/internal/config"
+	"github.com/broadinstitute/sherlock/sherlock/internal/models"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestCiRunIsDeploy(t *testing.T) {
+	config.LoadTestConfig()
+	assert.NoError(t, Init())
+	type args struct {
+		ciRun models.CiRun
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "matches",
+			args: args{ciRun: models.CiRun{
+				Platform:                   "github-actions",
+				GithubActionsOwner:         "broadinstitute",
+				GithubActionsRepo:          "terra-github-workflows",
+				GithubActionsRunID:         123123,
+				GithubActionsAttemptNumber: 1,
+				GithubActionsWorkflowPath:  ".github/workflows/sync-release.yaml",
+			}},
+			want: true,
+		},
+		{
+			name: "no platform match",
+			args: args{ciRun: models.CiRun{
+				Platform:               "argo-workflows",
+				ArgoWorkflowsNamespace: "namespace",
+				ArgoWorkflowsName:      "name",
+				ArgoWorkflowsTemplate:  "template",
+			}},
+			want: false,
+		},
+		{
+			name: "no owner match",
+			args: args{ciRun: models.CiRun{
+				Platform:                   "github-actions",
+				GithubActionsOwner:         "DataBiosphere",
+				GithubActionsRepo:          "terra-github-workflows",
+				GithubActionsRunID:         123123,
+				GithubActionsAttemptNumber: 1,
+				GithubActionsWorkflowPath:  ".github/workflows/sync-release.yaml",
+			}},
+			want: false,
+		},
+		{
+			name: "no repo match",
+			args: args{ciRun: models.CiRun{
+				Platform:                   "github-actions",
+				GithubActionsOwner:         "broadinstitute",
+				GithubActionsRepo:          "terra-helmfile",
+				GithubActionsRunID:         123123,
+				GithubActionsAttemptNumber: 1,
+				GithubActionsWorkflowPath:  ".github/workflows/sync-release.yaml",
+			}},
+			want: false,
+		},
+		{
+			name: "no path match",
+			args: args{ciRun: models.CiRun{
+				Platform:                   "github-actions",
+				GithubActionsOwner:         "broadinstitute",
+				GithubActionsRepo:          "terra-github-workflows",
+				GithubActionsRunID:         123123,
+				GithubActionsAttemptNumber: 1,
+				GithubActionsWorkflowPath:  ".github/workflows/bee-create.yaml",
+			}},
+			want: false,
+		},
+		{
+			name: "matches even if otherwise required fields are missing",
+			args: args{ciRun: models.CiRun{
+				Platform:                  "github-actions",
+				GithubActionsOwner:        "broadinstitute",
+				GithubActionsRepo:         "terra-github-workflows",
+				GithubActionsWorkflowPath: ".github/workflows/sync-release.yaml",
+			}},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, CiRunIsDeploy(tt.args.ciRun), "CiRunIsDeploy(%v)", tt.args.ciRun)
+		})
+	}
+}

--- a/sherlock/internal/deployhooks/deployhooks_test.go
+++ b/sherlock/internal/deployhooks/deployhooks_test.go
@@ -1,0 +1,16 @@
+package deployhooks
+
+import (
+	"github.com/broadinstitute/sherlock/sherlock/internal/models"
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type deployHooksSuite struct {
+	suite.Suite
+	models.TestSuiteHelper
+}
+
+func TestDeployHooksSuite(t *testing.T) {
+	suite.Run(t, new(deployHooksSuite))
+}

--- a/sherlock/internal/deployhooks/dispatch_ci_run.go
+++ b/sherlock/internal/deployhooks/dispatch_ci_run.go
@@ -1,0 +1,136 @@
+package deployhooks
+
+import (
+	"fmt"
+	"github.com/broadinstitute/sherlock/sherlock/internal/models"
+	"github.com/broadinstitute/sherlock/sherlock/internal/slack"
+	"github.com/rs/zerolog/log"
+	"gorm.io/gorm"
+	"sync"
+)
+
+func DispatchCiRun(db *gorm.DB, ciRun models.CiRun) {
+	errs := dispatchCiRun(db, ciRun, dispatchSlackDeployHook, dispatchGithubActionsDeployHook)
+	if len(errs) > 0 {
+		log.Error().Msgf("HOOK | encountered %d errors handling deploy hooks for CiRun %d", len(errs), ciRun.ID)
+		for index, err := range errs {
+			log.Error().Err(err).Msgf("HOOK | error %d of %d: %v", index+1, len(errs), err)
+		}
+		slack.ReportError(db.Statement.Context, append([]error{fmt.Errorf("encountered %d errors handling deploy hooks for CiRun %d", len(errs), ciRun.ID)}, errs...)...)
+	}
+}
+
+func dispatchCiRun(db *gorm.DB, ciRun models.CiRun,
+	dispatchSlackCallback func(db *gorm.DB, hook models.SlackDeployHook, ciRun models.CiRun) error,
+	dispatchGithubActionsCallback func(db *gorm.DB, hook models.GithubActionsDeployHook, ciRun models.CiRun) error) (errs []error) {
+	// If we have no related resources, re-query to make sure that's actually the case
+	// (and it's not just that we were called with a partially loaded CiRun)
+	if len(ciRun.RelatedResources) == 0 {
+		if err := db.Preload("RelatedResources").First(&ciRun, ciRun.ID).Error; err != nil {
+			return []error{err}
+		}
+	}
+	// If we still have no related resources, exit
+	if len(ciRun.RelatedResources) == 0 {
+		return nil
+	}
+
+	// Collect hooks to trigger across all environments and chart releases the CiRun affected
+	var deployHookTriggers []models.DeployHookTriggerConfig
+	for _, resourceIdentifier := range ciRun.RelatedResources {
+		var resourceDeployHookTriggers []models.DeployHookTriggerConfig
+
+		if resourceIdentifier.ResourceType == "environment" {
+			// If the resource was an environment, query hooks to trigger on that environment
+			if err := db.Where(models.DeployHookTriggerConfig{
+				OnEnvironmentID: &resourceIdentifier.ResourceID,
+			}).Find(&resourceDeployHookTriggers).Error; err != nil {
+				errs = append(errs, fmt.Errorf("failed to query DeployHookTriggerConfig with Environment ID %d (CiIdentifier %d): %v", resourceIdentifier.ResourceID, resourceIdentifier.ID, err))
+				continue
+			}
+		} else if resourceIdentifier.ResourceType == "chart-release" {
+			// If the resource was a chart release, query hooks to trigger on that chart release
+			if err := db.Where(models.DeployHookTriggerConfig{
+				OnChartReleaseID: &resourceIdentifier.ResourceID,
+			}).Find(&resourceDeployHookTriggers).Error; err != nil {
+				errs = append(errs, fmt.Errorf("failed to query DeployHookTriggerConfig with ChartRelease ID %d (CiIdentifier %d): %v", resourceIdentifier.ResourceID, resourceIdentifier.ID, err))
+				continue
+			}
+		}
+
+		// If we found any hooks for this resource, add them to the list
+		if len(resourceDeployHookTriggers) > 0 {
+			deployHookTriggers = append(deployHookTriggers, resourceDeployHookTriggers...)
+		}
+	}
+
+	// We'd be in a very weird case if we ever hit duplicate DeployHookTriggerConfigs...
+	// but let's not make it worse. We dedupe based on the ID.
+	var deduplicatedDeployHookTriggers []models.DeployHookTriggerConfig
+addingToDeduplicatedDeployHookTriggers:
+	for _, potentialDeployHookTrigger := range deployHookTriggers {
+		for _, existingDeployHookTriggerInList := range deduplicatedDeployHookTriggers {
+			if potentialDeployHookTrigger.ID == existingDeployHookTriggerInList.ID {
+				continue addingToDeduplicatedDeployHookTriggers
+			}
+		}
+		deduplicatedDeployHookTriggers = append(deduplicatedDeployHookTriggers, potentialDeployHookTrigger)
+	}
+
+	// Now for each thing to trigger, get the full hook of that type and dispatch it
+	var waitGroup sync.WaitGroup
+	var errsMutex sync.Mutex // mutex errs so we don't lose any as we append to it in parallel below
+	for _, deployHookTrigger := range deduplicatedDeployHookTriggers {
+		if deployHookTrigger.HookType == "slack" {
+			var hook models.SlackDeployHook
+			if err := db.
+				Preload("Trigger").
+				Preload("Trigger.OnEnvironment").
+				Preload("Trigger.OnChartRelease").
+				First(&hook, deployHookTrigger.HookID).Error; err != nil {
+				errsMutex.Lock()
+				errs = append(errs, fmt.Errorf("failed to get SlackDeployHook for DeployHookTriggerConfig ID %d: %v", deployHookTrigger.ID, err))
+				errsMutex.Unlock()
+				continue
+			}
+			waitGroup.Add(1)
+			go func() {
+				defer waitGroup.Done()
+				if err := dispatchSlackCallback(db, hook, ciRun); err != nil {
+					errsMutex.Lock()
+					errs = append(errs, fmt.Errorf("failed to dispatch SlackDeployHook %d: %v", hook.ID, err))
+					errsMutex.Unlock()
+				}
+			}()
+		} else if deployHookTrigger.HookType == "github-actions" {
+			var hook models.GithubActionsDeployHook
+			if err := db.
+				Preload("Trigger").
+				Preload("Trigger.OnEnvironment").
+				Preload("Trigger.OnChartRelease").
+				First(&hook, deployHookTrigger.HookID).Error; err != nil {
+				errsMutex.Lock()
+				errs = append(errs, fmt.Errorf("failed to get GithubActionsDeployHook for DeployHookTriggerConfig ID %d: %v", deployHookTrigger.ID, err))
+				errsMutex.Unlock()
+				continue
+			}
+			waitGroup.Add(1)
+			go func() {
+				defer waitGroup.Done()
+				if err := dispatchGithubActionsCallback(db, hook, ciRun); err != nil {
+					errsMutex.Lock()
+					errs = append(errs, fmt.Errorf("failed to dispatch GithubActionsDeployHook %d: %v", hook.ID, err))
+					errsMutex.Unlock()
+				}
+			}()
+		} else {
+			errsMutex.Lock()
+			errs = append(errs, fmt.Errorf("unknown DeployHookTriggerConfig hook type '%s'", deployHookTrigger.HookType))
+			errsMutex.Unlock()
+		}
+	}
+
+	// Wait for all hook dispatches to complete, then exit with whatever errors we've accumulated
+	waitGroup.Wait()
+	return errs
+}

--- a/sherlock/internal/deployhooks/dispatch_ci_run_test.go
+++ b/sherlock/internal/deployhooks/dispatch_ci_run_test.go
@@ -1,0 +1,185 @@
+package deployhooks
+
+import (
+	"fmt"
+	"github.com/broadinstitute/sherlock/go-shared/pkg/testutils"
+	"github.com/broadinstitute/sherlock/sherlock/internal/models"
+	"gorm.io/gorm"
+)
+
+func (s *deployHooksSuite) Test_dispatchCiRun() {
+	user := s.SetSuitableTestUserForDB()
+
+	chart := models.Chart{
+		Name:      "leonardo",
+		ChartRepo: testutils.PointerTo("terra-helm"),
+	}
+	s.NoError(s.DB.Create(&chart).Error)
+
+	cluster := models.Cluster{
+		Name:                "terra-prod",
+		HelmfileRef:         testutils.PointerTo("HEAD"),
+		RequiresSuitability: testutils.PointerTo(true),
+		Provider:            "google",
+		GoogleProject:       "broad-dsde-prod",
+		Location:            "us-central1-a",
+		Base:                testutils.PointerTo("terra"),
+		Address:             testutils.PointerTo("0.0.0.0"),
+	}
+	s.NoError(s.DB.Create(&cluster).Error)
+
+	environment := models.Environment{
+		Name:                 "prod",
+		ValuesName:           "prod",
+		UniqueResourcePrefix: "a123",
+		HelmfileRef:          testutils.PointerTo("HEAD"),
+		RequiresSuitability:  testutils.PointerTo(true),
+		Base:                 "live",
+		DefaultClusterID:     &cluster.ID,
+		DefaultNamespace:     "terra-prod",
+		Lifecycle:            "static",
+		PreventDeletion:      testutils.PointerTo(true),
+		OwnerID:              &user.ID,
+	}
+	s.NoError(s.DB.Create(&environment).Error)
+	environmentCiIdentifier := environment.GetCiIdentifier()
+	s.NoError(s.DB.Create(&environmentCiIdentifier).Error)
+
+	environmentGithubHook := models.GithubActionsDeployHook{
+		Trigger: models.DeployHookTriggerConfig{
+			OnEnvironmentID: &environment.ID,
+			OnSuccess:       testutils.PointerTo(true),
+			OnFailure:       testutils.PointerTo(true),
+		},
+		GithubActionsOwner:        testutils.PointerTo("broadinstitute"),
+		GithubActionsRepo:         testutils.PointerTo("terra-github-workflows"),
+		GithubActionsWorkflowPath: testutils.PointerTo(".github/workflows/some-workflow.yaml"),
+		GithubActionsDefaultRef:   testutils.PointerTo("HEAD"),
+		GithubActionsRefBehavior:  testutils.PointerTo("always-use-default-ref"),
+	}
+	s.NoError(s.DB.Create(&environmentGithubHook).Error)
+
+	environmentSlackHook := models.SlackDeployHook{
+		Trigger: models.DeployHookTriggerConfig{
+			OnEnvironmentID: &environment.ID,
+			OnSuccess:       testutils.PointerTo(true),
+			OnFailure:       testutils.PointerTo(true),
+		},
+		SlackChannel: testutils.PointerTo("#workbench-release"),
+	}
+	s.NoError(s.DB.Create(&environmentSlackHook).Error)
+
+	chartRelease := models.ChartRelease{
+		Name:            "leonardo-prod",
+		ChartID:         chart.ID,
+		ClusterID:       &cluster.ID,
+		EnvironmentID:   &environment.ID,
+		Namespace:       "terra-prod",
+		DestinationType: "environment",
+		ChartReleaseVersion: models.ChartReleaseVersion{
+			HelmfileRef:          testutils.PointerTo("HEAD"),
+			AppVersionResolver:   testutils.PointerTo("exact"),
+			AppVersionExact:      testutils.PointerTo("v1.2.3"),
+			ChartVersionResolver: testutils.PointerTo("exact"),
+			ChartVersionExact:    testutils.PointerTo("v2.3.4"),
+		},
+	}
+	s.NoError(s.DB.Create(&chartRelease).Error)
+	chartReleaseCiIdentifier := chartRelease.GetCiIdentifier()
+	s.NoError(s.DB.Create(&chartReleaseCiIdentifier).Error)
+
+	chartReleaseGithubHook := models.GithubActionsDeployHook{
+		Trigger: models.DeployHookTriggerConfig{
+			OnChartReleaseID: &chartRelease.ID,
+			OnSuccess:        testutils.PointerTo(true),
+			OnFailure:        testutils.PointerTo(true),
+		},
+		GithubActionsOwner:        testutils.PointerTo("broadinstitute"),
+		GithubActionsRepo:         testutils.PointerTo("sam"),
+		GithubActionsWorkflowPath: testutils.PointerTo(".github/workflows/some-workflow.yaml"),
+		GithubActionsDefaultRef:   testutils.PointerTo("HEAD"),
+		GithubActionsRefBehavior:  testutils.PointerTo("always-use-default-ref"),
+	}
+	s.NoError(s.DB.Create(&chartReleaseGithubHook).Error)
+
+	chartReleaseSlackHook := models.SlackDeployHook{
+		Trigger: models.DeployHookTriggerConfig{
+			OnChartReleaseID: &chartRelease.ID,
+			OnSuccess:        testutils.PointerTo(true),
+			OnFailure:        testutils.PointerTo(true),
+		},
+		SlackChannel: testutils.PointerTo("#dsp-identiteam"),
+	}
+	s.NoError(s.DB.Create(&chartReleaseSlackHook).Error)
+
+	ciRun := models.CiRun{
+		Platform:                   "github-actions",
+		GithubActionsOwner:         "broadinstitute",
+		GithubActionsRepo:          "terra-github-workflows",
+		GithubActionsRunID:         123123,
+		GithubActionsAttemptNumber: 1,
+		GithubActionsWorkflowPath:  ".github/workflows/sync-release.yaml",
+		RelatedResources: []models.CiIdentifier{
+			environmentCiIdentifier,
+			chartReleaseCiIdentifier,
+		},
+	}
+	s.NoError(s.DB.Create(&ciRun).Error)
+
+	s.Run("normal case", func() {
+		var calledEnvironmentGithub, calledEnvironmentSlack, calledChartReleaseGithub, calledChartReleaseSlack bool
+		errs := dispatchCiRun(
+			s.DB,
+			models.CiRun{Model: gorm.Model{ID: ciRun.ID}},
+			func(db *gorm.DB, hook models.SlackDeployHook, ciRun models.CiRun) error {
+				if hook.ID == environmentSlackHook.ID {
+					calledEnvironmentSlack = true
+				} else if hook.ID == chartReleaseSlackHook.ID {
+					calledChartReleaseSlack = true
+				}
+				return nil
+			},
+			func(db *gorm.DB, hook models.GithubActionsDeployHook, ciRun models.CiRun) error {
+				if hook.ID == environmentGithubHook.ID {
+					calledEnvironmentGithub = true
+				} else if hook.ID == chartReleaseGithubHook.ID {
+					calledChartReleaseGithub = true
+				}
+				return nil
+			})
+		s.Empty(errs)
+		s.True(calledEnvironmentGithub)
+		s.True(calledEnvironmentSlack)
+		s.True(calledChartReleaseGithub)
+		s.True(calledChartReleaseSlack)
+	})
+	s.Run("collects errors", func() {
+		errs := dispatchCiRun(
+			s.DB,
+			models.CiRun{Model: gorm.Model{ID: ciRun.ID}},
+			func(db *gorm.DB, hook models.SlackDeployHook, ciRun models.CiRun) error {
+				return fmt.Errorf("error")
+			},
+			func(db *gorm.DB, hook models.GithubActionsDeployHook, ciRun models.CiRun) error {
+				return fmt.Errorf("error")
+			})
+		s.Len(errs, 4)
+	})
+	s.Run("collects errors from deleted hooks", func() {
+		s.NoError(s.DB.Where(&environmentGithubHook).Delete(&environmentGithubHook).Error)
+		s.NoError(s.DB.Where(&environmentSlackHook).Delete(&environmentSlackHook).Error)
+		s.NoError(s.DB.Where(&chartReleaseGithubHook).Delete(&chartReleaseGithubHook).Error)
+		s.NoError(s.DB.Where(&chartReleaseSlackHook).Delete(&chartReleaseSlackHook).Error)
+		errs := dispatchCiRun(
+			s.DB,
+			models.CiRun{Model: gorm.Model{ID: ciRun.ID}},
+			func(db *gorm.DB, hook models.SlackDeployHook, ciRun models.CiRun) error {
+				s.Fail("should have errored")
+				return nil
+			},
+			func(db *gorm.DB, hook models.GithubActionsDeployHook, ciRun models.CiRun) error {
+				return fmt.Errorf("should have errored")
+			})
+		s.Len(errs, 4)
+	})
+}

--- a/sherlock/internal/deployhooks/dispatch_github_actions_deploy_hook.go
+++ b/sherlock/internal/deployhooks/dispatch_github_actions_deploy_hook.go
@@ -1,0 +1,12 @@
+package deployhooks
+
+import (
+	"github.com/broadinstitute/sherlock/sherlock/internal/models"
+	"github.com/rs/zerolog/log"
+	"gorm.io/gorm"
+)
+
+func dispatchGithubActionsDeployHook(db *gorm.DB, hook models.GithubActionsDeployHook, ciRun models.CiRun) error {
+	log.Warn().Msg("HOOK | models.GithubActionsDeployHook isn't currently implemented, doing nothing")
+	return nil
+}

--- a/sherlock/internal/deployhooks/dispatch_slack_deploy_hook.go
+++ b/sherlock/internal/deployhooks/dispatch_slack_deploy_hook.go
@@ -1,0 +1,73 @@
+package deployhooks
+
+import (
+	"fmt"
+	"github.com/broadinstitute/sherlock/go-shared/pkg/utils"
+	"github.com/broadinstitute/sherlock/sherlock/internal/config"
+	"github.com/broadinstitute/sherlock/sherlock/internal/models"
+	"github.com/broadinstitute/sherlock/sherlock/internal/slack"
+	"gorm.io/gorm"
+	"strings"
+)
+
+func dispatchSlackDeployHook(db *gorm.DB, hook models.SlackDeployHook, ciRun models.CiRun) error {
+	if hook.SlackChannel == nil {
+		return fmt.Errorf("slack channel was nil on SlackDeployHook %d, shouldn't be possible", hook.ID)
+	} else if attachment, err := generateSlackAttachment(db, hook, ciRun); err != nil {
+		return fmt.Errorf("failed to generate summary of CiRun %d for SlackDeployHook %d: %v", ciRun.ID, hook.ID, err)
+	} else {
+		slack.SendMessage(db.Statement.Context, *hook.SlackChannel, "", attachment)
+		return nil
+	}
+}
+
+func generateSlackAttachment(_ *gorm.DB, hook models.SlackDeployHook, ciRun models.CiRun) (slack.Attachment, error) {
+	var sb strings.Builder
+
+	sb.WriteString("Deployment to ")
+
+	if hook.Trigger.OnEnvironment != nil {
+		sb.WriteString(hook.Trigger.OnEnvironment.Name)
+	} else if hook.Trigger.OnChartRelease != nil {
+		sb.WriteString(hook.Trigger.OnChartRelease.Name)
+	} else {
+		return nil, fmt.Errorf("SlackDeployHook %d didn't have Trigger fully loaded", hook.ID)
+	}
+
+	sb.WriteString(": ")
+
+	if ciRun.Status != nil {
+		sb.WriteString(slack.LinkHelper(ciRun.WebURL(), *ciRun.Status))
+	} else {
+		return nil, fmt.Errorf("CiRun %d didn't have status present", ciRun.ID)
+	}
+
+	sb.WriteString(".")
+
+	var changesetIDs []uint
+	for _, ciIdentifier := range ciRun.RelatedResources {
+		if ciIdentifier.ResourceType == "changeset" {
+			changesetIDs = append(changesetIDs, ciIdentifier.ResourceID)
+		}
+	}
+
+	if len(changesetIDs) > 0 {
+		sb.WriteString(" Review all changes made by this deployment ")
+
+		var changesetLinkSB strings.Builder
+		changesetLinkSB.WriteString(config.Config.String("beehive.reviewChangesetsUrl"))
+		changesetLinkSB.WriteString("?")
+		changesetLinkSB.WriteString(strings.Join(utils.Map(changesetIDs, func(id uint) string {
+			return fmt.Sprintf("changeset=%d", id)
+		}), "&"))
+
+		sb.WriteString(slack.LinkHelper(changesetLinkSB.String(), "here"))
+		sb.WriteString(".")
+	}
+
+	if ciRun.Succeeded() {
+		return slack.GreenBlock{Text: sb.String()}, nil
+	} else {
+		return slack.RedBlock{Text: sb.String()}, nil
+	}
+}

--- a/sherlock/internal/deployhooks/dispatch_slack_deploy_hook.go
+++ b/sherlock/internal/deployhooks/dispatch_slack_deploy_hook.go
@@ -15,10 +15,10 @@ func dispatchSlackDeployHook(db *gorm.DB, hook models.SlackDeployHook, ciRun mod
 		return fmt.Errorf("slack channel was nil on SlackDeployHook %d, shouldn't be possible", hook.ID)
 	} else if attachment, err := generateSlackAttachment(db, hook, ciRun); err != nil {
 		return fmt.Errorf("failed to generate summary of CiRun %d for SlackDeployHook %d: %v", ciRun.ID, hook.ID, err)
-	} else {
+	} else if config.Config.Bool("slack.behaviors.deployHooks.enable") {
 		slack.SendMessage(db.Statement.Context, *hook.SlackChannel, "", attachment)
-		return nil
 	}
+	return nil
 }
 
 func generateSlackAttachment(_ *gorm.DB, hook models.SlackDeployHook, ciRun models.CiRun) (slack.Attachment, error) {

--- a/sherlock/internal/deployhooks/dispatch_slack_deploy_hook_test.go
+++ b/sherlock/internal/deployhooks/dispatch_slack_deploy_hook_test.go
@@ -1,0 +1,237 @@
+package deployhooks
+
+import (
+	"github.com/broadinstitute/sherlock/go-shared/pkg/testutils"
+	"github.com/broadinstitute/sherlock/sherlock/internal/models"
+	"github.com/broadinstitute/sherlock/sherlock/internal/slack"
+	"gorm.io/gorm"
+	"time"
+)
+
+func (s *deployHooksSuite) Test_generateSlackAttachment_triggerNotLoaded() {
+	_, err := generateSlackAttachment(nil, models.SlackDeployHook{
+		Model:        gorm.Model{ID: 123},
+		Trigger:      models.DeployHookTriggerConfig{},
+		SlackChannel: testutils.PointerTo("channel"),
+	}, models.CiRun{})
+	s.ErrorContains(err, "SlackDeployHook 123 didn't have Trigger fully loaded")
+}
+
+func (s *deployHooksSuite) Test_generateSlackAttachment_statusNotPresent() {
+	_, err := generateSlackAttachment(nil, models.SlackDeployHook{
+		Trigger: models.DeployHookTriggerConfig{
+			OnEnvironment: &models.Environment{Name: "name"},
+		},
+	}, models.CiRun{
+		Model: gorm.Model{ID: 123},
+	})
+	s.ErrorContains(err, "CiRun 123 didn't have status present")
+}
+
+func (s *deployHooksSuite) Test_generateSlackAttachment_environmentNoChangesets_success() {
+	result, err := generateSlackAttachment(nil, models.SlackDeployHook{
+		Trigger: models.DeployHookTriggerConfig{
+			OnEnvironment: &models.Environment{Name: "dev"},
+		},
+	}, models.CiRun{
+		Model:                      gorm.Model{ID: 123},
+		TerminalAt:                 testutils.PointerTo(time.Now()),
+		Status:                     testutils.PointerTo("success"),
+		Platform:                   "github-actions",
+		GithubActionsOwner:         "broadinstitute",
+		GithubActionsRepo:          "terra-github-workflows",
+		GithubActionsRunID:         123123,
+		GithubActionsAttemptNumber: 1,
+	})
+	s.NoError(err)
+	s.Equal(slack.GreenBlock{Text: "Deployment to dev: <https://github.com/broadinstitute/terra-github-workflows/actions/runs/123123/attempts/1|success>."}, result)
+}
+
+func (s *deployHooksSuite) Test_generateSlackAttachment_environmentNoChangesets_failure() {
+	result, err := generateSlackAttachment(nil, models.SlackDeployHook{
+		Trigger: models.DeployHookTriggerConfig{
+			OnEnvironment: &models.Environment{Name: "dev"},
+		},
+	}, models.CiRun{
+		Model:                      gorm.Model{ID: 123},
+		TerminalAt:                 testutils.PointerTo(time.Now()),
+		Status:                     testutils.PointerTo("failure"),
+		Platform:                   "github-actions",
+		GithubActionsOwner:         "broadinstitute",
+		GithubActionsRepo:          "terra-github-workflows",
+		GithubActionsRunID:         123123,
+		GithubActionsAttemptNumber: 1,
+	})
+	s.NoError(err)
+	s.Equal(slack.RedBlock{Text: "Deployment to dev: <https://github.com/broadinstitute/terra-github-workflows/actions/runs/123123/attempts/1|failure>."}, result)
+}
+
+func (s *deployHooksSuite) Test_generateSlackAttachment_chartReleaseNoChangesets_success() {
+	result, err := generateSlackAttachment(nil, models.SlackDeployHook{
+		Trigger: models.DeployHookTriggerConfig{
+			OnChartRelease: &models.ChartRelease{Name: "leonardo-dev"},
+		},
+	}, models.CiRun{
+		Model:                      gorm.Model{ID: 123},
+		TerminalAt:                 testutils.PointerTo(time.Now()),
+		Status:                     testutils.PointerTo("success"),
+		Platform:                   "github-actions",
+		GithubActionsOwner:         "broadinstitute",
+		GithubActionsRepo:          "terra-github-workflows",
+		GithubActionsRunID:         123123,
+		GithubActionsAttemptNumber: 1,
+	})
+	s.NoError(err)
+	s.Equal(slack.GreenBlock{Text: "Deployment to leonardo-dev: <https://github.com/broadinstitute/terra-github-workflows/actions/runs/123123/attempts/1|success>."}, result)
+}
+
+func (s *deployHooksSuite) Test_generateSlackAttachment_chartReleaseNoChangesets_failure() {
+	result, err := generateSlackAttachment(nil, models.SlackDeployHook{
+		Trigger: models.DeployHookTriggerConfig{
+			OnChartRelease: &models.ChartRelease{Name: "leonardo-dev"},
+		},
+	}, models.CiRun{
+		Model:                      gorm.Model{ID: 123},
+		TerminalAt:                 testutils.PointerTo(time.Now()),
+		Status:                     testutils.PointerTo("failure"),
+		Platform:                   "github-actions",
+		GithubActionsOwner:         "broadinstitute",
+		GithubActionsRepo:          "terra-github-workflows",
+		GithubActionsRunID:         123123,
+		GithubActionsAttemptNumber: 1,
+	})
+	s.NoError(err)
+	s.Equal(slack.RedBlock{Text: "Deployment to leonardo-dev: <https://github.com/broadinstitute/terra-github-workflows/actions/runs/123123/attempts/1|failure>."}, result)
+}
+
+func (s *deployHooksSuite) Test_generateSlackAttachment_environmentChangesets_success() {
+	result, err := generateSlackAttachment(nil, models.SlackDeployHook{
+		Trigger: models.DeployHookTriggerConfig{
+			OnEnvironment: &models.Environment{Name: "dev"},
+		},
+	}, models.CiRun{
+		Model:                      gorm.Model{ID: 123},
+		TerminalAt:                 testutils.PointerTo(time.Now()),
+		Status:                     testutils.PointerTo("success"),
+		Platform:                   "github-actions",
+		GithubActionsOwner:         "broadinstitute",
+		GithubActionsRepo:          "terra-github-workflows",
+		GithubActionsRunID:         123123,
+		GithubActionsAttemptNumber: 1,
+		RelatedResources: []models.CiIdentifier{
+			{
+				ResourceType: "changeset",
+				ResourceID:   1122,
+			},
+			{
+				ResourceType: "chart-release",
+				ResourceID:   1123,
+			},
+			{
+				ResourceType: "changeset",
+				ResourceID:   1124,
+			},
+		},
+	})
+	s.NoError(err)
+	s.Equal(slack.GreenBlock{Text: "Deployment to dev: <https://github.com/broadinstitute/terra-github-workflows/actions/runs/123123/attempts/1|success>. Review all changes made by this deployment <https://beehive.dsp-devops.broadinstitute.org/review-changesets?changeset=1122&changeset=1124|here>."}, result)
+}
+
+func (s *deployHooksSuite) Test_generateSlackAttachment_environmentChangesets_failure() {
+	result, err := generateSlackAttachment(nil, models.SlackDeployHook{
+		Trigger: models.DeployHookTriggerConfig{
+			OnEnvironment: &models.Environment{Name: "dev"},
+		},
+	}, models.CiRun{
+		Model:                      gorm.Model{ID: 123},
+		TerminalAt:                 testutils.PointerTo(time.Now()),
+		Status:                     testutils.PointerTo("failure"),
+		Platform:                   "github-actions",
+		GithubActionsOwner:         "broadinstitute",
+		GithubActionsRepo:          "terra-github-workflows",
+		GithubActionsRunID:         123123,
+		GithubActionsAttemptNumber: 1,
+		RelatedResources: []models.CiIdentifier{
+			{
+				ResourceType: "changeset",
+				ResourceID:   1122,
+			},
+			{
+				ResourceType: "chart-release",
+				ResourceID:   1123,
+			},
+			{
+				ResourceType: "changeset",
+				ResourceID:   1124,
+			},
+		},
+	})
+	s.NoError(err)
+	s.Equal(slack.RedBlock{Text: "Deployment to dev: <https://github.com/broadinstitute/terra-github-workflows/actions/runs/123123/attempts/1|failure>. Review all changes made by this deployment <https://beehive.dsp-devops.broadinstitute.org/review-changesets?changeset=1122&changeset=1124|here>."}, result)
+}
+
+func (s *deployHooksSuite) Test_generateSlackAttachment_chartReleaseChangesets_success() {
+	result, err := generateSlackAttachment(nil, models.SlackDeployHook{
+		Trigger: models.DeployHookTriggerConfig{
+			OnChartRelease: &models.ChartRelease{Name: "leonardo-dev"},
+		},
+	}, models.CiRun{
+		Model:                      gorm.Model{ID: 123},
+		TerminalAt:                 testutils.PointerTo(time.Now()),
+		Status:                     testutils.PointerTo("success"),
+		Platform:                   "github-actions",
+		GithubActionsOwner:         "broadinstitute",
+		GithubActionsRepo:          "terra-github-workflows",
+		GithubActionsRunID:         123123,
+		GithubActionsAttemptNumber: 1,
+		RelatedResources: []models.CiIdentifier{
+			{
+				ResourceType: "changeset",
+				ResourceID:   1122,
+			},
+			{
+				ResourceType: "chart-release",
+				ResourceID:   1123,
+			},
+			{
+				ResourceType: "changeset",
+				ResourceID:   1124,
+			},
+		},
+	})
+	s.NoError(err)
+	s.Equal(slack.GreenBlock{Text: "Deployment to leonardo-dev: <https://github.com/broadinstitute/terra-github-workflows/actions/runs/123123/attempts/1|success>. Review all changes made by this deployment <https://beehive.dsp-devops.broadinstitute.org/review-changesets?changeset=1122&changeset=1124|here>."}, result)
+}
+
+func (s *deployHooksSuite) Test_generateSlackAttachment_chartReleaseChangesets_failure() {
+	result, err := generateSlackAttachment(nil, models.SlackDeployHook{
+		Trigger: models.DeployHookTriggerConfig{
+			OnChartRelease: &models.ChartRelease{Name: "leonardo-dev"},
+		},
+	}, models.CiRun{
+		Model:                      gorm.Model{ID: 123},
+		TerminalAt:                 testutils.PointerTo(time.Now()),
+		Status:                     testutils.PointerTo("failure"),
+		Platform:                   "github-actions",
+		GithubActionsOwner:         "broadinstitute",
+		GithubActionsRepo:          "terra-github-workflows",
+		GithubActionsRunID:         123123,
+		GithubActionsAttemptNumber: 1,
+		RelatedResources: []models.CiIdentifier{
+			{
+				ResourceType: "changeset",
+				ResourceID:   1122,
+			},
+			{
+				ResourceType: "chart-release",
+				ResourceID:   1123,
+			},
+			{
+				ResourceType: "changeset",
+				ResourceID:   1124,
+			},
+		},
+	})
+	s.NoError(err)
+	s.Equal(slack.RedBlock{Text: "Deployment to leonardo-dev: <https://github.com/broadinstitute/terra-github-workflows/actions/runs/123123/attempts/1|failure>. Review all changes made by this deployment <https://beehive.dsp-devops.broadinstitute.org/review-changesets?changeset=1122&changeset=1124|here>."}, result)
+}


### PR DESCRIPTION
It does the deploy hook thing (just for Slack, but still).

"What is a deploy" is [defined in config](https://github.com/broadinstitute/sherlock/pull/255/files#diff-4d384cde637e16a25a2c337aa142a42be5b727ab3b5d5f52db3d864844e392a7). Everything else is defined via the API.

If there were changesets reported by the deploy, the Slack message will link out to the Beehive page to view them. Easier than writing a ton of code to try to summarize all that again in Slack. Might do that at some point, but the current Jenkins notifications don't do that, so we're already past parity.

## Testing

Lots of tests -- not quite end to end (hard to set up mocks from outside the package, that kinda thing) but complete enough that I'm confident here. Enough that project coverage goes up, even with the stuff I'm introducing here that I can't test.

## Risk

Lowish... maybe it doesn't work, but it wouldn't impact existing functionality. The only API endpoint that's having functionality changed here is CiRun upsert, which is only called by the webhook. If these changes introduce failures, it won't impact the baseline CiRun functionality that Beehive relies on today.