### PR TITLE
[DDO-3100] Rename deployHooksDispatchedAt

### DIFF
--- a/sherlock/db/migrations/000051_rename_dispatched_at.down.sql
+++ b/sherlock/db/migrations/000051_rename_dispatched_at.down.sql
@@ -1,0 +1,2 @@
+alter table v2_ci_runs
+    rename column termination_hooks_dispatched_at to deploy_hooks_dispatched_at;

--- a/sherlock/db/migrations/000051_rename_dispatched_at.up.sql
+++ b/sherlock/db/migrations/000051_rename_dispatched_at.up.sql
@@ -1,0 +1,2 @@
+alter table v2_ci_runs
+    rename column deploy_hooks_dispatched_at to termination_hooks_dispatched_at;

--- a/sherlock/internal/api/sherlock/ci_runs_v3.go
+++ b/sherlock/internal/api/sherlock/ci_runs_v3.go
@@ -8,8 +8,8 @@ import (
 type CiRunV3 struct {
 	CommonFields
 	ciRunFields
-	DeployHooksDispatchedAt *string          `json:"deployHooksDispatchedAt,omitempty" form:"deployHooksDispatchedAt" format:"date-time"`
-	RelatedResources        []CiIdentifierV3 `json:"relatedResources" form:"-"`
+	TerminationHooksDispatchedAt *string          `json:"terminationHooksDispatchedAt,omitempty" form:"terminationHooksDispatchedAt" format:"date-time"`
+	RelatedResources             []CiIdentifierV3 `json:"relatedResources" form:"-"`
 }
 
 type ciRunFields struct {
@@ -29,20 +29,20 @@ type ciRunFields struct {
 
 func (c CiRunV3) toModel() models.CiRun {
 	return models.CiRun{
-		Model:                      c.toGormModel(),
-		Platform:                   c.Platform,
-		GithubActionsOwner:         c.GithubActionsOwner,
-		GithubActionsRepo:          c.GithubActionsRepo,
-		GithubActionsRunID:         c.GithubActionsRunID,
-		GithubActionsAttemptNumber: c.GithubActionsAttemptNumber,
-		GithubActionsWorkflowPath:  c.GithubActionsWorkflowPath,
-		ArgoWorkflowsNamespace:     c.ArgoWorkflowsNamespace,
-		ArgoWorkflowsName:          c.ArgoWorkflowsName,
-		ArgoWorkflowsTemplate:      c.ArgoWorkflowsTemplate,
-		DeployHooksDispatchedAt:    c.DeployHooksDispatchedAt,
-		StartedAt:                  c.StartedAt,
-		TerminalAt:                 c.TerminalAt,
-		Status:                     c.Status,
+		Model:                        c.toGormModel(),
+		Platform:                     c.Platform,
+		GithubActionsOwner:           c.GithubActionsOwner,
+		GithubActionsRepo:            c.GithubActionsRepo,
+		GithubActionsRunID:           c.GithubActionsRunID,
+		GithubActionsAttemptNumber:   c.GithubActionsAttemptNumber,
+		GithubActionsWorkflowPath:    c.GithubActionsWorkflowPath,
+		ArgoWorkflowsNamespace:       c.ArgoWorkflowsNamespace,
+		ArgoWorkflowsName:            c.ArgoWorkflowsName,
+		ArgoWorkflowsTemplate:        c.ArgoWorkflowsTemplate,
+		TerminationHooksDispatchedAt: c.TerminationHooksDispatchedAt,
+		StartedAt:                    c.StartedAt,
+		TerminalAt:                   c.TerminalAt,
+		Status:                       c.Status,
 	}
 }
 
@@ -70,7 +70,7 @@ func ciRunFromModel(model models.CiRun) CiRunV3 {
 			TerminalAt:                 model.TerminalAt,
 			Status:                     model.Status,
 		},
-		DeployHooksDispatchedAt: model.DeployHooksDispatchedAt,
-		RelatedResources:        relatedResources,
+		TerminationHooksDispatchedAt: model.TerminationHooksDispatchedAt,
+		RelatedResources:             relatedResources,
 	}
 }

--- a/sherlock/internal/api/sherlock/ci_runs_v3_upsert_test.go
+++ b/sherlock/internal/api/sherlock/ci_runs_v3_upsert_test.go
@@ -466,7 +466,7 @@ func (s *handlerSuite) TestCiRunsV3UpsertIdentifiers() {
 				}),
 				&got)
 			s.Equal(http.StatusCreated, code)
-			s.Empty(got.DeployHooksDispatchedAt)
+			s.Empty(got.TerminationHooksDispatchedAt)
 		})
 		s.Run("when finished", func() {
 			code := s.HandleRequest(
@@ -484,7 +484,7 @@ func (s *handlerSuite) TestCiRunsV3UpsertIdentifiers() {
 				}),
 				&got)
 			s.Equal(http.StatusCreated, code)
-			s.NotNil(got.DeployHooksDispatchedAt)
+			s.NotNil(got.TerminationHooksDispatchedAt)
 		})
 	})
 }

--- a/sherlock/internal/models/ci_run.go
+++ b/sherlock/internal/models/ci_run.go
@@ -23,14 +23,14 @@ type CiRun struct {
 	ArgoWorkflowsName          string
 	ArgoWorkflowsTemplate      string `koanf:"argoWorkflowsTemplate"`
 
-	// DeployHooksDispatchedAt will only be set when the CiRun is recognized
-	// as a deployment. A lot of why it exists is to help avoid double-send
-	// with multiple Sherlock replicas/goroutines thinking they observed a
-	// CiRun terminate. This field is similar to UpdatedAt in that while
-	// technically mutable it isn't exposed as such directly in the API.
-	// It's a string so that we can store higher-than-Postgres levels of
-	// accuracy (again, to avoid double-send, since we use it like a mutex).
-	DeployHooksDispatchedAt *string
+	// TerminationHooksDispatchedAt is set when Sherlock sees a CiRun complete.
+	// A lot of why it exists is to help avoid double-send with multiple Sherlock
+	// replicas/goroutines thinking they observed a CiRun terminate. This field
+	// is similar to UpdatedAt in that while technically mutable it isn't exposed
+	// as such directly in the API. It's a string so that we can store
+	// higher-than-Postgres levels of accuracy (again, to avoid double-send,
+	// since we use it like a mutex).
+	TerminationHooksDispatchedAt *string
 
 	// Mutable
 	RelatedResources []CiIdentifier `gorm:"many2many:v2_ci_runs_for_identifiers"`

--- a/sherlock/internal/models/ci_run_test.go
+++ b/sherlock/internal/models/ci_run_test.go
@@ -203,21 +203,21 @@ func TestCiRun_WebURL(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &CiRun{
-				Model:                      tt.fields.Model,
-				Platform:                   tt.fields.Platform,
-				GithubActionsOwner:         tt.fields.GithubActionsOwner,
-				GithubActionsRepo:          tt.fields.GithubActionsRepo,
-				GithubActionsRunID:         tt.fields.GithubActionsRunID,
-				GithubActionsAttemptNumber: tt.fields.GithubActionsAttemptNumber,
-				GithubActionsWorkflowPath:  tt.fields.GithubActionsWorkflowPath,
-				ArgoWorkflowsNamespace:     tt.fields.ArgoWorkflowsNamespace,
-				ArgoWorkflowsName:          tt.fields.ArgoWorkflowsName,
-				ArgoWorkflowsTemplate:      tt.fields.ArgoWorkflowsTemplate,
-				DeployHooksDispatchedAt:    tt.fields.DeployHooksDispatchedAt,
-				RelatedResources:           tt.fields.RelatedResources,
-				StartedAt:                  tt.fields.StartedAt,
-				TerminalAt:                 tt.fields.TerminalAt,
-				Status:                     tt.fields.Status,
+				Model:                        tt.fields.Model,
+				Platform:                     tt.fields.Platform,
+				GithubActionsOwner:           tt.fields.GithubActionsOwner,
+				GithubActionsRepo:            tt.fields.GithubActionsRepo,
+				GithubActionsRunID:           tt.fields.GithubActionsRunID,
+				GithubActionsAttemptNumber:   tt.fields.GithubActionsAttemptNumber,
+				GithubActionsWorkflowPath:    tt.fields.GithubActionsWorkflowPath,
+				ArgoWorkflowsNamespace:       tt.fields.ArgoWorkflowsNamespace,
+				ArgoWorkflowsName:            tt.fields.ArgoWorkflowsName,
+				ArgoWorkflowsTemplate:        tt.fields.ArgoWorkflowsTemplate,
+				TerminationHooksDispatchedAt: tt.fields.DeployHooksDispatchedAt,
+				RelatedResources:             tt.fields.RelatedResources,
+				StartedAt:                    tt.fields.StartedAt,
+				TerminalAt:                   tt.fields.TerminalAt,
+				Status:                       tt.fields.Status,
 			}
 			if got := c.WebURL(); got != tt.want {
 				t.Errorf("WebURL() = %v, want %v", got, tt.want)
@@ -283,21 +283,21 @@ func TestCiRun_Succeeded(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &CiRun{
-				Model:                      tt.fields.Model,
-				Platform:                   tt.fields.Platform,
-				GithubActionsOwner:         tt.fields.GithubActionsOwner,
-				GithubActionsRepo:          tt.fields.GithubActionsRepo,
-				GithubActionsRunID:         tt.fields.GithubActionsRunID,
-				GithubActionsAttemptNumber: tt.fields.GithubActionsAttemptNumber,
-				GithubActionsWorkflowPath:  tt.fields.GithubActionsWorkflowPath,
-				ArgoWorkflowsNamespace:     tt.fields.ArgoWorkflowsNamespace,
-				ArgoWorkflowsName:          tt.fields.ArgoWorkflowsName,
-				ArgoWorkflowsTemplate:      tt.fields.ArgoWorkflowsTemplate,
-				DeployHooksDispatchedAt:    tt.fields.DeployHooksDispatchedAt,
-				RelatedResources:           tt.fields.RelatedResources,
-				StartedAt:                  tt.fields.StartedAt,
-				TerminalAt:                 tt.fields.TerminalAt,
-				Status:                     tt.fields.Status,
+				Model:                        tt.fields.Model,
+				Platform:                     tt.fields.Platform,
+				GithubActionsOwner:           tt.fields.GithubActionsOwner,
+				GithubActionsRepo:            tt.fields.GithubActionsRepo,
+				GithubActionsRunID:           tt.fields.GithubActionsRunID,
+				GithubActionsAttemptNumber:   tt.fields.GithubActionsAttemptNumber,
+				GithubActionsWorkflowPath:    tt.fields.GithubActionsWorkflowPath,
+				ArgoWorkflowsNamespace:       tt.fields.ArgoWorkflowsNamespace,
+				ArgoWorkflowsName:            tt.fields.ArgoWorkflowsName,
+				ArgoWorkflowsTemplate:        tt.fields.ArgoWorkflowsTemplate,
+				TerminationHooksDispatchedAt: tt.fields.DeployHooksDispatchedAt,
+				RelatedResources:             tt.fields.RelatedResources,
+				StartedAt:                    tt.fields.StartedAt,
+				TerminalAt:                   tt.fields.TerminalAt,
+				Status:                       tt.fields.Status,
 			}
 			if got := c.Succeeded(); got != tt.want {
 				t.Errorf("Succeeded() = %v, want %v", got, tt.want)


### PR DESCRIPTION
terminationHooksDispatchedAt is a better name for the field because of some of the changes I think we'll be making in the future. This isn't a fancy zero-downtime rename because frankly the prepared statement cache will cause issues anyway, so might as well just do it all at once.

## Testing

Tests work and I ran this against my local copy of prod to check that the migration works and doesn't take a while

## Risk

Might drop an automated CiRun request or two if we get unlucky. I think that's okay -- the absolute worst case scenario is that we don't send a slack notification for a deployment. Sherlock will DM us the errors so we'll know what needs cleanup.

That said, I'm still going to deploy this off-hours. Just easier for me to spend 5 seconds running a command tonight than make like 7 PR-deploy cycles to do this in a safer way.