### PR TITLE
[DDO-3049] Improve deploy-to-dev Slack deploy hooks

### DIFF
--- a/.github/workflows/client-refresh-environment.yaml
+++ b/.github/workflows/client-refresh-environment.yaml
@@ -76,6 +76,8 @@ env:
 jobs:
   refresh:
     runs-on: ubuntu-22.04
+    outputs:
+      changesets: ${{ steps.changesets.outputs.changesets }}
     permissions:
       id-token: 'write'
     
@@ -133,7 +135,15 @@ jobs:
             -H 'Content-Type: application/json' \
             -H 'Authorization: Bearer ${{ steps.iap_auth.outputs.id_token }}' \
             -H 'X-GHA-OIDC-JWT: ${{ steps.gha_auth.outputs.id_token }}' \
-            -d "@$RUNNER_TEMP/body.json" | jq
+            -d "@$RUNNER_TEMP/body.json" | jq > $RUNNER_TEMP/response.json
+          cat $RUNNER_TEMP/response.json
+
+      - name: "Parse changesets"
+        id: changesets
+        shell: bash
+        run: |
+          set -ex
+          echo "changesets=$(cat $RUNNER_TEMP/response.json | jq -r 'map(.id) | join(",")')" >> $GITHUB_OUTPUT
 
   can-sync:
     runs-on: ubuntu-22.04
@@ -184,5 +194,6 @@ jobs:
     needs: refresh
     with:
       environments: ${{ inputs.environment-name }}
+      changesets: ${{ needs.refresh.outputs.changesets }}
     permissions:
       id-token: write

--- a/.github/workflows/client-set-environment-app-version.yaml
+++ b/.github/workflows/client-set-environment-app-version.yaml
@@ -225,4 +225,4 @@ jobs:
           workflow: .github/workflows/sync-release.yaml
           ref: refs/heads/main
           token: ${{ secrets.sync-git-token }}
-          inputs: '{ "chart-release-names": "${{ needs.get-chart-release.outputs.name }}", "refresh-only": "false" }'
+          inputs: '{ "chart-release-names": "${{ needs.get-chart-release.outputs.name }}", "changeset-ids": "${{ needs.set-version.outputs.changesets }}", "refresh-only": "false" }'

--- a/.github/workflows/client-set-environment-chart-version.yaml
+++ b/.github/workflows/client-set-environment-chart-version.yaml
@@ -227,4 +227,4 @@ jobs:
           workflow: .github/workflows/sync-release.yaml
           ref: refs/heads/main
           token: ${{ secrets.sync-git-token }}
-          inputs: '{ "chart-release-names": "${{ needs.get-chart-release.outputs.name }}", "refresh-only": "false" }'
+          inputs: '{ "chart-release-names": "${{ needs.get-chart-release.outputs.name }}", "changeset-ids": "${{ needs.set-version.outputs.changesets }}", "refresh-only": "false" }'


### PR DESCRIPTION
When Beehive calls sync-release, it includes Changeset IDs that helps Sherlock make Slack messages that link back to the changes that were applied.

Some of Sherlock's reusable workflows also call sync-release, or otherwise do fun things with Changesets. This PR closes the loop a bit:

- client-set-environment-app-version now passes Changeset IDs to sync-release (it already passed them elsewhere, one-line change)
- client-set-environment-chart-version, same as above
- client-refresh-environment now reports its Changeset IDs (it uses sync-environment, so not passing it through all the way, but this is better still)