### PR TITLE
[DDO-3175] Sort chart release names in Slack message

### DIFF
--- a/sherlock/internal/deployhooks/dispatch_slack_deploy_hook.go
+++ b/sherlock/internal/deployhooks/dispatch_slack_deploy_hook.go
@@ -7,6 +7,7 @@ import (
 	"github.com/broadinstitute/sherlock/sherlock/internal/models"
 	"github.com/broadinstitute/sherlock/sherlock/internal/slack"
 	"gorm.io/gorm"
+	"sort"
 	"strings"
 )
 
@@ -44,6 +45,7 @@ func generateSlackAttachment(db *gorm.DB, hook models.SlackDeployHook, ciRun mod
 		}
 
 		if len(chartReleaseNames) > 0 {
+			sort.Strings(chartReleaseNames)
 			sb.WriteString(" (")
 			sb.WriteString(strings.Join(utils.Map(chartReleaseNames, func(name string) string {
 				return slack.LinkHelper(


### PR DESCRIPTION
It isn't everything that Gary asked for -- I think he wants some sort of structured table in the Slack message? -- but this is what's actually feasible at the moment. Function from https://pkg.go.dev/sort#Strings

## Testing

It's, uh, not, because I'm just calling a standard library function to sort a list. I believe we'll rework this before long so I'm not going to go out of my way to make a big test here. Can't be worse than the unsorted it currently is.

## Risk

Very low.