### PR TITLE
[DDO-3053] Harden Sherlock's webhook proxy

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -16,3 +16,7 @@ updates:
     directory: /sherlock-go-client
     schedule:
       interval: weekly
+  - package-ecosystem: gomod
+    directory: /sherlock-webhook-proxy
+    schedule:
+      interval: weekly

--- a/makefile
+++ b/makefile
@@ -52,7 +52,7 @@ deploy-webhook-proxy:
 			--allow-unauthenticated \
 			--source . \
 			--entry-point HandleWebhook \
-			--set-env-vars SHERLOCK_URL='https://sherlock.dsp-devops.broadinstitute.org',IAP_AUDIENCE="1038484894585-k8qvf7l876733laev0lm8kenfa2lj6bn.apps.googleusercontent.com" \
+			--set-env-vars SHERLOCK_URL='https://sherlock.dsp-devops.broadinstitute.org',IAP_AUDIENCE="1038484894585-k8qvf7l876733laev0lm8kenfa2lj6bn.apps.googleusercontent.com",ALLOWED_GITHUB_ORGS="broadinstitute,DataBiosphere,CancerDataAggregator" \
 			--set-secrets GITHUB_WEBHOOK_SECRET=sherlock-prod-webhook-secret:latest \
 			--service-account sherlock-webhook-proxy@dsp-tools-k8s.iam.gserviceaccount.com \
 		; rm -rf vendor

--- a/sherlock-webhook-proxy/README.md
+++ b/sherlock-webhook-proxy/README.md
@@ -8,7 +8,7 @@ It receives webhooks, validates them, and turns them into IAP-authenticated call
 make local-up
 ```
 ```
-cd sherlock-webhook-proxy && FUNCTION_TARGET="HandleWebhook" IAP_TOKEN=$(thelma auth iap --echo) SHERLOCK_URL=http://localhost:8080 GITHUB_WEBHOOK_SECRET=foobar go run cmd/main.go
+cd sherlock-webhook-proxy && FUNCTION_TARGET="HandleWebhook" IAP_TOKEN=$(thelma auth iap --echo) SHERLOCK_URL=http://localhost:8080 GITHUB_WEBHOOK_SECRET=foobar ALLOWED_GITHUB_ORGS=broadinstitute go run cmd/main.go
 ```
 ```
 gh webhook forward --repo=broadinstitute/sherlock --events=workflow_run --url=http://localhost:8090/webhook --secret=foobar

--- a/sherlock-webhook-proxy/go.mod
+++ b/sherlock-webhook-proxy/go.mod
@@ -4,12 +4,14 @@ go 1.19
 
 require (
 	github.com/GoogleCloudPlatform/functions-framework-go v1.7.4
+	github.com/broadinstitute/sherlock/go-shared v0.0.0
 	github.com/broadinstitute/sherlock/sherlock-go-client v0.0.0
 	github.com/go-openapi/runtime v0.26.0
 	github.com/go-openapi/strfmt v0.21.7
 	github.com/go-playground/webhooks/v6 v6.1.0
-
 )
+
+replace github.com/broadinstitute/sherlock/go-shared => ../go-shared
 
 replace github.com/broadinstitute/sherlock/sherlock-go-client => ../sherlock-go-client
 


### PR DESCRIPTION
A consequence of our shiny new Beehive GitHub app needing to span multiple orgs is that it needs to be a public app. That means anyone can install it. That's wouldn't really be a problem -- if random people want to give us read/write on their repo, not really our problem -- except that it'll loop us in to webhook events coming from their installation.

Solution is to filter out unknown orgs. Then the data never reaches Sherlock, and we're in the same security model as before, where this is a public cloud function that'll happily eat spurious requests.

In other words, this change prevents Sherlock from ever being affected if some random person figures out how to install our GitHub Apps.

While I was at it, I touched up the code a little bit and enabled Dependabot.

## Testing

I copied/pasted the updated commands in the README to spin it up locally, then hit Sherlock's dummy test action. It worked fine, so it's clearly parsing the org correctly.

## Risk

If there's a problem... idk, we miss a few CiRuns. Not a big deal and I've tested this against actual GitHub already.