### PR TITLE
[DDO-3124] Improve app version reporting from detached tags or commits

### DIFF
--- a/.github/workflows/client-report-app-version.yaml
+++ b/.github/workflows/client-report-app-version.yaml
@@ -143,7 +143,7 @@ jobs:
           
           # If $BRANCH is empty, we weren't directly on a branch. Presumably we're on a tag or commit.
           # List branches containing the current commit and pick the first one.
-          # We have to filter out empty lines (awk) and ones that say "detached at" (grep) and then
+          # We have to filter out empty spaces (awk) and ones that say "detached at" (grep) and then
           # pick the first option since there could be multiple (head).
           # This is at least better than throwing our hands up.
           if [ -z "$BRANCH" ]

--- a/.github/workflows/client-report-app-version.yaml
+++ b/.github/workflows/client-report-app-version.yaml
@@ -139,7 +139,19 @@ jobs:
         if: ${{ inputs.use-git == true && inputs.override-branch == '' }}
         shell: bash
         run: |
-          export BRANCH="$(git rev-parse --abbrev-ref HEAD || true)"
+          export BRANCH="$(git branch --show-current || true)"
+          
+          # If $BRANCH is empty, we weren't directly on a branch. Presumably we're on a tag or commit.
+          # List branches containing the current commit and pick the first one.
+          # We have to filter out empty lines (awk) and ones that say "detached at" (grep) and then
+          # pick the first option since there could be multiple (head).
+          # This is at least better than throwing our hands up.
+          if [ -z "$BRANCH" ]
+          then
+            export BRANCH="$((git branch --format='%(refname:short)' --list --contains $(git rev-parse HEAD) | awk '{$1=$1};NF' | grep -v -F " " | head -n 1) || true)"
+          fi
+          
+          # If $BRANCH is not empty, then we go and write it into the request body.
           if [ -n "$BRANCH" ]
           then
             cat <<< $(jq '.gitBranch = env.BRANCH' "$RUNNER_TEMP/body.json") > "$RUNNER_TEMP/body.json"


### PR DESCRIPTION
Rather than assuming one git command will be able to figure out what branch a GHA is running on, we now have two layers.

It used to just run `git rev-parse --abbrev-ref HEAD`, but that returns HEAD if the GHA is running directly on a tag.

The first runs `git branch --show-current`. If we're on a branch, that returns it. Nice and easy.

The second runs if we didn't find anything with that. It runs `git branch --format='%(refname:short)' --list --contains $(git rev-parse HEAD) | awk '{$1=$1};NF' | grep -v -F " " | head -n 1`, which lists branches containing the current checked-out commit, filters consecutive spaces and blank lines, filters out "blah detached at blah", and grabs the first line. That comes up with a reasonable branch name in many cases, which is better than HEAD (which is wholly incorrect).

## Testing

I ran this block of bash locally in some repos to check that it would work as expected.

## Risk

Low. If there's an issue, these commands all are `|| true` so it shouldn't break anything majorly, just might be less info in the UI until I fix it.