### PR TITLE
[DDO-3215] Fix v3 version upsert paths

### DIFF
--- a/sherlock/internal/api/api_test.go
+++ b/sherlock/internal/api/api_test.go
@@ -1,0 +1,32 @@
+package api
+
+import (
+	"embed"
+	"github.com/stretchr/testify/assert"
+	"path"
+	"regexp"
+	"testing"
+)
+
+//go:embed *
+var apiFiles embed.FS
+var capsInApiPathRegex = regexp.MustCompile("/api/\\w*[A-Z]")
+
+func TestApiFiles(t *testing.T) {
+	validateApiPathsInDirectory(t, ".")
+}
+
+func validateApiPathsInDirectory(t *testing.T, subdirectory string) {
+	entries, err := apiFiles.ReadDir(subdirectory)
+	assert.NoError(t, err)
+	for _, entry := range entries {
+		filesystemPath := path.Join(subdirectory, entry.Name())
+		if entry.IsDir() {
+			validateApiPathsInDirectory(t, filesystemPath)
+		} else {
+			data, err := apiFiles.ReadFile(filesystemPath)
+			assert.NoError(t, err, "file %s read error", filesystemPath)
+			assert.Falsef(t, capsInApiPathRegex.Match(data), "file %s contains an API path with capitalized letters (matching %s)", filesystemPath, capsInApiPathRegex.String())
+		}
+	}
+}

--- a/sherlock/internal/api/api_test.go
+++ b/sherlock/internal/api/api_test.go
@@ -10,7 +10,7 @@ import (
 
 //go:embed *
 var apiFiles embed.FS
-var capsInApiPathRegex = regexp.MustCompile("/api/\\w*[A-Z]")
+var capsInApiPathRegex = regexp.MustCompile(`/api/\w*[A-Z]`)
 
 func TestApiFiles(t *testing.T) {
 	validateApiPathsInDirectory(t, ".")

--- a/sherlock/internal/api/sherlock/app_version_v3_upsert.go
+++ b/sherlock/internal/api/sherlock/app_version_v3_upsert.go
@@ -21,7 +21,7 @@ import (
 //	@param			appVersion				body		AppVersionV3Create	true	"The AppVersion to upsert"
 //	@success		201						{object}	AppVersionV3
 //	@failure		400,403,404,407,409,500	{object}	errors.ErrorResponse
-//	@router			/api/appVersions/v3 [post]
+//	@router			/api/app-versions/v3 [post]
 func appVersionsV3Upsert(ctx *gin.Context) {
 	db, err := authentication.MustUseDB(ctx)
 	if err != nil {

--- a/sherlock/internal/api/sherlock/chart_version_v3_upsert.go
+++ b/sherlock/internal/api/sherlock/chart_version_v3_upsert.go
@@ -21,7 +21,7 @@ import (
 //	@param			chartVersion			body		ChartVersionV3Create	true	"The ChartVersion to upsert"
 //	@success		201						{object}	ChartVersionV3
 //	@failure		400,403,404,407,409,500	{object}	errors.ErrorResponse
-//	@router			/api/chartVersions/v3 [post]
+//	@router			/api/chart-versions/v3 [post]
 func chartVersionsV3Upsert(ctx *gin.Context) {
 	db, err := authentication.MustUseDB(ctx)
 	if err != nil {


### PR DESCRIPTION
The v3 upsert endpoints work properly but the comments were indicating the endpoints were at `/api/appVersions/v3` and `/api/chartVersions/v3` instead of `/api/app-versions/v3` and `/api/chart-versions/v3`.

This means that the client libraries were getting a gin fallback 404, instead of an API-level 404 like the client libraries are built to handle. [This is why Thelma was complaining about not being able to parse the error response](https://broadinstitute.slack.com/archives/CQ6SL4N5T/p1697048156679049?thread_ts=1697047954.711599&cid=CQ6SL4N5T) (it wasn't json that was coming back from gin).

## Testing 

I added a unit test to scan Sherlock's own source code files for declarations for API paths with capitalized letters in them. We can improve the regex over time if we need but it should help avoid this sort of thing in the future (it's super easy to miss, since it's just a comment).

## Risk

No one could be successfully using the existing endpoint because it's at an unexpected URL, so I think this is safe