### PR TITLE
[DDO-3208] Record authors upon v3 version creation

### DIFF
--- a/sherlock/db/migrations/000059_version_user.down.sql
+++ b/sherlock/db/migrations/000059_version_user.down.sql
@@ -1,0 +1,11 @@
+alter table v2_chart_versions
+    drop constraint fk_v2_chart_versions_authored_by;
+
+alter table v2_chart_versions
+    drop if exists authored_by_id;
+
+alter table v2_app_versions
+    drop constraint fk_v2_app_versions_authored_by;
+
+alter table v2_app_versions
+    drop if exists authored_by_id;

--- a/sherlock/db/migrations/000059_version_user.up.sql
+++ b/sherlock/db/migrations/000059_version_user.up.sql
@@ -1,0 +1,13 @@
+alter table v2_app_versions
+    add if not exists authored_by_id bigint;
+
+alter table v2_app_versions
+    add constraint fk_v2_app_versions_authored_by
+        foreign key (authored_by_id) references v2_users;
+
+alter table v2_chart_versions
+    add if not exists authored_by_id bigint;
+
+alter table v2_chart_versions
+    add constraint fk_v2_chart_versions_authored_by
+        foreign key (authored_by_id) references v2_users;

--- a/sherlock/internal/api/sherlock/app_version_procedures_v3_changelog_test.go
+++ b/sherlock/internal/api/sherlock/app_version_procedures_v3_changelog_test.go
@@ -26,6 +26,7 @@ func (s *handlerSuite) TestAppVersionsProceduresV3Changelog_badParentSelector() 
 }
 
 func (s *handlerSuite) TestAppVersionsProceduresV3Changelog_childNotFound() {
+	s.SetNonSuitableTestUserForDB()
 	chart := models.Chart{Name: "my-chart", ChartRepo: utils.PointerTo("some-repo")}
 	s.NoError(s.DB.Create(&chart).Error)
 	appVersion := models.AppVersion{ChartID: chart.ID, AppVersion: "1"}
@@ -41,6 +42,7 @@ func (s *handlerSuite) TestAppVersionsProceduresV3Changelog_childNotFound() {
 }
 
 func (s *handlerSuite) TestAppVersionsProceduresV3Changelog_parentNotFound() {
+	s.SetNonSuitableTestUserForDB()
 	chart := models.Chart{Name: "my-chart", ChartRepo: utils.PointerTo("some-repo")}
 	s.NoError(s.DB.Create(&chart).Error)
 	appVersion := models.AppVersion{ChartID: chart.ID, AppVersion: "1"}
@@ -56,6 +58,7 @@ func (s *handlerSuite) TestAppVersionsProceduresV3Changelog_parentNotFound() {
 }
 
 func (s *handlerSuite) TestAppVersionsProceduresV3Changelog_sameChildAndParent() {
+	s.SetNonSuitableTestUserForDB()
 	chart := models.Chart{Name: "my-chart", ChartRepo: utils.PointerTo("some-repo")}
 	s.NoError(s.DB.Create(&chart).Error)
 	appVersion := models.AppVersion{ChartID: chart.ID, AppVersion: "1"}
@@ -71,6 +74,7 @@ func (s *handlerSuite) TestAppVersionsProceduresV3Changelog_sameChildAndParent()
 }
 
 func (s *handlerSuite) TestAppVersionsProceduresV3Changelog_noPathFound() {
+	s.SetNonSuitableTestUserForDB()
 	chart := models.Chart{Name: "my-chart", ChartRepo: utils.PointerTo("some-repo")}
 	s.NoError(s.DB.Create(&chart).Error)
 	appVersion1 := models.AppVersion{ChartID: chart.ID, AppVersion: "1"}
@@ -99,6 +103,7 @@ func (s *handlerSuite) TestAppVersionsProceduresV3Changelog_noPathFound() {
 }
 
 func (s *handlerSuite) TestAppVersionsProceduresV3Changelog_findsPath() {
+	s.SetNonSuitableTestUserForDB()
 	chart := models.Chart{Name: "my-chart", ChartRepo: utils.PointerTo("some-repo")}
 	s.NoError(s.DB.Create(&chart).Error)
 	appVersion1 := models.AppVersion{ChartID: chart.ID, AppVersion: "1"}

--- a/sherlock/internal/api/sherlock/app_version_v3_edit_test.go
+++ b/sherlock/internal/api/sherlock/app_version_v3_edit_test.go
@@ -40,6 +40,7 @@ func (s *handlerSuite) TestAppVersionsV3Edit_notFound() {
 }
 
 func (s *handlerSuite) TestAppVersionsV3Edit() {
+	s.SetNonSuitableTestUserForDB()
 	chart := models.Chart{
 		Name:      "name",
 		ChartRepo: utils.PointerTo("terra-helm"),

--- a/sherlock/internal/api/sherlock/app_version_v3_get_test.go
+++ b/sherlock/internal/api/sherlock/app_version_v3_get_test.go
@@ -2,6 +2,7 @@ package sherlock
 
 import (
 	"github.com/broadinstitute/sherlock/go-shared/pkg/utils"
+	"github.com/broadinstitute/sherlock/sherlock/internal/authentication/test_users"
 	"github.com/broadinstitute/sherlock/sherlock/internal/errors"
 	"github.com/broadinstitute/sherlock/sherlock/internal/models"
 	"net/http"
@@ -26,6 +27,7 @@ func (s *handlerSuite) TestAppVersionV3Get_notFound() {
 }
 
 func (s *handlerSuite) TestAppVersionV3Get() {
+	s.SetNonSuitableTestUserForDB()
 	chart := models.Chart{Name: "my-chart", ChartRepo: utils.PointerTo("some-repo")}
 	s.NoError(s.DB.Create(&chart).Error)
 	appVersion := models.AppVersion{ChartID: chart.ID, AppVersion: "1"}
@@ -38,6 +40,9 @@ func (s *handlerSuite) TestAppVersionV3Get() {
 	s.Equal(http.StatusOK, code)
 	if s.NotNil(got.ChartInfo) {
 		s.NotZero(got.ChartInfo.ID)
+	}
+	if s.NotNil(got.AuthoredByInfo) {
+		s.Equal(test_users.NonSuitableTestUserEmail, got.AuthoredByInfo.Email)
 	}
 	s.Equal("1", got.AppVersion)
 }

--- a/sherlock/internal/api/sherlock/app_version_v3_list_test.go
+++ b/sherlock/internal/api/sherlock/app_version_v3_list_test.go
@@ -1,7 +1,9 @@
 package sherlock
 
 import (
+	"fmt"
 	"github.com/broadinstitute/sherlock/go-shared/pkg/utils"
+	"github.com/broadinstitute/sherlock/sherlock/internal/authentication/test_users"
 	"github.com/broadinstitute/sherlock/sherlock/internal/errors"
 	"github.com/broadinstitute/sherlock/sherlock/internal/models"
 	"net/http"
@@ -77,6 +79,14 @@ func (s *handlerSuite) TestAppVersionsV3List() {
 		var got []AppVersionV3
 		code := s.HandleRequest(
 			s.NewRequest("GET", "/api/app-versions/v3", nil),
+			&got)
+		s.Equal(http.StatusOK, code)
+		s.Len(got, 3)
+	})
+	s.Run("all via user filter", func() {
+		var got []AppVersionV3
+		code := s.HandleRequest(
+			s.NewRequest("GET", fmt.Sprintf("/api/app-versions/v3?authoredBy=%s", test_users.NonSuitableTestUserEmail), nil),
 			&got)
 		s.Equal(http.StatusOK, code)
 		s.Len(got, 3)

--- a/sherlock/internal/api/sherlock/app_version_v3_list_test.go
+++ b/sherlock/internal/api/sherlock/app_version_v3_list_test.go
@@ -44,6 +44,7 @@ func (s *handlerSuite) TestAppVersionsV3List_badOffset() {
 }
 
 func (s *handlerSuite) TestAppVersionsV3List() {
+	s.SetNonSuitableTestUserForDB()
 	chart1 := models.Chart{
 		Name:      "name1",
 		ChartRepo: utils.PointerTo("terra-helm"),

--- a/sherlock/internal/api/sherlock/app_version_v3_upsert_test.go
+++ b/sherlock/internal/api/sherlock/app_version_v3_upsert_test.go
@@ -2,6 +2,7 @@ package sherlock
 
 import (
 	"github.com/broadinstitute/sherlock/go-shared/pkg/utils"
+	"github.com/broadinstitute/sherlock/sherlock/internal/authentication/test_users"
 	"github.com/broadinstitute/sherlock/sherlock/internal/errors"
 	"github.com/broadinstitute/sherlock/sherlock/internal/models"
 	"github.com/gin-gonic/gin"
@@ -75,6 +76,9 @@ func (s *handlerSuite) TestAppVersionsV3Upsert() {
 	}
 	if s.NotNil(got.Description) {
 		s.Equal("original description", got.Description)
+	}
+	if s.NotNil(got.AuthoredByInfo) {
+		s.Equal(test_users.SuitableTestUserEmail, got.AuthoredByInfo.Email)
 	}
 
 	var got2 AppVersionV3

--- a/sherlock/internal/api/sherlock/chart_version_procedures_v3_changelog_test.go
+++ b/sherlock/internal/api/sherlock/chart_version_procedures_v3_changelog_test.go
@@ -26,6 +26,7 @@ func (s *handlerSuite) TestChartVersionsProceduresV3Changelog_badParentSelector(
 }
 
 func (s *handlerSuite) TestChartVersionsProceduresV3Changelog_childNotFound() {
+	s.SetNonSuitableTestUserForDB()
 	chart := models.Chart{Name: "my-chart", ChartRepo: utils.PointerTo("some-repo")}
 	s.NoError(s.DB.Create(&chart).Error)
 	chartVersion := models.ChartVersion{ChartID: chart.ID, ChartVersion: "1"}
@@ -41,6 +42,7 @@ func (s *handlerSuite) TestChartVersionsProceduresV3Changelog_childNotFound() {
 }
 
 func (s *handlerSuite) TestChartVersionsProceduresV3Changelog_parentNotFound() {
+	s.SetNonSuitableTestUserForDB()
 	chart := models.Chart{Name: "my-chart", ChartRepo: utils.PointerTo("some-repo")}
 	s.NoError(s.DB.Create(&chart).Error)
 	chartVersion := models.ChartVersion{ChartID: chart.ID, ChartVersion: "1"}
@@ -56,6 +58,7 @@ func (s *handlerSuite) TestChartVersionsProceduresV3Changelog_parentNotFound() {
 }
 
 func (s *handlerSuite) TestChartVersionsProceduresV3Changelog_sameChildAndParent() {
+	s.SetNonSuitableTestUserForDB()
 	chart := models.Chart{Name: "my-chart", ChartRepo: utils.PointerTo("some-repo")}
 	s.NoError(s.DB.Create(&chart).Error)
 	chartVersion := models.ChartVersion{ChartID: chart.ID, ChartVersion: "1"}
@@ -71,6 +74,7 @@ func (s *handlerSuite) TestChartVersionsProceduresV3Changelog_sameChildAndParent
 }
 
 func (s *handlerSuite) TestChartVersionsProceduresV3Changelog_noPathFound() {
+	s.SetNonSuitableTestUserForDB()
 	chart := models.Chart{Name: "my-chart", ChartRepo: utils.PointerTo("some-repo")}
 	s.NoError(s.DB.Create(&chart).Error)
 	chartVersion1 := models.ChartVersion{ChartID: chart.ID, ChartVersion: "1"}
@@ -99,6 +103,7 @@ func (s *handlerSuite) TestChartVersionsProceduresV3Changelog_noPathFound() {
 }
 
 func (s *handlerSuite) TestChartVersionsProceduresV3Changelog_findsPath() {
+	s.SetNonSuitableTestUserForDB()
 	chart := models.Chart{Name: "my-chart", ChartRepo: utils.PointerTo("some-repo")}
 	s.NoError(s.DB.Create(&chart).Error)
 	chartVersion1 := models.ChartVersion{ChartID: chart.ID, ChartVersion: "1"}

--- a/sherlock/internal/api/sherlock/chart_version_v3_edit_test.go
+++ b/sherlock/internal/api/sherlock/chart_version_v3_edit_test.go
@@ -40,6 +40,7 @@ func (s *handlerSuite) TestChartVersionsV3Edit_notFound() {
 }
 
 func (s *handlerSuite) TestChartVersionsV3Edit() {
+	s.SetNonSuitableTestUserForDB()
 	chart := models.Chart{
 		Name:      "name",
 		ChartRepo: utils.PointerTo("terra-helm"),

--- a/sherlock/internal/api/sherlock/chart_version_v3_get_test.go
+++ b/sherlock/internal/api/sherlock/chart_version_v3_get_test.go
@@ -2,6 +2,7 @@ package sherlock
 
 import (
 	"github.com/broadinstitute/sherlock/go-shared/pkg/utils"
+	"github.com/broadinstitute/sherlock/sherlock/internal/authentication/test_users"
 	"github.com/broadinstitute/sherlock/sherlock/internal/errors"
 	"github.com/broadinstitute/sherlock/sherlock/internal/models"
 	"net/http"
@@ -26,6 +27,7 @@ func (s *handlerSuite) TestChartVersionV3Get_notFound() {
 }
 
 func (s *handlerSuite) TestChartVersionV3Get() {
+	s.SetNonSuitableTestUserForDB()
 	chart := models.Chart{Name: "my-chart", ChartRepo: utils.PointerTo("some-repo")}
 	s.NoError(s.DB.Create(&chart).Error)
 	chartVersion := models.ChartVersion{ChartID: chart.ID, ChartVersion: "1"}
@@ -38,6 +40,9 @@ func (s *handlerSuite) TestChartVersionV3Get() {
 	s.Equal(http.StatusOK, code)
 	if s.NotNil(got.ChartInfo) {
 		s.NotZero(got.ChartInfo.ID)
+	}
+	if s.NotNil(got.AuthoredByInfo) {
+		s.Equal(test_users.NonSuitableTestUserEmail, got.AuthoredByInfo.Email)
 	}
 	s.Equal("1", got.ChartVersion)
 }

--- a/sherlock/internal/api/sherlock/chart_version_v3_list_test.go
+++ b/sherlock/internal/api/sherlock/chart_version_v3_list_test.go
@@ -65,7 +65,6 @@ func (s *handlerSuite) TestChartVersionsV3List() {
 		s.NotZero(chart.ID)
 	}
 
-	println("Chart1", chart1.ID)
 	chartVersion1 := models.ChartVersion{ChartID: chart1.ID, ChartVersion: "1"}
 	chartVersion2 := models.ChartVersion{ChartID: chart2.ID, ChartVersion: "2"}
 	chartVersion3 := models.ChartVersion{ChartID: chart3.ID, ChartVersion: "3"}

--- a/sherlock/internal/api/sherlock/chart_version_v3_list_test.go
+++ b/sherlock/internal/api/sherlock/chart_version_v3_list_test.go
@@ -44,6 +44,7 @@ func (s *handlerSuite) TestChartVersionsV3List_badOffset() {
 }
 
 func (s *handlerSuite) TestChartVersionsV3List() {
+	s.SetNonSuitableTestUserForDB()
 	chart1 := models.Chart{
 		Name:      "name1",
 		ChartRepo: utils.PointerTo("terra-helm"),

--- a/sherlock/internal/api/sherlock/chart_version_v3_list_test.go
+++ b/sherlock/internal/api/sherlock/chart_version_v3_list_test.go
@@ -1,7 +1,9 @@
 package sherlock
 
 import (
+	"fmt"
 	"github.com/broadinstitute/sherlock/go-shared/pkg/utils"
+	"github.com/broadinstitute/sherlock/sherlock/internal/authentication/test_users"
 	"github.com/broadinstitute/sherlock/sherlock/internal/errors"
 	"github.com/broadinstitute/sherlock/sherlock/internal/models"
 	"net/http"
@@ -77,6 +79,14 @@ func (s *handlerSuite) TestChartVersionsV3List() {
 		var got []ChartVersionV3
 		code := s.HandleRequest(
 			s.NewRequest("GET", "/api/chart-versions/v3", nil),
+			&got)
+		s.Equal(http.StatusOK, code)
+		s.Len(got, 3)
+	})
+	s.Run("all via user filter", func() {
+		var got []ChartVersionV3
+		code := s.HandleRequest(
+			s.NewRequest("GET", fmt.Sprintf("/api/chart-versions/v3?authoredBy=%s", test_users.NonSuitableTestUserEmail), nil),
 			&got)
 		s.Equal(http.StatusOK, code)
 		s.Len(got, 3)

--- a/sherlock/internal/api/sherlock/chart_version_v3_upsert_test.go
+++ b/sherlock/internal/api/sherlock/chart_version_v3_upsert_test.go
@@ -2,6 +2,7 @@ package sherlock
 
 import (
 	"github.com/broadinstitute/sherlock/go-shared/pkg/utils"
+	"github.com/broadinstitute/sherlock/sherlock/internal/authentication/test_users"
 	"github.com/broadinstitute/sherlock/sherlock/internal/errors"
 	"github.com/broadinstitute/sherlock/sherlock/internal/models"
 	"github.com/gin-gonic/gin"
@@ -40,6 +41,7 @@ func (s *handlerSuite) TestChartVersionsV3Upsert_error() {
 }
 
 func (s *handlerSuite) TestChartVersionsV3Upsert() {
+	s.SetNonSuitableTestUserForDB()
 	chart := models.Chart{
 		Name:      "chart-name",
 		ChartRepo: utils.PointerTo("terra-helm"),
@@ -69,6 +71,9 @@ func (s *handlerSuite) TestChartVersionsV3Upsert() {
 	}
 	if s.NotNil(got.Description) {
 		s.Equal("original description", got.Description)
+	}
+	if s.NotNil(got.AuthoredByInfo) {
+		s.Equal(test_users.SuitableTestUserEmail, got.AuthoredByInfo.Email)
 	}
 
 	var got2 ChartVersionV3

--- a/sherlock/internal/models/app_version.go
+++ b/sherlock/internal/models/app_version.go
@@ -16,18 +16,29 @@ type AppVersion struct {
 	Description        string
 	ParentAppVersion   *AppVersion
 	ParentAppVersionID *uint
+	AuthoredBy         *User
+	AuthoredByID       *uint
 }
 
-func (a AppVersion) TableName() string {
+func (a *AppVersion) TableName() string {
 	return "v2_app_versions"
 }
 
-func (a AppVersion) GetCiIdentifier() CiIdentifier {
+func (a *AppVersion) GetCiIdentifier() CiIdentifier {
 	if a.CiIdentifier != nil {
 		return *a.CiIdentifier
 	} else {
 		return CiIdentifier{ResourceType: "app-version", ResourceID: a.ID}
 	}
+}
+
+func (a *AppVersion) BeforeCreate(tx *gorm.DB) error {
+	if user, err := GetCurrentUserForDB(tx); err != nil {
+		return err
+	} else {
+		a.AuthoredByID = &user.ID
+	}
+	return nil
 }
 
 // GetAppVersionPathIDs iterates from one AppVersion to another, treating each one's parent like a linked list.

--- a/sherlock/internal/models/chart_version.go
+++ b/sherlock/internal/models/chart_version.go
@@ -14,18 +14,29 @@ type ChartVersion struct {
 	Description          string
 	ParentChartVersion   *ChartVersion
 	ParentChartVersionID *uint
+	AuthoredBy           *User
+	AuthoredByID         *uint
 }
 
-func (c ChartVersion) TableName() string {
+func (c *ChartVersion) TableName() string {
 	return "v2_chart_versions"
 }
 
-func (c ChartVersion) GetCiIdentifier() CiIdentifier {
+func (c *ChartVersion) GetCiIdentifier() CiIdentifier {
 	if c.CiIdentifier != nil {
 		return *c.CiIdentifier
 	} else {
 		return CiIdentifier{ResourceType: "chart-version", ResourceID: c.ID}
 	}
+}
+
+func (c *ChartVersion) BeforeCreate(tx *gorm.DB) error {
+	if user, err := GetCurrentUserForDB(tx); err != nil {
+		return err
+	} else {
+		c.AuthoredByID = &user.ID
+	}
+	return nil
 }
 
 // GetChartVersionPathIDs iterates from one ChartVersion to another, treating each one's parent like a linked list.


### PR DESCRIPTION
As @katiewelch rolls out #321 and #306, we'll begin ingesting version authorship.

This will be helpful for making deploy notifications that can @ the specific folks who authored versions in the deployment.

## Testing

Full coverage (including different creation mechanisms, ensuring that the pre-create hooks work)

## Risk

Very low. Will need to disable the prepared statement cache before deployment so the database migration will run smoothly.