### PR TITLE
[DDO-3194] Also trigger deploy hooks when sync-environment is run

### DIFF
--- a/sherlock/config/default_config.yaml
+++ b/sherlock/config/default_config.yaml
@@ -185,6 +185,10 @@ model:
         githubActionsOwner: broadinstitute
         githubActionsRepo: terra-github-workflows
         githubActionsWorkflowPath: .github/workflows/sync-release.yaml
+      - platform: github-actions
+        githubActionsOwner: broadinstitute
+        githubActionsRepo: terra-github-workflows
+        githubActionsWorkflowPath: .github/workflows/sync-environment.yaml
 
 beehive:
     chartReleaseUrlFormatString: https://beehive.dsp-devops.broadinstitute.org/r/chart-release/%s


### PR DESCRIPTION
Per [Jack Warren's suggestion](https://broadinstitute.slack.com/archives/CQ6SL4N5T/p1696359038252119?thread_ts=1695817323.661329&cid=CQ6SL4N5T), update Sherlock to also trigger deploy hooks when sync-environment is run.