### PR TITLE
[DDO-3101] Cut over GHA to use the new client-report-workflow

### DIFF
--- a/.github/workflows/client-refresh-environment.yaml
+++ b/.github/workflows/client-refresh-environment.yaml
@@ -189,11 +189,11 @@ jobs:
           token: ${{ secrets.sync-git-token }}
           inputs: '{ "environment-names": "${{ inputs.environment-name }}", "refresh-only": "false" }'
 
-  report-workflow-relation:
-    uses: ./.github/workflows/client-report-workflow-related-resources.yaml
+  report-workflow:
+    uses: ./.github/workflows/client-report-workflow.yaml
     needs: refresh
     with:
-      environments: ${{ inputs.environment-name }}
-      changesets: ${{ needs.refresh.outputs.changesets }}
+      relates-to-environments: ${{ inputs.environment-name }}
+      relates-to-changesets: ${{ needs.refresh.outputs.changesets }}
     permissions:
       id-token: write

--- a/.github/workflows/client-report-app-version.yaml
+++ b/.github/workflows/client-report-app-version.yaml
@@ -252,10 +252,10 @@ jobs:
             -d "@$RUNNER_TEMP/body.json" | jq
           echo "### Available in Beehive at $BEEHIVE_PROD_VANITY_URL/r/app-version/${{ inputs.chart-name }}/${{ inputs.new-version }}" >> $GITHUB_STEP_SUMMARY
 
-  report-workflow-relation:
-    uses: ./.github/workflows/client-report-workflow-related-resources.yaml
+  report-workflow:
+    uses: ./.github/workflows/client-report-workflow.yaml
     needs: report-new-version
     with:
-      app-versions: ${{ inputs.chart-name }}/${{ inputs.new-version }}
+      relates-to-app-versions: ${{ inputs.chart-name }}/${{ inputs.new-version }}
     permissions:
       id-token: write

--- a/.github/workflows/client-report-chart-version.yaml
+++ b/.github/workflows/client-report-chart-version.yaml
@@ -243,10 +243,10 @@ jobs:
             -d "@$RUNNER_TEMP/body.json" | jq
           echo "### Available in Beehive at $BEEHIVE_PROD_VANITY_URL/r/chart-version/${{ inputs.chart-name }}/${{ inputs.new-version }}" >> $GITHUB_STEP_SUMMARY
 
-  report-workflow-relation:
-    uses: ./.github/workflows/client-report-workflow-related-resources.yaml
+  report-workflow:
+    uses: ./.github/workflows/client-report-workflow.yaml
     needs: report-new-version
     with:
-      chart-versions: ${{ inputs.chart-name }}/${{ inputs.new-version }}
+      relates-to-chart-versions: ${{ inputs.chart-name }}/${{ inputs.new-version }}
     permissions:
       id-token: write

--- a/.github/workflows/client-set-environment-app-version.yaml
+++ b/.github/workflows/client-set-environment-app-version.yaml
@@ -175,11 +175,11 @@ jobs:
           set -ex
           echo "changesets=$(cat $RUNNER_TEMP/response.json | jq -r 'map(.id) | join(",")')" >> $GITHUB_OUTPUT
 
-  report-workflow-relation:
-    uses: ./.github/workflows/client-report-workflow-related-resources.yaml
+  report-workflow:
+    uses: ./.github/workflows/client-report-workflow.yaml
     needs: set-version
     with:
-      changesets: ${{ needs.set-version.outputs.changesets }}
+      relates-to-changesets: ${{ needs.set-version.outputs.changesets }}
     permissions:
       id-token: write
 

--- a/.github/workflows/client-set-environment-chart-version.yaml
+++ b/.github/workflows/client-set-environment-chart-version.yaml
@@ -177,11 +177,11 @@ jobs:
           set -ex
           echo "changesets=$(cat $RUNNER_TEMP/response.json | jq -r 'map(.id) | join(",")')" >> $GITHUB_OUTPUT
 
-  report-workflow-relation:
-    uses: ./.github/workflows/client-report-workflow-related-resources.yaml
+  report-workflow:
+    uses: ./.github/workflows/client-report-workflow.yaml
     needs: set-version
     with:
-      changesets: ${{ needs.set-version.outputs.changesets }}
+      relates-to-changesets: ${{ needs.set-version.outputs.changesets }}
     permissions:
       id-token: write
 

--- a/.github/workflows/test-auth-transparency.yaml
+++ b/.github/workflows/test-auth-transparency.yaml
@@ -61,10 +61,3 @@ jobs:
             -H 'Authorization: Bearer ${{ steps.iap_auth.outputs.id_token }}' \
             -H 'X-GHA-OIDC-JWT: ${{ steps.gha_auth.outputs.id_token }}' | jq >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
-
-  report-workflow:
-    uses: ./.github/workflows/client-report-workflow.yaml
-    with:
-      notify-slack-channels-upon-workflow-completion: "D04BFUBR4SE" # Jack <-> Beehive
-    permissions:
-      id-token: write

--- a/.github/workflows/test-auth-transparency.yaml
+++ b/.github/workflows/test-auth-transparency.yaml
@@ -61,3 +61,10 @@ jobs:
             -H 'Authorization: Bearer ${{ steps.iap_auth.outputs.id_token }}' \
             -H 'X-GHA-OIDC-JWT: ${{ steps.gha_auth.outputs.id_token }}' | jq >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
+
+  report-workflow:
+    uses: .github/workflows/client-report-workflow.yaml
+    with:
+      notify-slack-channels-upon-workflow-completion: "D04BFUBR4SE" # Jack <-> Beehive
+    permissions:
+      id-token: write

--- a/.github/workflows/test-auth-transparency.yaml
+++ b/.github/workflows/test-auth-transparency.yaml
@@ -63,7 +63,7 @@ jobs:
           echo '```' >> $GITHUB_STEP_SUMMARY
 
   report-workflow:
-    uses: .github/workflows/client-report-workflow.yaml
+    uses: ./.github/workflows/client-report-workflow.yaml
     with:
       notify-slack-channels-upon-workflow-completion: "D04BFUBR4SE" # Jack <-> Beehive
     permissions:


### PR DESCRIPTION
Go from client-report-workflow-relates-resource.yaml to client-report-workflow.yaml. Works the same for this stuff but prefixes the old inputs with `relates-to-`.

## Testing

I briefly modified test-auth-transprancy.yaml to use the new workflow and send a slack notification, checking as best I can that this doesn't blow everything up.

## Risk

GHA are really hard to test. I've checked this over as best I can -- hopefully you can see the uniformity in the diff. GitHub does now check the syntax of GHA pushed to branches, you'll see errors in the actions tab if they're invalid. So if there are errors they should be logical instead of workflow-crashing.