### PR TITLE
[DDO-3054] Have Gorm not upsert associations in the old code

### DIFF
--- a/sherlock/internal/deprecated_models/v2models/changeset.go
+++ b/sherlock/internal/deprecated_models/v2models/changeset.go
@@ -59,6 +59,9 @@ func init() {
 			modelToSelectors:     changesetToSelectors,
 			validateModel:        validateChangeset,
 			preCreate:            preCreateChangeset,
+			customCreationAssociationsClause: func(db *gorm.DB) *gorm.DB {
+				return db.Omit("CiIdentifier", "ChartRelease")
+			},
 		},
 	}
 }

--- a/sherlock/internal/deprecated_models/v2models/ci_run.go
+++ b/sherlock/internal/deprecated_models/v2models/ci_run.go
@@ -51,6 +51,7 @@ func init() {
 			"RelatedResources": func(edits *CiRun) any { return edits.RelatedResources },
 		},
 		customCreationAssociationsClause: func(db *gorm.DB) *gorm.DB {
+			// Don't exclude any associations, the only one is RelatedResources which we need
 			return db
 		},
 	}

--- a/sherlock/internal/deprecated_models/v2models/ci_run.go
+++ b/sherlock/internal/deprecated_models/v2models/ci_run.go
@@ -50,6 +50,9 @@ func init() {
 		editsAppendManyToMany: map[string]func(edits *CiRun) any{
 			"RelatedResources": func(edits *CiRun) any { return edits.RelatedResources },
 		},
+		customCreationAssociationsClause: func(db *gorm.DB) *gorm.DB {
+			return db
+		},
 	}
 }
 


### PR DESCRIPTION
I didn't read the manual.

Gorm will upsert associations during creation if it's got data to do so. My generic abstractions 1) made it always have that data 2) made it always unnecessary.

That came to a head today, where we got some deadlocks in the v2_ci_identifiers on unrelated operations.

I'm a bit fuzzy on how it could become a problem all of a sudden, but "don't touch the v2_ci_identifiers table during creation in general" seems like a really good start.

## Testing

I may have built an unnecessary abstraction around Gorm, but at least I tested it. Tests uncovered some instances where I actually was relying on this behavior, so I added a stupid hack thingy to let those types more specifically declare what could actually be safely omitted.

## Risk

Some risk here -- this will kinda be a stress test on my abstractions, because it turns out that Gorm has been beneath them the whole time. They are tested, though, so at least for the frequently traveled functionality I'm still confident. I think we need to merge this change to try to stem the bleeding of the deadlock issue.