### PR TITLE
[DDO-3053] Fix proxy cloud function deployment

### DIFF
--- a/makefile
+++ b/makefile
@@ -52,7 +52,7 @@ deploy-webhook-proxy:
 			--allow-unauthenticated \
 			--source . \
 			--entry-point HandleWebhook \
-			--set-env-vars SHERLOCK_URL='https://sherlock.dsp-devops.broadinstitute.org',IAP_AUDIENCE="1038484894585-k8qvf7l876733laev0lm8kenfa2lj6bn.apps.googleusercontent.com",ALLOWED_GITHUB_ORGS="broadinstitute DataBiosphere CancerDataAggregator" \
+			--set-env-vars SHERLOCK_URL='https://sherlock.dsp-devops.broadinstitute.org',IAP_AUDIENCE='1038484894585-k8qvf7l876733laev0lm8kenfa2lj6bn.apps.googleusercontent.com',ALLOWED_GITHUB_ORGS='broadinstitute DataBiosphere CancerDataAggregator' \
 			--set-secrets GITHUB_WEBHOOK_SECRET=sherlock-prod-webhook-secret:latest \
 			--service-account sherlock-webhook-proxy@dsp-tools-k8s.iam.gserviceaccount.com \
 		; rm -rf vendor

--- a/makefile
+++ b/makefile
@@ -52,7 +52,7 @@ deploy-webhook-proxy:
 			--allow-unauthenticated \
 			--source . \
 			--entry-point HandleWebhook \
-			--set-env-vars SHERLOCK_URL='https://sherlock.dsp-devops.broadinstitute.org',IAP_AUDIENCE="1038484894585-k8qvf7l876733laev0lm8kenfa2lj6bn.apps.googleusercontent.com",ALLOWED_GITHUB_ORGS="broadinstitute,DataBiosphere,CancerDataAggregator" \
+			--set-env-vars SHERLOCK_URL='https://sherlock.dsp-devops.broadinstitute.org',IAP_AUDIENCE="1038484894585-k8qvf7l876733laev0lm8kenfa2lj6bn.apps.googleusercontent.com",ALLOWED_GITHUB_ORGS="broadinstitute DataBiosphere CancerDataAggregator" \
 			--set-secrets GITHUB_WEBHOOK_SECRET=sherlock-prod-webhook-secret:latest \
 			--service-account sherlock-webhook-proxy@dsp-tools-k8s.iam.gserviceaccount.com \
 		; rm -rf vendor

--- a/sherlock-webhook-proxy/pkg/handler.go
+++ b/sherlock-webhook-proxy/pkg/handler.go
@@ -33,7 +33,7 @@ const (
 	iapAudienceEnvVar = "IAP_AUDIENCE"
 	// githubWebhookSecretEnvVar should be set to the secret set in the GitHub Webhook config
 	githubWebhookSecretEnvVar = "GITHUB_WEBHOOK_SECRET"
-	// allowedGithubOrgsEnvVar should be a comma-separated list of GitHub orgs that this cloud function should pay attention to.
+	// allowedGithubOrgsEnvVar should be a space-separated list of GitHub orgs that this cloud function should pay attention to.
 	// This is necessary because GitHub Apps can theoretically be installed by anyone. That doesn't affect us except for webhooks,
 	// where it technically allows arbitrary people to lob requests at this endpoint. That's not new, this endpoint is public,
 	// but these requests will come from GitHub, so we should filter.
@@ -86,8 +86,8 @@ func init() {
 		log.Fatalf("os.LookupEnv(%s): present=false\n", allowedGithubOrgsEnvVar)
 	} else if allowedGithubOrgsString == "" {
 		log.Fatalf("os.LookupEnv(%s): allowedGithubOrgsString=''\n", allowedGithubOrgsEnvVar)
-	} else if allowedGithubOrgs = strings.Split(allowedGithubOrgsString, ","); len(allowedGithubOrgs) == 0 {
-		log.Fatalf("len(strings.Split(\"%s\", \",\"))=0\n", allowedGithubOrgsString)
+	} else if allowedGithubOrgs = strings.Split(allowedGithubOrgsString, " "); len(allowedGithubOrgs) == 0 {
+		log.Fatalf("len(strings.Split(\"%s\", \" \"))=0\n", allowedGithubOrgsString)
 	}
 }
 


### PR DESCRIPTION
In hindsight, I guess it makes sense that `gcloud` would be unhappy with comma-separated stuff, even in quotes, because it isn't like it gets to see the fact that it's in quotes.

Whatever, now it's space-separated.