### PR TITLE
[DDO-3161] Enable chart release tag promotion

### DIFF
--- a/sherlock/config/default_config.yaml
+++ b/sherlock/config/default_config.yaml
@@ -176,13 +176,6 @@ model:
       # Uses appVersionResolver = "none", chartVersionResolver = "latest", and helmfileRef = "HEAD"
       autoPopulateCharts:
         - name: honeycomb
-  changesets:
-    #
-    # if true: set helmfile ref to chart release tag ("charts/sam-1.2.3") when promoting a chart release
-    # if false: set helmfile ref to "HEAD" when promoting a chart release
-    #
-    # this flag is temporary and should be removed when it is defaulted to true
-    helmfileRefDefaultToChartReleaseTags: false
   ciRuns:
     # A list of partial CiRuns where if any has a match on all non-zero fields with an actual CiRun,
     # the actual CiRun should be considered a deploy (and should dispatch deploy hooks upon completion).

--- a/sherlock/internal/deprecated_controllers/v2controllers/changeset_test.go
+++ b/sherlock/internal/deprecated_controllers/v2controllers/changeset_test.go
@@ -365,7 +365,7 @@ func (suite *changesetControllerSuite) TestChangesetFlow() {
 	assert.NoError(suite.T(), err)
 	samInProd, err = suite.ChartReleaseController.Get("terra-prod/sam")
 	assert.NoError(suite.T(), err)
-	assert.Equal(suite.T(), "HEAD", *samInProd.HelmfileRef)
+	assert.Equal(suite.T(), "charts/sam-0.0.3", *samInProd.HelmfileRef)
 	_, err = suite.ChangesetController.PlanAndApply(ChangesetPlanRequest{
 		ChartReleases: []ChangesetPlanRequestChartReleaseEntry{
 			{CreatableChangeset: CreatableChangeset{ChartRelease: "terra-dev/sam", ToHelmfileRef: utils.PointerTo("a-branch")}},

--- a/sherlock/internal/deprecated_models/v2models/chart_release_version.go
+++ b/sherlock/internal/deprecated_models/v2models/chart_release_version.go
@@ -168,7 +168,7 @@ func (chartReleaseVersion *ChartReleaseVersion) resolve(db *gorm.DB, chartQuery 
 		}
 	}
 	if chartReleaseVersion.HelmfileRefEnabled == nil || !*chartReleaseVersion.HelmfileRefEnabled || chartReleaseVersion.HelmfileRef == nil {
-		if config.Config.Bool("model.changesets.helmfileRefDefaultToChartReleaseTags") && chartReleaseVersion.ChartVersion != nil {
+		if chartReleaseVersion.ChartVersion != nil {
 			// eg. "charts/sam-0.102.0"
 			tag := "charts/" + chart.Name + "-" + chartReleaseVersion.ChartVersion.ChartVersion
 			chartReleaseVersion.HelmfileRef = &tag

--- a/sherlock/internal/deprecated_models/v2models/chart_release_version.go
+++ b/sherlock/internal/deprecated_models/v2models/chart_release_version.go
@@ -3,7 +3,6 @@ package v2models
 import (
 	"fmt"
 	"github.com/broadinstitute/sherlock/go-shared/pkg/utils"
-	"github.com/broadinstitute/sherlock/sherlock/internal/config"
 	"time"
 
 	"github.com/broadinstitute/sherlock/sherlock/internal/errors"


### PR DESCRIPTION
Enable the chart release tag promotion feature, which was introduced in https://github.com/broadinstitute/sherlock/pull/295

The linter failures seem to be known and happening on mainline.