### PR TITLE
[DDO-3113] Remember changeset planners and appliers

### DIFF
--- a/sherlock/db/migrations/000053_changeset_user.down.sql
+++ b/sherlock/db/migrations/000053_changeset_user.down.sql
@@ -1,0 +1,11 @@
+alter table v2_changesets
+    drop constraint if exists fk_v2_changesets_applied_by;
+
+alter table v2_changesets
+    drop column if exists applied_by_id;
+
+alter table v2_changesets
+    drop constraint if exists fk_v2_changesets_planned_by;
+
+alter table v2_changesets
+    drop column if exists planned_by_id;

--- a/sherlock/db/migrations/000053_changeset_user.up.sql
+++ b/sherlock/db/migrations/000053_changeset_user.up.sql
@@ -1,0 +1,13 @@
+alter table v2_changesets
+    add if not exists planned_by_id bigint;
+
+alter table v2_changesets
+    add constraint fk_v2_changesets_planned_by
+        foreign key (planned_by_id) references v2_users;
+
+alter table v2_changesets
+    add if not exists applied_by_id bigint;
+
+alter table v2_changesets
+    add constraint fk_v2_changesets_applied_by
+        foreign key (applied_by_id) references v2_users;

--- a/sherlock/internal/deprecated_controllers/v2controllers/changeset_test.go
+++ b/sherlock/internal/deprecated_controllers/v2controllers/changeset_test.go
@@ -3,6 +3,7 @@ package v2controllers
 import (
 	"fmt"
 	"github.com/broadinstitute/sherlock/go-shared/pkg/testutils"
+	"github.com/broadinstitute/sherlock/sherlock/internal/authentication/test_users"
 	"github.com/broadinstitute/sherlock/sherlock/internal/config"
 	"github.com/broadinstitute/sherlock/sherlock/internal/deprecated_db"
 	"github.com/broadinstitute/sherlock/sherlock/internal/deprecated_models/v2models"
@@ -106,6 +107,12 @@ func (suite *changesetControllerSuite) TestChangesetFlow() {
 	}, generateUser(suite.T(), suite.db, true))
 	assert.NoError(suite.T(), err)
 	assert.Len(suite.T(), applied, 1)
+	if assert.NotNil(suite.T(), applied[0].PlannedBy) {
+		assert.Equal(suite.T(), test_users.SuitableTestUserEmail, *applied[0].PlannedBy)
+	}
+	if assert.NotNil(suite.T(), applied[0].AppliedBy) {
+		assert.Equal(suite.T(), test_users.SuitableTestUserEmail, *applied[0].AppliedBy)
+	}
 
 	// Now the BEE's Sam will be tracking the PR branch--and it'll have the version the engineer just committed.
 	samInBee, err = suite.ChartReleaseController.Get(fmt.Sprintf("%s/%s", newBee.Name, "sam"))
@@ -226,6 +233,10 @@ func (suite *changesetControllerSuite) TestChangesetFlow() {
 	assert.Len(suite.T(), planTo030, 1)
 	assert.Equal(suite.T(), "sam-terra-staging", planTo030[0].ChartRelease)
 	assert.Equal(suite.T(), "0.3.0", *planTo030[0].ToAppVersionExact)
+	if assert.NotNil(suite.T(), planTo030[0].PlannedBy) {
+		assert.Equal(suite.T(), test_users.SuitableTestUserEmail, *planTo030[0].PlannedBy)
+	}
+	assert.Nil(suite.T(), planTo030[0].AppliedBy)
 
 	// Rather than deploying immediately, maybe the engineer merges another PR to mainline:
 	sam040, created, err := suite.AppVersionController.Create(CreatableAppVersion{

--- a/sherlock/internal/models/changeset.go
+++ b/sherlock/internal/models/changeset.go
@@ -17,6 +17,11 @@ type Changeset struct {
 	SupersededAt     *time.Time
 	NewAppVersions   []*AppVersion   `gorm:"many2many:v2_changeset_new_app_versions;constraint:OnDelete:CASCADE,OnUpdate:CASCADE;"`
 	NewChartVersions []*ChartVersion `gorm:"many2many:v2_changeset_new_chart_versions;constraint:OnDelete:CASCADE,OnUpdate:CASCADE;"`
+
+	PlannedBy   *User
+	PlannedByID *uint
+	AppliedBy   *User
+	AppliedByID *uint
 }
 
 func (c Changeset) TableName() string {


### PR DESCRIPTION
Remember users who plan and apply changesets. Adds `plannedBy`, `plannedByInfo`, `appliedBy`, and `appliedByInfo` to the changeset spec. All are technically nullable, but plannedBy is filled upon creation going forward.

## Testing

Wired this in to the tests. Codecov gets confused with the generics, it's coverage stats are wrong here I believe.

## Risk

Just additive, and I took care to avoid scenarios where Gorm might try to recursively update (I only assign IDs, never to the full field).