### PR TITLE
[DDO-3141] Add new `HelmfileRefEnabled` field

### DIFF
--- a/sherlock/config/default_config.yaml
+++ b/sherlock/config/default_config.yaml
@@ -164,6 +164,13 @@ model:
       # Uses appVersionResolver = "none", chartVersionResolver = "latest", and helmfileRef = "HEAD"
       autoPopulateCharts:
         - name: honeycomb
+  changesets:
+    #
+    # if true: set helmfile ref to chart release tag ("charts/sam-1.2.3") when promoting a chart release
+    # if false: set helmfile ref to "HEAD" when promoting a chart release
+    #
+    # this flag is temporary and should be removed when it is defaulted to true
+    helmfileRefDefaultToChartReleaseTags: false
   ciRuns:
     # A list of partial CiRuns where if any has a match on all non-zero fields with an actual CiRun,
     # the actual CiRun should be considered a deploy (and should dispatch deploy hooks upon completion).

--- a/sherlock/db/migrations/000054_add_helmfile_ref_enabled.down.sql
+++ b/sherlock/db/migrations/000054_add_helmfile_ref_enabled.down.sql
@@ -1,0 +1,2 @@
+alter table v2_chart_releases
+    drop column if exists helmfile_ref_enabled;

--- a/sherlock/db/migrations/000054_add_helmfile_ref_enabled.down.sql
+++ b/sherlock/db/migrations/000054_add_helmfile_ref_enabled.down.sql
@@ -1,2 +1,7 @@
 alter table v2_chart_releases
     drop column if exists helmfile_ref_enabled;
+
+
+alter table v2_changesets
+    drop column if exists from_helmfile_ref_enabled,
+    drop column if exists to_helmfile_ref_enabled;

--- a/sherlock/db/migrations/000054_add_helmfile_ref_enabled.up.sql
+++ b/sherlock/db/migrations/000054_add_helmfile_ref_enabled.up.sql
@@ -1,0 +1,2 @@
+alter table v2_ci_runs
+    add if not exists helmfile_ref_enabled boolean default false;

--- a/sherlock/db/migrations/000054_add_helmfile_ref_enabled.up.sql
+++ b/sherlock/db/migrations/000054_add_helmfile_ref_enabled.up.sql
@@ -1,2 +1,2 @@
-alter table v2_ci_runs
+alter table v2_chart_releases
     add if not exists helmfile_ref_enabled boolean default false;

--- a/sherlock/db/migrations/000054_add_helmfile_ref_enabled.up.sql
+++ b/sherlock/db/migrations/000054_add_helmfile_ref_enabled.up.sql
@@ -1,2 +1,6 @@
 alter table v2_chart_releases
-    add if not exists helmfile_ref_enabled boolean default false;
+    add if not exists helmfile_ref_enabled boolean not null default false;
+
+alter table v2_changesets
+    add column if not exists from_helmfile_ref_enabled boolean,
+    add column if not exists to_helmfile_ref_enabled boolean;

--- a/sherlock/internal/api/sherlock/ci_identifiers_v3_get_test.go
+++ b/sherlock/internal/api/sherlock/ci_identifiers_v3_get_test.go
@@ -189,6 +189,7 @@ func (s *handlerSuite) TestCiIdentifiersV3Get() {
 			ChartVersionResolver: testutils.PointerTo("exact"),
 			ChartVersionExact:    testutils.PointerTo("chart version blah"),
 			HelmfileRef:          testutils.PointerTo("HEAD"),
+			HelmfileRefEnabled:   testutils.PointerTo(false),
 			FirecloudDevelopRef:  testutils.PointerTo("dev"),
 		},
 	}, user)

--- a/sherlock/internal/api/sherlock/ci_runs_v3_upsert_test.go
+++ b/sherlock/internal/api/sherlock/ci_runs_v3_upsert_test.go
@@ -180,6 +180,7 @@ func (s *handlerSuite) TestCiRunsV3UpsertIdentifiers() {
 			ChartVersionResolver: testutils.PointerTo("exact"),
 			ChartVersionExact:    testutils.PointerTo("chart version blah"),
 			HelmfileRef:          testutils.PointerTo("HEAD"),
+			HelmfileRefEnabled:   testutils.PointerTo(false),
 			FirecloudDevelopRef:  testutils.PointerTo("dev"),
 		},
 	}, user)
@@ -197,6 +198,7 @@ func (s *handlerSuite) TestCiRunsV3UpsertIdentifiers() {
 			ChartVersionResolver: testutils.PointerTo("exact"),
 			ChartVersionExact:    testutils.PointerTo("chart version blah"),
 			HelmfileRef:          testutils.PointerTo("HEAD"),
+			HelmfileRefEnabled:   testutils.PointerTo(false),
 			FirecloudDevelopRef:  testutils.PointerTo("dev"),
 		},
 	}, user)
@@ -683,6 +685,7 @@ func (s *handlerSuite) TestCiRunsV3Upsert_slackNotifications() {
 				ChartVersionResolver: testutils.PointerTo("exact"),
 				ChartVersionExact:    testutils.PointerTo("chart version blah"),
 				HelmfileRef:          testutils.PointerTo("HEAD"),
+				HelmfileRefEnabled:   testutils.PointerTo(false),
 				FirecloudDevelopRef:  testutils.PointerTo("dev"),
 			},
 		}, user)
@@ -770,6 +773,7 @@ func (s *handlerSuite) TestCiRunsV3Upsert_makeSlackMessageTExt() {
 			ChartVersionResolver: testutils.PointerTo("exact"),
 			ChartVersionExact:    testutils.PointerTo("chart version blah"),
 			HelmfileRef:          testutils.PointerTo("HEAD"),
+			HelmfileRefEnabled:   testutils.PointerTo(false),
 			FirecloudDevelopRef:  testutils.PointerTo("dev"),
 		},
 	}, user)

--- a/sherlock/internal/api/sherlock/deploy_hook_trigger_configs_v3_test.go
+++ b/sherlock/internal/api/sherlock/deploy_hook_trigger_configs_v3_test.go
@@ -125,6 +125,7 @@ func (s *handlerSuite) Test_deployHookTriggerConfigV3_toModel_chartReleaseValid(
 			ChartVersionResolver: testutils.PointerTo("exact"),
 			ChartVersionExact:    testutils.PointerTo("chart version blah"),
 			HelmfileRef:          testutils.PointerTo("HEAD"),
+			HelmfileRefEnabled:   testutils.PointerTo(false),
 			FirecloudDevelopRef:  testutils.PointerTo("dev"),
 		},
 	}, user)

--- a/sherlock/internal/deployhooks/dispatch_ci_run_test.go
+++ b/sherlock/internal/deployhooks/dispatch_ci_run_test.go
@@ -78,6 +78,7 @@ func (s *deployHooksSuite) Test_dispatchCiRun() {
 		DestinationType: "environment",
 		ChartReleaseVersion: models.ChartReleaseVersion{
 			HelmfileRef:          testutils.PointerTo("HEAD"),
+			HelmfileRefEnabled:   testutils.PointerTo(false),
 			AppVersionResolver:   testutils.PointerTo("exact"),
 			AppVersionExact:      testutils.PointerTo("v1.2.3"),
 			ChartVersionResolver: testutils.PointerTo("exact"),

--- a/sherlock/internal/deployhooks/dispatch_github_actions_deploy_hook_test.go
+++ b/sherlock/internal/deployhooks/dispatch_github_actions_deploy_hook_test.go
@@ -148,6 +148,7 @@ func (s *deployHooksSuite) Test_dispatchGithubActionsDeployHook_appVersionRefFro
 		DestinationType: "environment",
 		ChartReleaseVersion: models.ChartReleaseVersion{
 			HelmfileRef:          testutils.PointerTo("HEAD"),
+			HelmfileRefEnabled:   testutils.PointerTo(false),
 			AppVersionResolver:   testutils.PointerTo("exact"),
 			AppVersionExact:      testutils.PointerTo("v1.2.3"),
 			ChartVersionResolver: testutils.PointerTo("exact"),
@@ -161,6 +162,7 @@ func (s *deployHooksSuite) Test_dispatchGithubActionsDeployHook_appVersionRefFro
 		AppliedAt:      testutils.PointerTo(time.Now().Add(-time.Minute)),
 		From: models.ChartReleaseVersion{
 			HelmfileRef:          testutils.PointerTo("HEAD"),
+			HelmfileRefEnabled:   testutils.PointerTo(false),
 			AppVersionResolver:   testutils.PointerTo("exact"),
 			AppVersionExact:      testutils.PointerTo("v1.1.3"),
 			ChartVersionResolver: testutils.PointerTo("exact"),
@@ -168,6 +170,7 @@ func (s *deployHooksSuite) Test_dispatchGithubActionsDeployHook_appVersionRefFro
 		},
 		To: models.ChartReleaseVersion{
 			HelmfileRef:          testutils.PointerTo("HEAD"),
+			HelmfileRefEnabled:   testutils.PointerTo(false),
 			AppVersionResolver:   testutils.PointerTo("exact"),
 			AppVersionExact:      testutils.PointerTo("v1.1.4"),
 			ChartVersionResolver: testutils.PointerTo("exact"),
@@ -180,6 +183,7 @@ func (s *deployHooksSuite) Test_dispatchGithubActionsDeployHook_appVersionRefFro
 		AppliedAt:      testutils.PointerTo(time.Now()),
 		From: models.ChartReleaseVersion{
 			HelmfileRef:          testutils.PointerTo("HEAD"),
+			HelmfileRefEnabled:   testutils.PointerTo(false),
 			AppVersionResolver:   testutils.PointerTo("exact"),
 			AppVersionExact:      testutils.PointerTo("v1.1.4"),
 			ChartVersionResolver: testutils.PointerTo("exact"),
@@ -187,6 +191,7 @@ func (s *deployHooksSuite) Test_dispatchGithubActionsDeployHook_appVersionRefFro
 		},
 		To: models.ChartReleaseVersion{
 			HelmfileRef:          testutils.PointerTo("HEAD"),
+			HelmfileRefEnabled:   testutils.PointerTo(false),
 			AppVersionResolver:   testutils.PointerTo("exact"),
 			AppVersionExact:      testutils.PointerTo("v1.1.5"),
 			ChartVersionResolver: testutils.PointerTo("exact"),
@@ -264,6 +269,7 @@ func (s *deployHooksSuite) Test_dispatchGithubActionsDeployHook_appVersionCommit
 		DestinationType: "environment",
 		ChartReleaseVersion: models.ChartReleaseVersion{
 			HelmfileRef:          testutils.PointerTo("HEAD"),
+			HelmfileRefEnabled:   testutils.PointerTo(false),
 			AppVersionResolver:   testutils.PointerTo("exact"),
 			AppVersionExact:      testutils.PointerTo("v1.2.3"),
 			AppVersionCommit:     testutils.PointerTo("commit a"),
@@ -278,6 +284,7 @@ func (s *deployHooksSuite) Test_dispatchGithubActionsDeployHook_appVersionCommit
 		AppliedAt:      testutils.PointerTo(time.Now().Add(-time.Minute)),
 		From: models.ChartReleaseVersion{
 			HelmfileRef:          testutils.PointerTo("HEAD"),
+			HelmfileRefEnabled:   testutils.PointerTo(false),
 			AppVersionResolver:   testutils.PointerTo("exact"),
 			AppVersionExact:      testutils.PointerTo("v1.1.3"),
 			AppVersionCommit:     testutils.PointerTo("commit b"),
@@ -286,6 +293,7 @@ func (s *deployHooksSuite) Test_dispatchGithubActionsDeployHook_appVersionCommit
 		},
 		To: models.ChartReleaseVersion{
 			HelmfileRef:          testutils.PointerTo("HEAD"),
+			HelmfileRefEnabled:   testutils.PointerTo(false),
 			AppVersionResolver:   testutils.PointerTo("exact"),
 			AppVersionExact:      testutils.PointerTo("v1.1.4"),
 			AppVersionCommit:     testutils.PointerTo("commit c"),
@@ -299,6 +307,7 @@ func (s *deployHooksSuite) Test_dispatchGithubActionsDeployHook_appVersionCommit
 		AppliedAt:      testutils.PointerTo(time.Now()),
 		From: models.ChartReleaseVersion{
 			HelmfileRef:          testutils.PointerTo("HEAD"),
+			HelmfileRefEnabled:   testutils.PointerTo(false),
 			AppVersionResolver:   testutils.PointerTo("exact"),
 			AppVersionExact:      testutils.PointerTo("v1.1.4"),
 			AppVersionCommit:     testutils.PointerTo("commit d"),
@@ -307,6 +316,7 @@ func (s *deployHooksSuite) Test_dispatchGithubActionsDeployHook_appVersionCommit
 		},
 		To: models.ChartReleaseVersion{
 			HelmfileRef:          testutils.PointerTo("HEAD"),
+			HelmfileRefEnabled:   testutils.PointerTo(false),
 			AppVersionResolver:   testutils.PointerTo("exact"),
 			AppVersionExact:      testutils.PointerTo("v1.1.5"),
 			AppVersionCommit:     testutils.PointerTo("commit e"),

--- a/sherlock/internal/deployhooks/dispatch_slack_deploy_hook_test.go
+++ b/sherlock/internal/deployhooks/dispatch_slack_deploy_hook_test.go
@@ -383,6 +383,7 @@ func (s *deployHooksSuite) Test_generateSlackAttachment_environmentChangesets_ch
 		DestinationType: "environment",
 		ChartReleaseVersion: models.ChartReleaseVersion{
 			HelmfileRef:          testutils.PointerTo("HEAD"),
+			HelmfileRefEnabled:   testutils.PointerTo(false),
 			AppVersionResolver:   testutils.PointerTo("exact"),
 			AppVersionExact:      testutils.PointerTo("v1.2.3"),
 			ChartVersionResolver: testutils.PointerTo("exact"),

--- a/sherlock/internal/deprecated_controllers/v2controllers/changeset.go
+++ b/sherlock/internal/deprecated_controllers/v2controllers/changeset.go
@@ -32,6 +32,7 @@ type Changeset struct {
 	FromChartVersionFollowChartRelease string     `json:"fromChartVersionFollowChartRelease,omitempty" form:"fromChartVersionFollowChartRelease"`
 	FromChartVersionReference          string     `json:"fromChartVersionReference,omitempty" form:"fromChartVersionReference"`
 	FromHelmfileRef                    *string    `json:"fromHelmfileRef,omitempty" form:"fromHelmfileRef"`
+	FromHelmfileRefEnabled             *bool      `json:"fromHelmfileRefEnabled,omitempty" form:"fromHelmfileRefEnabled"`
 	FromFirecloudDevelopRef            *string    `json:"fromFirecloudDevelopRef,omitempty" form:"fromFirecloudDevelopRef"`
 
 	ToResolvedAt            *time.Time `json:"toResolvedAt,omitempty" from:"toResolvedAt"  format:"date-time"`
@@ -56,6 +57,7 @@ type CreatableChangeset struct {
 	ToChartVersionExact              *string `json:"toChartVersionExact,omitempty" form:"toChartVersionExact"`
 	ToChartVersionFollowChartRelease string  `json:"toChartVersionFollowChartRelease,omitempty" form:"toChartVersionFollowChartRelease"`
 	ToHelmfileRef                    *string `json:"toHelmfileRef,omitempty" form:"toHelmfileRef"`
+	ToHelmfileRefEnabled             *bool   `json:"toHelmfileRefEnabled,omitempty" form:"toHelmfileRefEnabled"`
 	ToFirecloudDevelopRef            *string `json:"toFirecloudDevelopRef,omitempty" form:"toFirecloudDevelopRef"`
 
 	ChartRelease string `json:"chartRelease" form:"chartRelease"`
@@ -179,6 +181,7 @@ func (c Changeset) toModel(storeSet *v2models.StoreSet) (v2models.Changeset, err
 			ChartVersionFollowChartReleaseID: fromChartVersionFollowChartReleaseID,
 			ChartVersionID:                   fromChartVersionID,
 			HelmfileRef:                      c.FromHelmfileRef,
+			HelmfileRefEnabled:               c.FromHelmfileRefEnabled,
 			FirecloudDevelopRef:              c.FromFirecloudDevelopRef,
 		},
 		To: v2models.ChartReleaseVersion{
@@ -194,6 +197,7 @@ func (c Changeset) toModel(storeSet *v2models.StoreSet) (v2models.Changeset, err
 			ChartVersionFollowChartReleaseID: toChartVersionFollowChartReleaseID,
 			ChartVersionID:                   toChartVersionID,
 			HelmfileRef:                      c.ToHelmfileRef,
+			HelmfileRefEnabled:               c.ToHelmfileRefEnabled,
 			FirecloudDevelopRef:              c.ToFirecloudDevelopRef,
 		},
 		AppliedAt:    c.AppliedAt,
@@ -234,6 +238,7 @@ func (c CreatableChangeset) toReadable(storeSet *v2models.StoreSet) (Changeset, 
 		changeset.FromChartVersionReference = strconv.FormatUint(uint64(*chartRelease.ChartVersionID), 10)
 	}
 	changeset.FromHelmfileRef = chartRelease.HelmfileRef
+	changeset.FromHelmfileRefEnabled = chartRelease.HelmfileRefEnabled
 	changeset.FromFirecloudDevelopRef = chartRelease.FirecloudDevelopRef
 
 	if changeset.ToAppVersionResolver == nil {
@@ -262,6 +267,9 @@ func (c CreatableChangeset) toReadable(storeSet *v2models.StoreSet) (Changeset, 
 	}
 	if changeset.ToHelmfileRef == nil {
 		changeset.ToHelmfileRef = changeset.FromHelmfileRef
+	}
+	if changeset.ToHelmfileRefEnabled == nil {
+		changeset.ToHelmfileRefEnabled = changeset.FromHelmfileRefEnabled
 	}
 	if changeset.ToFirecloudDevelopRef == nil {
 		changeset.ToFirecloudDevelopRef = changeset.FromFirecloudDevelopRef
@@ -405,6 +413,7 @@ func modelChangesetToChangeset(model *v2models.Changeset) *Changeset {
 		FromChartVersionFollowChartRelease: fromChartVersionFollowChartRelease,
 		FromChartVersionReference:          fromChartVersionReference,
 		FromHelmfileRef:                    model.From.HelmfileRef,
+		FromHelmfileRefEnabled:             model.From.HelmfileRefEnabled,
 		FromFirecloudDevelopRef:            model.From.FirecloudDevelopRef,
 		ToResolvedAt:                       model.To.ResolvedAt,
 		ToAppVersionReference:              toAppVersionReference,
@@ -419,6 +428,7 @@ func modelChangesetToChangeset(model *v2models.Changeset) *Changeset {
 			ToChartVersionExact:              model.To.ChartVersionExact,
 			ToChartVersionFollowChartRelease: toChartVersionFollowChartRelease,
 			ToHelmfileRef:                    model.To.HelmfileRef,
+			ToHelmfileRefEnabled:             model.To.HelmfileRefEnabled,
 			ToFirecloudDevelopRef:            model.To.FirecloudDevelopRef,
 			ChartRelease:                     chartReleaseName,
 			EditableChangeset:                EditableChangeset{},

--- a/sherlock/internal/deprecated_controllers/v2controllers/changeset_procedures.go
+++ b/sherlock/internal/deprecated_controllers/v2controllers/changeset_procedures.go
@@ -64,6 +64,7 @@ func (c ChangesetController) changesetPlanRequestToModelChangesets(request Chang
 			fullChangesetRequest.ToChartVersionExact = otherChartRelease.ChartVersionExact
 			if chartReleaseRequestEntry.UseOthersHelmfileRef != nil && *chartReleaseRequestEntry.UseOthersHelmfileRef {
 				fullChangesetRequest.ToHelmfileRef = otherChartRelease.HelmfileRef
+				fullChangesetRequest.ToHelmfileRefEnabled = otherChartRelease.HelmfileRefEnabled
 			}
 			if chartReleaseRequestEntry.UseOthersFirecloudDevelopRef != nil && *chartReleaseRequestEntry.UseOthersFirecloudDevelopRef {
 				fullChangesetRequest.ToFirecloudDevelopRef = otherChartRelease.FirecloudDevelopRef
@@ -167,6 +168,7 @@ func (c ChangesetController) changesetPlanRequestToModelChangesets(request Chang
 				generatedChangeset.ToChartVersionExact = otherChartRelease.ChartVersionExact
 				if environmentRequestEntry.UseOthersHelmfileRef != nil && *environmentRequestEntry.UseOthersHelmfileRef {
 					generatedChangeset.ToHelmfileRef = otherChartRelease.HelmfileRef
+					generatedChangeset.ToHelmfileRefEnabled = otherChartRelease.HelmfileRefEnabled
 				}
 				if environmentRequestEntry.UseOthersFirecloudDevelopRef != nil && *environmentRequestEntry.UseOthersFirecloudDevelopRef {
 					generatedChangeset.ToFirecloudDevelopRef = otherChartRelease.FirecloudDevelopRef

--- a/sherlock/internal/deprecated_controllers/v2controllers/changeset_test.go
+++ b/sherlock/internal/deprecated_controllers/v2controllers/changeset_test.go
@@ -350,7 +350,7 @@ func (suite *changesetControllerSuite) TestChangesetFlow() {
 	// If we set a helmfile ref, that won't get copied unless we explicitly ask for it
 	_, err = suite.ChangesetController.PlanAndApply(ChangesetPlanRequest{
 		ChartReleases: []ChangesetPlanRequestChartReleaseEntry{
-			{CreatableChangeset: CreatableChangeset{ChartRelease: "terra-dev/sam", ToHelmfileRef: testutils.PointerTo("a-branch")}},
+			{CreatableChangeset: CreatableChangeset{ChartRelease: "terra-dev/sam", ToHelmfileRef: testutils.PointerTo("a-branch"), ToHelmfileRefEnabled: testutils.PointerTo(true)}},
 		},
 	}, generateUser(suite.T(), suite.db, true))
 	assert.NoError(suite.T(), err)
@@ -385,6 +385,7 @@ func (suite *changesetControllerSuite) TestChangesetFlow() {
 	samInProd, err = suite.ChartReleaseController.Get("terra-prod/sam")
 	assert.NoError(suite.T(), err)
 	assert.Equal(suite.T(), "a-branch", *samInProd.HelmfileRef)
+	assert.True(suite.T(), *samInProd.HelmfileRefEnabled)
 
 	// Plans can't get created if there's chart mismatches:
 	_, err = suite.ChangesetController.Plan(ChangesetPlanRequest{

--- a/sherlock/internal/deprecated_controllers/v2controllers/chart_release.go
+++ b/sherlock/internal/deprecated_controllers/v2controllers/chart_release.go
@@ -41,7 +41,7 @@ type CreatableChartRelease struct {
 	ChartVersionExact              *string `json:"chartVersionExact" form:"chartVersionExact"`
 	ChartVersionFollowChartRelease string  `json:"chartVersionFollowChartRelease" form:"chartVersionFollowChartRelease"`
 	HelmfileRef                    *string `json:"helmfileRef" form:"helmfileRef" default:"HEAD"`
-	HelmfileRefEnabled             *bool   `json:"helmfileRefEnabled" form:"helmfileRefEnabled"` // When creating, will default to false
+	HelmfileRefEnabled             *bool   `json:"helmfileRefEnabled" form:"helmfileRefEnabled"`
 	FirecloudDevelopRef            *string `json:"firecloudDevelopRef" form:"firecloudDevelopRef"`
 	EditableChartRelease
 }

--- a/sherlock/internal/deprecated_controllers/v2controllers/chart_release.go
+++ b/sherlock/internal/deprecated_controllers/v2controllers/chart_release.go
@@ -41,6 +41,7 @@ type CreatableChartRelease struct {
 	ChartVersionExact              *string `json:"chartVersionExact" form:"chartVersionExact"`
 	ChartVersionFollowChartRelease string  `json:"chartVersionFollowChartRelease" form:"chartVersionFollowChartRelease"`
 	HelmfileRef                    *string `json:"helmfileRef" form:"helmfileRef" default:"HEAD"`
+	HelmfileRefEnabled             *bool   `json:"helmfileRefEnabled" form:"helmfileRefEnabled"` // When creating, will default to false
 	FirecloudDevelopRef            *string `json:"firecloudDevelopRef" form:"firecloudDevelopRef"`
 	EditableChartRelease
 }
@@ -143,6 +144,7 @@ func (c ChartRelease) toModel(storeSet *v2models.StoreSet) (v2models.ChartReleas
 			ChartVersionFollowChartReleaseID: chartVersionFollowChartReleaseID,
 			ChartVersionID:                   chartVersionID,
 			HelmfileRef:                      c.HelmfileRef,
+			HelmfileRefEnabled:               c.HelmfileRefEnabled,
 			FirecloudDevelopRef:              c.FirecloudDevelopRef,
 		},
 		Subdomain:               c.Subdomain,

--- a/sherlock/internal/deprecated_controllers/v2controllers/chart_release.go
+++ b/sherlock/internal/deprecated_controllers/v2controllers/chart_release.go
@@ -270,6 +270,7 @@ func modelChartReleaseToChartRelease(model *v2models.ChartRelease) *ChartRelease
 			ChartVersionExact:              model.ChartVersionExact,
 			ChartVersionFollowChartRelease: chartVersionFollowChartRelease,
 			HelmfileRef:                    model.HelmfileRef,
+			HelmfileRefEnabled:             model.HelmfileRefEnabled,
 			FirecloudDevelopRef:            model.FirecloudDevelopRef,
 			EditableChartRelease: EditableChartRelease{
 				Subdomain:               model.Subdomain,
@@ -362,6 +363,12 @@ func setChartReleaseDynamicDefaults(chartRelease *CreatableChartRelease, stores 
 			}
 		}
 	}
+
+	if chartRelease.HelmfileRefEnabled == nil {
+		var f bool
+		chartRelease.HelmfileRefEnabled = &f
+	}
+
 	return nil
 }
 

--- a/sherlock/internal/deprecated_controllers/v2controllers/chart_release.go
+++ b/sherlock/internal/deprecated_controllers/v2controllers/chart_release.go
@@ -41,7 +41,7 @@ type CreatableChartRelease struct {
 	ChartVersionExact              *string `json:"chartVersionExact" form:"chartVersionExact"`
 	ChartVersionFollowChartRelease string  `json:"chartVersionFollowChartRelease" form:"chartVersionFollowChartRelease"`
 	HelmfileRef                    *string `json:"helmfileRef" form:"helmfileRef" default:"HEAD"`
-	HelmfileRefEnabled             *bool   `json:"helmfileRefEnabled" form:"helmfileRefEnabled"`
+	HelmfileRefEnabled             *bool   `json:"helmfileRefEnabled" form:"helmfileRefEnabled" default:"false"`
 	FirecloudDevelopRef            *string `json:"firecloudDevelopRef" form:"firecloudDevelopRef"`
 	EditableChartRelease
 }
@@ -362,11 +362,6 @@ func setChartReleaseDynamicDefaults(chartRelease *CreatableChartRelease, stores 
 				chartRelease.Name = fmt.Sprintf("%s-%s-%s", chart.Name, chartRelease.Namespace, cluster.Name)
 			}
 		}
-	}
-
-	if chartRelease.HelmfileRefEnabled == nil {
-		var f bool
-		chartRelease.HelmfileRefEnabled = &f
 	}
 
 	return nil

--- a/sherlock/internal/deprecated_models/v2models/chart_release_version.go
+++ b/sherlock/internal/deprecated_models/v2models/chart_release_version.go
@@ -3,19 +3,12 @@ package v2models
 import (
 	"fmt"
 	"github.com/broadinstitute/sherlock/go-shared/pkg/utils"
+	"github.com/broadinstitute/sherlock/sherlock/internal/config"
 	"time"
 
 	"github.com/broadinstitute/sherlock/sherlock/internal/errors"
 	"gorm.io/gorm"
 )
-
-// helmfileRefDefaultToChartReleaseTags
-//
-//	if true: set helmfile ref to chart release tag ("charts/sam-1.2.3") when promoting a chart release
-//	if false: set helmfile ref to "HEAD" when promoting a chart release
-//
-// this flag is temporary and will be removed when it is defaulted to true
-const helmfileRefDefaultToChartReleaseTags = false
 
 // ChartReleaseVersion isn't stored in the database on its own, it is included as a part of a ChartRelease or
 // Changeset. It has especially strict validation that requires it being fully loaded from the database. The resolve
@@ -175,7 +168,7 @@ func (chartReleaseVersion *ChartReleaseVersion) resolve(db *gorm.DB, chartQuery 
 		}
 	}
 	if chartReleaseVersion.HelmfileRefEnabled == nil || !*chartReleaseVersion.HelmfileRefEnabled || chartReleaseVersion.HelmfileRef == nil {
-		if helmfileRefDefaultToChartReleaseTags && chartReleaseVersion.ChartVersion != nil {
+		if config.Config.Bool("model.changesets.helmfileRefDefaultToChartReleaseTags") && chartReleaseVersion.ChartVersion != nil {
 			// eg. "charts/sam-0.102.0"
 			tag := "charts/" + chart.Name + "-" + chartReleaseVersion.ChartVersion.ChartVersion
 			chartReleaseVersion.HelmfileRef = &tag

--- a/sherlock/internal/deprecated_models/v2models/chart_release_version.go
+++ b/sherlock/internal/deprecated_models/v2models/chart_release_version.go
@@ -32,6 +32,7 @@ type ChartReleaseVersion struct {
 	ChartVersionID                   *uint
 
 	HelmfileRef         *string
+	HelmfileRefEnabled  *bool
 	FirecloudDevelopRef *string
 }
 
@@ -270,8 +271,10 @@ func (chartReleaseVersion *ChartReleaseVersion) validate() error {
 		}
 	}
 
-	if chartReleaseVersion.HelmfileRef == nil || *chartReleaseVersion.HelmfileRef == "" {
-		return fmt.Errorf("a %T must have a terra-helmfile git reference", chartReleaseVersion)
+	if chartReleaseVersion.HelmfileRefEnabled != nil && *chartReleaseVersion.HelmfileRefEnabled {
+		if chartReleaseVersion.HelmfileRef == nil || *chartReleaseVersion.HelmfileRef == "" {
+			return fmt.Errorf("a %T must have a terra-helmfile git reference if enabled", chartReleaseVersion)
+		}
 	}
 
 	return nil
@@ -311,6 +314,9 @@ func (chartReleaseVersion *ChartReleaseVersion) equalTo(other ChartReleaseVersio
 		((chartReleaseVersion.HelmfileRef == nil && other.HelmfileRef == nil) ||
 			(chartReleaseVersion.HelmfileRef != nil && other.HelmfileRef != nil &&
 				*chartReleaseVersion.HelmfileRef == *other.HelmfileRef)) &&
+		((chartReleaseVersion.HelmfileRefEnabled == nil && other.HelmfileRefEnabled == nil) ||
+			(chartReleaseVersion.HelmfileRefEnabled != nil && other.HelmfileRefEnabled != nil &&
+				*chartReleaseVersion.HelmfileRefEnabled == *other.HelmfileRefEnabled)) &&
 		((chartReleaseVersion.FirecloudDevelopRef == nil && other.FirecloudDevelopRef == nil) ||
 			(chartReleaseVersion.FirecloudDevelopRef != nil && other.FirecloudDevelopRef != nil &&
 				*chartReleaseVersion.FirecloudDevelopRef == *other.FirecloudDevelopRef))

--- a/sherlock/internal/deprecated_models/v2models/chart_release_version_test.go
+++ b/sherlock/internal/deprecated_models/v2models/chart_release_version_test.go
@@ -1281,7 +1281,35 @@ func TestChartReleaseVersion_validate(t *testing.T) {
 			},
 		},
 		{
-			name:    "chartReleaseVersionInvalidNoHelmfileRef",
+			name:    "chartReleaseVersionValidNoHelmfileRef",
+			wantErr: false,
+			obj: ChartReleaseVersion{
+				ResolvedAt: testutils.PointerTo(time.Now()),
+
+				AppVersionResolver: testutils.PointerTo("branch"),
+				AppVersionExact:    testutils.PointerTo("v1.2.3"),
+				AppVersionCommit:   testutils.PointerTo("a1b2c3d4"),
+				AppVersionBranch:   testutils.PointerTo("main"),
+				AppVersion: &AppVersion{
+					Model:      gorm.Model{ID: 1},
+					AppVersion: "v1.2.3",
+					GitCommit:  "a1b2c3d4",
+					GitBranch:  "main",
+				},
+				AppVersionID: testutils.PointerTo[uint](1),
+
+				ChartVersionResolver: testutils.PointerTo("latest"),
+				ChartVersionExact:    testutils.PointerTo("v0.0.100"),
+				ChartVersion: &ChartVersion{
+					Model:        gorm.Model{ID: 2},
+					ChartVersion: "v0.0.100",
+				},
+				ChartVersionID:      testutils.PointerTo[uint](2),
+				FirecloudDevelopRef: testutils.PointerTo("dev"),
+			},
+		},
+		{
+			name:    "chartReleaseVersionInvalidHelmfileRefEnabledNoHelmfileRef",
 			wantErr: true,
 			obj: ChartReleaseVersion{
 				ResolvedAt: testutils.PointerTo(time.Now()),
@@ -1306,6 +1334,7 @@ func TestChartReleaseVersion_validate(t *testing.T) {
 				},
 				ChartVersionID:      testutils.PointerTo[uint](2),
 				FirecloudDevelopRef: testutils.PointerTo("dev"),
+				HelmfileRefEnabled:  testutils.PointerTo(true),
 			},
 		},
 	}

--- a/sherlock/internal/deprecated_models/v2models/environment.go
+++ b/sherlock/internal/deprecated_models/v2models/environment.go
@@ -416,6 +416,7 @@ func postCreateEnvironment(db *gorm.DB, environment *Environment, user *models.U
 				latestString := "latest"
 				headString := "HEAD"
 				trueBoolean := true
+				falseBoolean := false
 				for index, chartEntry := range autoPopulateCharts {
 					if chartEntry.String("name") != "" {
 						chart, err := InternalChartStore.Get(db, Chart{Name: chartEntry.String("name")})
@@ -434,6 +435,7 @@ func postCreateEnvironment(db *gorm.DB, environment *Environment, user *models.U
 									AppVersionResolver:   &noneString,
 									ChartVersionResolver: &latestString,
 									HelmfileRef:          &headString,
+									HelmfileRefEnabled:   &falseBoolean,
 								},
 								Subdomain:               chart.DefaultSubdomain,
 								Protocol:                chart.DefaultProtocol,

--- a/sherlock/internal/models/chart_release_version.go
+++ b/sherlock/internal/models/chart_release_version.go
@@ -25,5 +25,6 @@ type ChartReleaseVersion struct {
 	ChartVersionID                   *uint
 
 	HelmfileRef         *string
+	HelmfileRefEnabled  *bool
 	FirecloudDevelopRef *string
 }

--- a/sherlock/internal/models/deploy_hook_trigger_config_test.go
+++ b/sherlock/internal/models/deploy_hook_trigger_config_test.go
@@ -28,7 +28,7 @@ func (s *modelSuite) TestDeployHookTriggerConfigEnvironmentAndChartRelease() {
 	s.NoError(s.DB.Create(&chart).Error)
 	chartRelease := ChartRelease{Name: "leonardo-dev", ChartID: chart.ID, EnvironmentID: &environment.ID, ClusterID: &cluster.ID, Namespace: "terra-dev",
 		ChartReleaseVersion: ChartReleaseVersion{AppVersionResolver: testutils.PointerTo("exact"), AppVersionExact: testutils.PointerTo("v1.2.3"),
-			ChartVersionResolver: testutils.PointerTo("exact"), ChartVersionExact: testutils.PointerTo("v2.3.4"), HelmfileRef: testutils.PointerTo("HEAD")}}
+			ChartVersionResolver: testutils.PointerTo("exact"), ChartVersionExact: testutils.PointerTo("v2.3.4"), HelmfileRef: testutils.PointerTo("HEAD"), HelmfileRefEnabled: testutils.PointerTo(false)}}
 	s.NoError(s.DB.Create(&chartRelease).Error)
 
 	config := DeployHookTriggerConfig{OnEnvironmentID: &environment.ID, OnChartReleaseID: &chartRelease.ID}
@@ -58,7 +58,7 @@ func (s *modelSuite) TestDeployHookTriggerConfigChartReleaseSuitableViaEnvironme
 	s.NoError(s.DB.Create(&chart).Error)
 	chartRelease := ChartRelease{Name: "leonardo-dev", ChartID: chart.ID, EnvironmentID: &environment.ID, ClusterID: &cluster.ID, Namespace: "terra-dev",
 		ChartReleaseVersion: ChartReleaseVersion{AppVersionResolver: testutils.PointerTo("exact"), AppVersionExact: testutils.PointerTo("v1.2.3"),
-			ChartVersionResolver: testutils.PointerTo("exact"), ChartVersionExact: testutils.PointerTo("v2.3.4"), HelmfileRef: testutils.PointerTo("HEAD")}}
+			ChartVersionResolver: testutils.PointerTo("exact"), ChartVersionExact: testutils.PointerTo("v2.3.4"), HelmfileRef: testutils.PointerTo("HEAD"), HelmfileRefEnabled: testutils.PointerTo(false)}}
 	s.NoError(s.DB.Create(&chartRelease).Error)
 
 	s.Run("when suitable", func() {
@@ -80,7 +80,7 @@ func (s *modelSuite) TestDeployHookTriggerConfigChartReleaseSuitableViaCluster()
 	s.NoError(s.DB.Create(&chart).Error)
 	chartRelease := ChartRelease{Name: "leonardo-dev", ChartID: chart.ID, EnvironmentID: &environment.ID, ClusterID: &cluster.ID, Namespace: "terra-dev",
 		ChartReleaseVersion: ChartReleaseVersion{AppVersionResolver: testutils.PointerTo("exact"), AppVersionExact: testutils.PointerTo("v1.2.3"),
-			ChartVersionResolver: testutils.PointerTo("exact"), ChartVersionExact: testutils.PointerTo("v2.3.4"), HelmfileRef: testutils.PointerTo("HEAD")}}
+			ChartVersionResolver: testutils.PointerTo("exact"), ChartVersionExact: testutils.PointerTo("v2.3.4"), HelmfileRef: testutils.PointerTo("HEAD"), HelmfileRefEnabled: testutils.PointerTo(false)}}
 	s.NoError(s.DB.Create(&chartRelease).Error)
 
 	s.Run("when suitable", func() {

--- a/sherlock/internal/models/github_actions_deploy_hook_test.go
+++ b/sherlock/internal/models/github_actions_deploy_hook_test.go
@@ -32,7 +32,7 @@ func (s *modelSuite) TestGithubActionsDeployHookChartRelease() {
 	s.NoError(s.DB.Create(&chart).Error)
 	chartRelease := ChartRelease{Name: "leonardo-dev", ChartID: chart.ID, EnvironmentID: &environment.ID, ClusterID: &cluster.ID, Namespace: "terra-dev",
 		ChartReleaseVersion: ChartReleaseVersion{AppVersionResolver: testutils.PointerTo("exact"), AppVersionExact: testutils.PointerTo("v1.2.3"),
-			ChartVersionResolver: testutils.PointerTo("exact"), ChartVersionExact: testutils.PointerTo("v2.3.4"), HelmfileRef: testutils.PointerTo("HEAD")}}
+			ChartVersionResolver: testutils.PointerTo("exact"), ChartVersionExact: testutils.PointerTo("v2.3.4"), HelmfileRef: testutils.PointerTo("HEAD"), HelmfileRefEnabled: testutils.PointerTo(false)}}
 	s.NoError(s.DB.Create(&chartRelease).Error)
 
 	hook := GithubActionsDeployHook{

--- a/sherlock/internal/models/slack_deploy_hook_test.go
+++ b/sherlock/internal/models/slack_deploy_hook_test.go
@@ -27,7 +27,7 @@ func (s *modelSuite) TestSlackDeployHookChartRelease() {
 	s.NoError(s.DB.Create(&chart).Error)
 	chartRelease := ChartRelease{Name: "leonardo-dev", ChartID: chart.ID, EnvironmentID: &environment.ID, ClusterID: &cluster.ID, Namespace: "terra-dev",
 		ChartReleaseVersion: ChartReleaseVersion{AppVersionResolver: testutils.PointerTo("exact"), AppVersionExact: testutils.PointerTo("v1.2.3"),
-			ChartVersionResolver: testutils.PointerTo("exact"), ChartVersionExact: testutils.PointerTo("v2.3.4"), HelmfileRef: testutils.PointerTo("HEAD")}}
+			ChartVersionResolver: testutils.PointerTo("exact"), ChartVersionExact: testutils.PointerTo("v2.3.4"), HelmfileRef: testutils.PointerTo("HEAD"), HelmfileRefEnabled: testutils.PointerTo(false)}}
 	s.NoError(s.DB.Create(&chartRelease).Error)
 
 	hook := SlackDeployHook{SlackChannel: testutils.PointerTo("channel"),


### PR DESCRIPTION
This PR adds a new boolean field, `HelmfileRefEnabled`, to ChartRelease, that defaults to false. It quacks like `HelmfileRef`. In other words, whenever or wherever `HelmfileRef` is copied or promoted from one chart release to another, the `HelmfileRefEnabled` field is as well.

This PR also updates Sherlock's Changeset logic so that when a new Changeset is planned, if `HelmfileRefEnabled` is:
* `true`: `HelmfileRef` will not be touched, because someone intentionally set the chart release to a custom ref
* `false`: `HelmfileRef` will be set to `HEAD`

This PR also adds a new config flag, `model.changesets.helmfileRefDefaultToChartReleaseTags`, currently set to `false`. When flipped, to true, the promotion described above will set `HelmfileRef` to `charts/<name>-<version>` instead of `HEAD`.

### Related

* https://github.com/broadinstitute/beehive/pull/327

### Testing

This PR includes updates to Sherlock's unit tests.

I also manually verified the following locally:
* Creating a chart release without setting `HelmfileRefEnabled` explicitly defaults to false
* Creating an environment from a template propagates the chart release `HelmfileRefEnabled` field as expected
* Plan-and-applying a changeset using exact versions from another chart release propagates the `HelmfileRefEnabled` field *if and only if* the `useOthersHelmfileRef` parameter is true
* `HelmfileRefEnabled `cannot be modified by PATCHing a chart release, only via a ChangeSet operation

### Props

I really appreciate all of Sherlock's test coverage, it saved me several times while making these changes!