### PR TITLE
[DDO-3060] API to create a timeline of when/where a version was deployed

### DIFF
--- a/sherlock/internal/deprecated_controllers/v2controllers/changeset_procedures.go
+++ b/sherlock/internal/deprecated_controllers/v2controllers/changeset_procedures.go
@@ -268,8 +268,21 @@ func (c ChangesetController) Apply(selectors []string, user *models.User) ([]Cha
 	return ret, nil
 }
 
-func (c ChangesetController) QueryApplied(chartReleaseSelector string, offset int, limit int) ([]Changeset, error) {
-	modelChangesets, err := c.ChangesetStore.QueryApplied(chartReleaseSelector, offset, limit)
+func (c ChangesetController) QueryAppliedForChartRelease(chartReleaseSelector string, offset int, limit int) ([]Changeset, error) {
+	modelChangesets, err := c.ChangesetStore.QueryAppliedForChartRelease(chartReleaseSelector, offset, limit)
+	if err != nil {
+		return nil, err
+	}
+	//golang:noinspection GoPreferNilSlice
+	ret := []Changeset{}
+	for _, modelChangeset := range modelChangesets {
+		ret = append(ret, *modelChangesetToChangeset(&modelChangeset))
+	}
+	return ret, nil
+}
+
+func (c ChangesetController) QueryAppliedForVersion(chartSelector string, version string, versionType string) ([]Changeset, error) {
+	modelChangesets, err := c.ChangesetStore.QueryAppliedForVersion(chartSelector, version, versionType)
 	if err != nil {
 		return nil, err
 	}

--- a/sherlock/internal/deprecated_controllers/v2controllers/changeset_test.go
+++ b/sherlock/internal/deprecated_controllers/v2controllers/changeset_test.go
@@ -475,7 +475,7 @@ func (suite *changesetControllerSuite) TestChangesetFlow() {
 	}, generateUser(suite.T(), suite.db, true))
 	assert.NoError(suite.T(), err)
 	assert.Len(suite.T(), applied, 1)
-	queried, err := suite.ChangesetController.QueryApplied("terra-dev/sam", 0, 100)
+	queried, err := suite.ChangesetController.QueryAppliedForChartRelease("terra-dev/sam", 0, 100)
 	assert.NoError(suite.T(), err)
 	for _, result := range queried {
 		assert.NotEqual(suite.T(), unapplied[0].ID, result.ID)

--- a/sherlock/internal/deprecated_models/v2models/changeset_store.go
+++ b/sherlock/internal/deprecated_models/v2models/changeset_store.go
@@ -39,7 +39,7 @@ func (s *ChangesetStore) Apply(selectors []string, user *models.User) ([]Changes
 	return InternalChangesetStore.apply(s.db, queries, user)
 }
 
-func (s *ChangesetStore) QueryApplied(chartReleaseSelector string, offset int, limit int) ([]Changeset, error) {
+func (s *ChangesetStore) QueryAppliedForChartRelease(chartReleaseSelector string, offset int, limit int) ([]Changeset, error) {
 	chartReleaseQuery, err := InternalChartReleaseStore.selectorToQueryModel(s.db, chartReleaseSelector)
 	if err != nil {
 		return nil, err
@@ -48,5 +48,13 @@ func (s *ChangesetStore) QueryApplied(chartReleaseSelector string, offset int, l
 	if err != nil {
 		return nil, err
 	}
-	return InternalChangesetStore.queryApplied(s.db, chartRelease.ID, offset, limit)
+	return InternalChangesetStore.queryAppliedForChartRelease(s.db, chartRelease.ID, offset, limit)
+}
+
+func (s *ChangesetStore) QueryAppliedForVersion(chartSelector string, version string, versionType string) ([]Changeset, error) {
+	chart, err := InternalChartStore.GetBySelector(s.db, chartSelector)
+	if err != nil {
+		return nil, err
+	}
+	return InternalChangesetStore.queryAppliedForVersion(s.db, chart.ID, version, versionType)
 }


### PR DESCRIPTION
It's `/api/v2/procedures/changesets/query-applied-for-version/{version-type}/{chart}/{version}`, you use it like `/api/v2/procedures/changesets/query-applied-for-version/app/sam/v0.0.102` and it returns a list of what changesets deployed that version, in timeline order (first is the latest applied).

When possible, it will handle scenarios where the specified version was an intermediary version, i.e. you care about version 2 but prod when from 1 to 3 directly. This endpoint will include that 1 to 3 changeset if you ask for 2.

If you ask for a version that was never recorded in Sherlock, it will still do a best effort search (but it obviously can't do the intermediary-version detection then).

## Testing

Manually tested against my clone of prod. It would take me another day to actually create a complicated enough test scenario to actually exercise this endpoint. I talked with Mike about this; I think it's an okay tradeoff in this case.

## Risk

It's a new endpoint, no existing code paths impacted. It only reads. Low risk IMO.