### PR TITLE
[DDO-3108] Prepared statement cache toggle

### DIFF
--- a/sherlock/config/default_config.yaml
+++ b/sherlock/config/default_config.yaml
@@ -16,6 +16,7 @@ db:
   name: sherlock
   port: 5432
   ssl: disable
+  preparedStatementCache: true
   maxIdleConnections: 50
   maxOpenConnections: 75
   connectionMaxIdleTime: 0s

--- a/sherlock/internal/db/connect.go
+++ b/sherlock/internal/db/connect.go
@@ -105,7 +105,7 @@ func openGorm(db *sql.DB) (*gorm.DB, error) {
 	return gorm.Open(
 		gormpg.New(gormpg.Config{
 			Conn:                 db,
-			PreferSimpleProtocol: config.Config.Bool("db.preparedStatementCache"),
+			PreferSimpleProtocol: !config.Config.Bool("db.preparedStatementCache"),
 		}),
 
 		&gorm.Config{

--- a/sherlock/internal/db/connect.go
+++ b/sherlock/internal/db/connect.go
@@ -104,7 +104,8 @@ func openGorm(db *sql.DB) (*gorm.DB, error) {
 	}
 	return gorm.Open(
 		gormpg.New(gormpg.Config{
-			Conn: db,
+			Conn:                 db,
+			PreferSimpleProtocol: config.Config.Bool("db.preparedStatementCache"),
 		}),
 
 		&gorm.Config{


### PR DESCRIPTION
As documented on https://gorm.io/docs/connecting_to_the_database.html#PostgreSQL, PGX enables a prepared statement cache by default. Enabling Gorm's config for "PreferSimpleProtocol" disables it.

This PR adds this to the config file, so that we can toggle this option from argo or something without needing to release a new Sherlock version

## Testing

This line covered by connected DB tests already

## Risk

Maintains the current default behavior (prepared statement cache true -> prefer simple protocol false)