### PR TITLE
[DDO-3072] GH deploy hook fixes

### DIFF
--- a/sherlock/internal/deployhooks/dispatch_github_actions_deploy_hook_test.go
+++ b/sherlock/internal/deployhooks/dispatch_github_actions_deploy_hook_test.go
@@ -34,13 +34,14 @@ func (s *deployHooksSuite) Test_dispatchGithubActionsDeployHook_basic() {
 	github.UseMockedClient(s.T(), func(c *github.MockClient) {
 		c.Actions.EXPECT().CreateWorkflowDispatchEventByFileName(
 			s.DB.Statement.Context, "owner", "repo", "path", github2.CreateWorkflowDispatchEventRequest{
-				Ref: "HEAD",
+				Ref: "main",
 			}).Return(nil, nil)
 	}, func() {
 		s.NoError(dispatchGithubActionsDeployHook(s.DB, models.GithubActionsDeployHook{
 			GithubActionsOwner:        testutils.PointerTo("owner"),
 			GithubActionsRepo:         testutils.PointerTo("repo"),
 			GithubActionsWorkflowPath: testutils.PointerTo("path"),
+			GithubActionsDefaultRef:   testutils.PointerTo("main"),
 		}, models.CiRun{}))
 	})
 }
@@ -50,30 +51,15 @@ func (s *deployHooksSuite) Test_dispatchGithubActionsDeployHook_passesThroughErr
 	github.UseMockedClient(s.T(), func(c *github.MockClient) {
 		c.Actions.EXPECT().CreateWorkflowDispatchEventByFileName(
 			s.DB.Statement.Context, "owner", "repo", "path", github2.CreateWorkflowDispatchEventRequest{
-				Ref: "HEAD",
+				Ref: "main",
 			}).Return(nil, err)
 	}, func() {
 		s.ErrorIs(dispatchGithubActionsDeployHook(s.DB, models.GithubActionsDeployHook{
 			GithubActionsOwner:        testutils.PointerTo("owner"),
 			GithubActionsRepo:         testutils.PointerTo("repo"),
 			GithubActionsWorkflowPath: testutils.PointerTo("path"),
+			GithubActionsDefaultRef:   testutils.PointerTo("main"),
 		}, models.CiRun{}), err)
-	})
-}
-
-func (s *deployHooksSuite) Test_dispatchGithubActionsDeployHook_withDefaultRef() {
-	github.UseMockedClient(s.T(), func(c *github.MockClient) {
-		c.Actions.EXPECT().CreateWorkflowDispatchEventByFileName(
-			s.DB.Statement.Context, "owner", "repo", "path", github2.CreateWorkflowDispatchEventRequest{
-				Ref: "custom ref",
-			}).Return(nil, nil)
-	}, func() {
-		s.NoError(dispatchGithubActionsDeployHook(s.DB, models.GithubActionsDeployHook{
-			GithubActionsOwner:        testutils.PointerTo("owner"),
-			GithubActionsRepo:         testutils.PointerTo("repo"),
-			GithubActionsWorkflowPath: testutils.PointerTo("path"),
-			GithubActionsDefaultRef:   testutils.PointerTo("custom ref"),
-		}, models.CiRun{}))
 	})
 }
 

--- a/sherlock/internal/github/dispatch_workflow.go
+++ b/sherlock/internal/github/dispatch_workflow.go
@@ -3,15 +3,19 @@ package github
 import (
 	"context"
 	"github.com/google/go-github/v50/github"
+	"strings"
 )
 
 // DispatchWorkflow basically wraps client.Actions.CreateWorkflowDispatchEventByFileName.
 // This is so that we can mock it and to simplify imports (the caller doesn't need to
 // import github.CreateWorkflowDispatchEventRequest, which clashes with our own package
-// name)
+// name).
+// We can also handle the case where GitHub's own API refers to workflow file paths
+// differently: here we always want to pass just the filename.
 func DispatchWorkflow(ctx context.Context, owner string, repo string, workflowPath string, gitRef string, inputs map[string]any) error {
+	workflowPathSplit := strings.Split(workflowPath, "/")
 	_, err := client.Actions.CreateWorkflowDispatchEventByFileName(
-		ctx, owner, repo, workflowPath, github.CreateWorkflowDispatchEventRequest{
+		ctx, owner, repo, workflowPathSplit[len(workflowPathSplit)-1], github.CreateWorkflowDispatchEventRequest{
 			Ref:    gitRef,
 			Inputs: inputs,
 		})

--- a/sherlock/internal/github/dispatch_workflow_test.go
+++ b/sherlock/internal/github/dispatch_workflow_test.go
@@ -61,6 +61,24 @@ func TestDispatchWorkflow(t *testing.T) {
 			},
 			wantErr: assert.Error,
 		},
+		{
+			name: "splits to filename",
+			args: args{
+				owner:        "owner",
+				repo:         "repo",
+				workflowPath: "path/to/file.yaml",
+				gitRef:       "head",
+				inputs:       map[string]any{"foo": true},
+			},
+			mockConfig: func(c *MockClient) {
+				c.Actions.EXPECT().CreateWorkflowDispatchEventByFileName(
+					ctx, "owner", "repo", "file.yaml", github.CreateWorkflowDispatchEventRequest{
+						Ref:    "head",
+						Inputs: map[string]any{"foo": true},
+					}).Return(nil, nil)
+			},
+			wantErr: assert.NoError,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
1. GitHub's API isn't consistent with how it treats workflow file paths. It gives us the full file path in some APIs, but this one fails if you don't pass just the filename in. This PR make our wrapper just handle that so we don't have to worry about it.
2. Turns out HEAD isn't recognized by this endpoint. Not a big deal, our API already requires that a specific default ref be passed in, but I'll remove HEAD as an internal failsafe.

## Testing

Updated our tests, full coverage over changes

## Risk

None