### PR TITLE
[DDO-3048] Disable prepared statements cache

### DIFF
--- a/sherlock/internal/db/connect.go
+++ b/sherlock/internal/db/connect.go
@@ -104,7 +104,8 @@ func openGorm(db *sql.DB) (*gorm.DB, error) {
 	}
 	return gorm.Open(
 		gormpg.New(gormpg.Config{
-			Conn: db,
+			Conn:                 db,
+			PreferSimpleProtocol: true,
 		}),
 
 		&gorm.Config{


### PR DESCRIPTION
From https://gorm.io/docs/connecting_to_the_database.html#PostgreSQL, how to disable PGX prepared statements cache, which appeared to cause the errors we saw in https://broadinstitute.slack.com/archives/C011NQS8Q2Z/p1692298158181069

## Testing

If this didn't work the entire testing thing would fall over

## Risk

Super low I think! Sherlock isn't really high-volume so I don't think performance will degrade by that much