### PR TITLE
[DDO-3204] Changelog capability for v3 app versions

### DIFF
--- a/sherlock/internal/api/sherlock/app_version_procedures_v3_changelog.go
+++ b/sherlock/internal/api/sherlock/app_version_procedures_v3_changelog.go
@@ -1,0 +1,91 @@
+package sherlock
+
+import (
+	"fmt"
+	"github.com/broadinstitute/sherlock/go-shared/pkg/utils"
+	"github.com/broadinstitute/sherlock/sherlock/internal/authentication"
+	"github.com/broadinstitute/sherlock/sherlock/internal/errors"
+	"github.com/broadinstitute/sherlock/sherlock/internal/models"
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm/clause"
+	"net/http"
+)
+
+type AppVersionV3ChangelogResponse struct {
+	Changelog []AppVersionV3 `json:"changelog"`
+	Complete  bool           `json:"complete"`
+}
+
+// appVersionsProceduresV3Changelog godoc
+//
+//	@summary		Get a changelog between two AppVersions
+//	@description	Get the path through parent references from a child AppVersion (inclusive) to a parent AppVersion (exclusive), if possible. Because parent references point from newer children to older parents, the newer AppVersion should be the child. The result will always exclude the parent.
+//	@tags			AppVersions
+//	@produce		json
+//	@param			child					query		string	true	"The selector of the newer AppVersion for the changelog"
+//	@param			parent					query		string	true	"The selector of the older AppVersion for the changelog"
+//	@success		200  					{object}	AppVersionV3ChangelogResponse
+//	@failure		400,403,404,407,409,500	{object}	errors.ErrorResponse
+//	@router			/api/app-versions/procedures/v3/changelog [get]
+func appVersionsProceduresV3Changelog(ctx *gin.Context) {
+	db, err := authentication.MustUseDB(ctx)
+	if err != nil {
+		return
+	}
+
+	var childQuery, parentQuery models.AppVersion
+
+	if childQuery, err = appVersionModelFromSelector(db, canonicalizeSelector(ctx.Query("child"))); err != nil {
+		errors.AbortRequest(ctx, fmt.Errorf("error parsing child: %w", err))
+		return
+	}
+
+	if parentQuery, err = appVersionModelFromSelector(db, canonicalizeSelector(ctx.Query("parent"))); err != nil {
+		errors.AbortRequest(ctx, fmt.Errorf("error parsing parent: %w", err))
+		return
+	}
+
+	var child, parent models.AppVersion
+
+	if err = db.Select("id").Where(&childQuery).First(&child).Error; err != nil {
+		errors.AbortRequest(ctx, fmt.Errorf("error querying child %s: %w", ctx.Query("child"), err))
+		return
+	}
+
+	if err = db.Select("id").Where(&parentQuery).First(&parent).Error; err != nil {
+		errors.AbortRequest(ctx, fmt.Errorf("error querying parent %s: %w", ctx.Query("parent"), err))
+		return
+	}
+
+	var path []uint
+	var foundPath bool
+
+	if path, foundPath, err = models.GetAppVersionPathIDs(db, child.ID, parent.ID); err != nil {
+		errors.AbortRequest(ctx, fmt.Errorf("(%s) error calculating changelog components: %w", errors.InternalServerError, err))
+		return
+	}
+
+	response := AppVersionV3ChangelogResponse{
+		Complete: foundPath,
+	}
+
+	if foundPath {
+		var pathModels []models.AppVersion
+		if len(path) > 0 {
+			if err = db.Preload(clause.Associations).Order("created_at desc").Find(&pathModels, path).Error; err != nil {
+				errors.AbortRequest(ctx, fmt.Errorf("error querying data of calculated changelog components: %w", err))
+				return
+			}
+		}
+		response.Changelog = utils.Map(pathModels, func(m models.AppVersion) AppVersionV3 { return appVersionFromModel(m) })
+	} else {
+		if err = db.Preload(clause.Associations).First(&child, child.ID).Error; err != nil {
+			errors.AbortRequest(ctx, fmt.Errorf("error querying data of child: %w", err))
+			return
+		} else {
+			response.Changelog = []AppVersionV3{appVersionFromModel(child)}
+		}
+	}
+
+	ctx.JSON(http.StatusOK, response)
+}

--- a/sherlock/internal/api/sherlock/app_version_procedures_v3_changelog_test.go
+++ b/sherlock/internal/api/sherlock/app_version_procedures_v3_changelog_test.go
@@ -1,0 +1,123 @@
+package sherlock
+
+import (
+	"github.com/broadinstitute/sherlock/go-shared/pkg/utils"
+	"github.com/broadinstitute/sherlock/sherlock/internal/errors"
+	"github.com/broadinstitute/sherlock/sherlock/internal/models"
+	"net/http"
+)
+
+func (s *handlerSuite) TestAppVersionsProceduresV3Changelog_badChildSelector() {
+	var got errors.ErrorResponse
+	code := s.HandleRequest(
+		s.NewRequest("GET", "/api/app-versions/procedures/v3/changelog?child=&parent=123", nil),
+		&got)
+	s.Equal(http.StatusBadRequest, code)
+	s.Equal(errors.BadRequest, got.Type)
+}
+
+func (s *handlerSuite) TestAppVersionsProceduresV3Changelog_badParentSelector() {
+	var got errors.ErrorResponse
+	code := s.HandleRequest(
+		s.NewRequest("GET", "/api/app-versions/procedures/v3/changelog?child=123&parent=", nil),
+		&got)
+	s.Equal(http.StatusBadRequest, code)
+	s.Equal(errors.BadRequest, got.Type)
+}
+
+func (s *handlerSuite) TestAppVersionsProceduresV3Changelog_childNotFound() {
+	chart := models.Chart{Name: "my-chart", ChartRepo: utils.PointerTo("some-repo")}
+	s.NoError(s.DB.Create(&chart).Error)
+	appVersion := models.AppVersion{ChartID: chart.ID, AppVersion: "1"}
+	s.NoError(s.DB.Create(&appVersion).Error)
+
+	var got errors.ErrorResponse
+	code := s.HandleRequest(
+		s.NewRequest("GET", "/api/app-versions/procedures/v3/changelog?child=123&parent=my-chart%2F1", nil),
+		&got)
+	s.Equal(http.StatusNotFound, code)
+	s.Equal(errors.NotFound, got.Type)
+	s.Contains(got.Message, "123")
+}
+
+func (s *handlerSuite) TestAppVersionsProceduresV3Changelog_parentNotFound() {
+	chart := models.Chart{Name: "my-chart", ChartRepo: utils.PointerTo("some-repo")}
+	s.NoError(s.DB.Create(&chart).Error)
+	appVersion := models.AppVersion{ChartID: chart.ID, AppVersion: "1"}
+	s.NoError(s.DB.Create(&appVersion).Error)
+
+	var got errors.ErrorResponse
+	code := s.HandleRequest(
+		s.NewRequest("GET", "/api/app-versions/procedures/v3/changelog?child=my-chart%2F1&parent=123", nil),
+		&got)
+	s.Equal(http.StatusNotFound, code)
+	s.Equal(errors.NotFound, got.Type)
+	s.Contains(got.Message, "123")
+}
+
+func (s *handlerSuite) TestAppVersionsProceduresV3Changelog_sameChildAndParent() {
+	chart := models.Chart{Name: "my-chart", ChartRepo: utils.PointerTo("some-repo")}
+	s.NoError(s.DB.Create(&chart).Error)
+	appVersion := models.AppVersion{ChartID: chart.ID, AppVersion: "1"}
+	s.NoError(s.DB.Create(&appVersion).Error)
+
+	var got AppVersionV3ChangelogResponse
+	code := s.HandleRequest(
+		s.NewRequest("GET", "/api/app-versions/procedures/v3/changelog?child=my-chart%2F1&parent=my-chart%2F1", nil),
+		&got)
+	s.Equal(http.StatusOK, code)
+	s.True(got.Complete)
+	s.Empty(got.Changelog)
+}
+
+func (s *handlerSuite) TestAppVersionsProceduresV3Changelog_noPathFound() {
+	chart := models.Chart{Name: "my-chart", ChartRepo: utils.PointerTo("some-repo")}
+	s.NoError(s.DB.Create(&chart).Error)
+	appVersion1 := models.AppVersion{ChartID: chart.ID, AppVersion: "1"}
+	s.NoError(s.DB.Create(&appVersion1).Error)
+	appVersion2 := models.AppVersion{ChartID: chart.ID, AppVersion: "2"}
+	s.NoError(s.DB.Create(&appVersion2).Error)
+
+	var got AppVersionV3ChangelogResponse
+	code := s.HandleRequest(
+		s.NewRequest("GET", "/api/app-versions/procedures/v3/changelog?child=my-chart%2F1&parent=my-chart%2F2", nil),
+		&got)
+	s.Equal(http.StatusOK, code)
+	s.False(got.Complete)
+	if s.Len(got.Changelog, 1) {
+		s.Equal(appVersion1.ID, got.Changelog[0].ID)
+	}
+
+	code = s.HandleRequest(
+		s.NewRequest("GET", "/api/app-versions/procedures/v3/changelog?child=my-chart%2F2&parent=my-chart%2F1", nil),
+		&got)
+	s.Equal(http.StatusOK, code)
+	s.False(got.Complete)
+	if s.Len(got.Changelog, 1) {
+		s.Equal(appVersion2.ID, got.Changelog[0].ID)
+	}
+}
+
+func (s *handlerSuite) TestAppVersionsProceduresV3Changelog_findsPath() {
+	chart := models.Chart{Name: "my-chart", ChartRepo: utils.PointerTo("some-repo")}
+	s.NoError(s.DB.Create(&chart).Error)
+	appVersion1 := models.AppVersion{ChartID: chart.ID, AppVersion: "1"}
+	s.NoError(s.DB.Create(&appVersion1).Error)
+	appVersion2 := models.AppVersion{ChartID: chart.ID, AppVersion: "2", ParentAppVersionID: &appVersion1.ID}
+	s.NoError(s.DB.Create(&appVersion2).Error)
+	appVersion3 := models.AppVersion{ChartID: chart.ID, AppVersion: "3", ParentAppVersionID: &appVersion2.ID}
+	s.NoError(s.DB.Create(&appVersion3).Error)
+
+	var got AppVersionV3ChangelogResponse
+	code := s.HandleRequest(
+		s.NewRequest("GET", "/api/app-versions/procedures/v3/changelog?child=my-chart/3&parent=my-chart/1", nil),
+		&got)
+	s.Equal(http.StatusOK, code)
+	s.True(got.Complete)
+	if s.Len(got.Changelog, 2) {
+		// It's possible for these tests to run so fast that the ordering of the output can actually get messed up,
+		// because we order by createdAt
+		s.True((got.Changelog[0].ID == appVersion3.ID && got.Changelog[1].ID == appVersion2.ID) ||
+			(got.Changelog[1].ID == appVersion3.ID && got.Changelog[0].ID == appVersion2.ID))
+	}
+}

--- a/sherlock/internal/api/sherlock/routes.go
+++ b/sherlock/internal/api/sherlock/routes.go
@@ -46,6 +46,7 @@ func ConfigureRoutes(apiRouter *gin.RouterGroup) {
 	apiRouter.GET("app-versions/v3", appVersionsV3List)
 	apiRouter.PATCH("app-versions/v3/*selector", appVersionsV3Edit)
 	apiRouter.PUT("app-versions/v3", appVersionsV3Upsert)
+	apiRouter.GET("app-versions/procedures/v3/changelog", appVersionsProceduresV3Changelog)
 
 	apiRouter.GET("charts/v3/*selector", chartsV3Get)
 	apiRouter.POST("charts/v3", chartsV3Create)

--- a/sherlock/internal/models/app_version.go
+++ b/sherlock/internal/models/app_version.go
@@ -1,6 +1,9 @@
 package models
 
-import "gorm.io/gorm"
+import (
+	"github.com/broadinstitute/sherlock/go-shared/pkg/utils"
+	"gorm.io/gorm"
+)
 
 type AppVersion struct {
 	gorm.Model
@@ -24,5 +27,62 @@ func (a AppVersion) GetCiIdentifier() CiIdentifier {
 		return *a.CiIdentifier
 	} else {
 		return CiIdentifier{ResourceType: "app-version", ResourceID: a.ID}
+	}
+}
+
+// GetAppVersionPathIDs iterates from one AppVersion to another, treating each one's parent like a linked list.
+// If a path is found in few enough iterations, it'll be returned according to these rules:
+// - It will always be exclusive of the end AppVersion
+// - It will be inclusive of the start AppVersion when possible
+// - It will be ordered by iteration (the last entry in the path is the one whose parent is the end AppVersion)
+func GetAppVersionPathIDs(db *gorm.DB, inclusiveStartID uint, exclusiveEndID uint) (path []uint, foundPath bool, err error) {
+	if inclusiveStartID == exclusiveEndID {
+		// If the start and end are the same, there's no path to calculate
+		return []uint{}, true, nil
+	}
+
+	type AppVersionPathEntry struct {
+		ID                 uint
+		ParentAppVersionID uint
+	}
+	var appVersionPath []AppVersionPathEntry
+	if err = db.Raw(
+		//language=SQL
+		`
+WITH RECURSIVE search_path(id, parent_app_version_id) AS (
+        -- Initially, get the ID and parent ID where:
+        SELECT v2_app_versions.id, v2_app_versions.parent_app_version_id
+        FROM v2_app_versions
+        WHERE
+            -- The app version is the one we're starting at
+            v2_app_versions.id = ? AND
+            -- The app version has a parent reference, so we don't start looking for a null parent (we'd rather bail with no results)
+            v2_app_versions.parent_app_version_id IS NOT NULL
+    -- UNION, not UNION ALL, so that duplicate rows in search_path are dropped and we automatically avoid cycles
+    UNION
+        -- Recursively, get the ID and parent ID where:
+        SELECT v2_app_versions.id, v2_app_versions.parent_app_version_id
+        FROM v2_app_versions, search_path
+        WHERE
+            -- The app version isn't the end of the path (if it is, bail because we want to stop searching then)
+            v2_app_versions.id != ? AND
+            -- The app version is the parent we're currently looking for
+            v2_app_versions.id = search_path.parent_app_version_id AND
+            -- The app version has a parent reference, so we don't start looking for a null parent (we'd rather bail)
+            v2_app_versions.parent_app_version_id IS NOT NULL
+)
+SELECT * FROM search_path
+          -- Postgres evaluates search_path lazily, so this LIMIT is an extra safeguard against lengthy recursion
+          LIMIT 100
+`, inclusiveStartID, exclusiveEndID).Scan(&appVersionPath).Error; err != nil {
+		// We got an error, bail
+		return []uint{}, false, err
+	} else if len(appVersionPath) > 0 && appVersionPath[len(appVersionPath)-1].ParentAppVersionID == exclusiveEndID {
+		// Path connected, transform to list of IDs and return
+		path = utils.Map(appVersionPath, func(e AppVersionPathEntry) uint { return e.ID })
+		return path, true, nil
+	} else {
+		// Path not connected, return nothing
+		return []uint{}, false, nil
 	}
 }

--- a/sherlock/internal/models/app_version_test.go
+++ b/sherlock/internal/models/app_version_test.go
@@ -60,3 +60,119 @@ func (s *modelSuite) TestAppVersionCiIdentifiers() {
 		s.Equal("app-version", result.CiIdentifier.ResourceType)
 	})
 }
+
+func (s *modelSuite) TestGetAppVersionPathIDs() {
+	/*
+		Here's the layout of the app versions we're creating for this test.
+		A, B, C, D are linear. B and E both point at C. Nothing points at F.
+
+			A ----> B ----> C ----> D
+			              ^
+						/
+			          /
+			        E               F
+
+	*/
+
+	chart := Chart{Name: "name", ChartRepo: utils.PointerTo("repo")}
+	s.NoError(s.DB.Create(&chart).Error)
+
+	f := AppVersion{ChartID: chart.ID, AppVersion: "f"}
+	s.NoError(s.DB.Create(&f).Error)
+	d := AppVersion{ChartID: chart.ID, AppVersion: "d"}
+	s.NoError(s.DB.Create(&d).Error)
+	c := AppVersion{ChartID: chart.ID, AppVersion: "c", ParentAppVersionID: &d.ID}
+	s.NoError(s.DB.Create(&c).Error)
+	e := AppVersion{ChartID: chart.ID, AppVersion: "e", ParentAppVersionID: &c.ID}
+	s.NoError(s.DB.Create(&e).Error)
+	b := AppVersion{ChartID: chart.ID, AppVersion: "b", ParentAppVersionID: &c.ID}
+	s.NoError(s.DB.Create(&b).Error)
+	a := AppVersion{ChartID: chart.ID, AppVersion: "a", ParentAppVersionID: &b.ID}
+	s.NoError(s.DB.Create(&a).Error)
+
+	s.Run("same start/end returns without checking db (normal)", func() {
+		var path []uint
+		var foundPath bool
+		var err error
+		s.NotPanics(func() {
+			path, foundPath, err = GetAppVersionPathIDs(nil, 0, 0)
+		})
+		s.Empty(path)
+		s.True(foundPath)
+		s.NoError(err)
+	})
+
+	s.Run("B to C (normal)", func() {
+		path, foundPath, err := GetAppVersionPathIDs(s.DB, b.ID, c.ID)
+		s.Equal([]uint{b.ID}, path)
+		s.True(foundPath)
+		s.NoError(err)
+	})
+
+	s.Run("A to D (normal)", func() {
+		path, foundPath, err := GetAppVersionPathIDs(s.DB, a.ID, d.ID)
+		s.Equal([]uint{a.ID, b.ID, c.ID}, path)
+		s.True(foundPath)
+		s.NoError(err)
+	})
+
+	s.Run("E to D (normal)", func() {
+		path, foundPath, err := GetAppVersionPathIDs(s.DB, e.ID, d.ID)
+		s.Equal([]uint{e.ID, c.ID}, path)
+		s.True(foundPath)
+		s.NoError(err)
+	})
+
+	s.Run("C to B (no path)", func() {
+		path, foundPath, err := GetAppVersionPathIDs(s.DB, c.ID, b.ID)
+		s.Empty(path)
+		s.False(foundPath)
+		s.NoError(err)
+	})
+
+	s.Run("A to F (no path)", func() {
+		path, foundPath, err := GetAppVersionPathIDs(s.DB, a.ID, f.ID)
+		s.Empty(path)
+		s.False(foundPath)
+		s.NoError(err)
+	})
+
+	s.Run("F to A (no path)", func() {
+		path, foundPath, err := GetAppVersionPathIDs(s.DB, f.ID, a.ID)
+		s.Empty(path)
+		s.False(foundPath)
+		s.NoError(err)
+	})
+
+	s.Run("F to non-existent (no path, doesn't error)", func() {
+		path, foundPath, err := GetAppVersionPathIDs(s.DB, f.ID, 0)
+		s.Empty(path)
+		s.False(foundPath)
+		s.NoError(err)
+	})
+
+	s.Run("A to non-existent (no path, doesn't error)", func() {
+		path, foundPath, err := GetAppVersionPathIDs(s.DB, a.ID, 0)
+		s.Empty(path)
+		s.False(foundPath)
+		s.NoError(err)
+	})
+
+	s.Run("non-existent to A (no path, doesn't error)", func() {
+		path, foundPath, err := GetAppVersionPathIDs(s.DB, 0, a.ID)
+		s.Empty(path)
+		s.False(foundPath)
+		s.NoError(err)
+	})
+
+	s.Run("non-existent to non-existent (no path, doesn't error)", func() {
+		// 0 won't ever be an ID but we need two non-existent IDs, so we awkwardly create and then delete an app version
+		deleted := AppVersion{ChartID: chart.ID, AppVersion: "deleted"}
+		s.NoError(s.DB.Create(&deleted).Error)
+		s.NoError(s.DB.Unscoped().Delete(&deleted).Error)
+		path, foundPath, err := GetAppVersionPathIDs(s.DB, 0, deleted.ID)
+		s.Empty(path)
+		s.False(foundPath)
+		s.NoError(err)
+	})
+}


### PR DESCRIPTION
Adds `/api/app-versions/procedures/v3/changelog`. It runs with hundreds fewer database roundtrips than `/api/v2/procedures/app-versions/children-path-to-parent` but runs the same algorithm, it just does so within the database using `WITH RECURSIVE`. We discussed this and its tradeoffs [here](https://broadinstitute.slack.com/archives/CQ6SL4N5T/p1696536340273929).

## Testing

Added tests, enough that I actually found some edge cases in the old endpoint's behavior. Rather than making breaking changes there I'll just have this endpoint handle them.

## Risk

Read-only endpoint, very low.