### PR TITLE
[DDO-3126] Improve Slack notifications

### DIFF
--- a/.github/workflows/client-report-workflow.yaml
+++ b/.github/workflows/client-report-workflow.yaml
@@ -19,6 +19,9 @@ name: Report GitHub Actions Workflow
 #     permissions:
 #       id-token: write
 # ```
+#
+# The Slack notifications will link to the job and will reference chart releases or environments that the workflow is
+# specified as relating to.
 
 on:
   workflow_call:


### PR DESCRIPTION
Now, if the workflow is marked as relating to a chart release (or environment), the message will no longer look like this:

> terra-java-project-template's build-and-test workflow: [success](https://github.com/DataBiosphere/terra-java-project-template/actions/runs/6125147705/attempts/1)

It'll look like this (hypothetically, fake example)

> terra-java-project-template's build-and-test workflow against [javatemplate-dev](example.com): [success](https://github.com/DataBiosphere/terra-java-project-template/actions/runs/6125147705/attempts/1)

Not amazing but it's a lil better. Tests included.