### PR TITLE
[DDO-3268] Improve logging/metrics for Gin responses

### DIFF
--- a/sherlock/config/default_config.yaml
+++ b/sherlock/config/default_config.yaml
@@ -6,7 +6,9 @@
 mode: debug
 
 log:
+  # Always true when mode="release"
   timestamp: true
+  # Always true when mode="release"
   caller: false
   level: debug
 

--- a/sherlock/internal/boot/middleware/logger.go
+++ b/sherlock/internal/boot/middleware/logger.go
@@ -13,7 +13,7 @@ import (
 	"time"
 )
 
-func Logger() gin.HandlerFunc {
+func Logger(consoleLogging bool) gin.HandlerFunc {
 	return func(ctx *gin.Context) {
 		t := time.Now()
 
@@ -48,12 +48,17 @@ func Logger() gin.HandlerFunc {
 		}
 
 		event.Int("status", ctx.Writer.Status())
-		event.Dur("latency", latency)
 		event.Str("principal", principal)
-		event.Str("client", ctx.ClientIP())
 		event.Str("method", ctx.Request.Method)
-		event.Str("route", ctx.FullPath())
-		event.Msgf("GIN  | %s", path)
+		if consoleLogging {
+			event.Stringer("latency", latency)
+			event.Msgf("GIN  | %-50s", path)
+		} else {
+			event.Dur("latency", latency)
+			event.Str("route", ctx.FullPath())
+			event.Str("client", ctx.ClientIP())
+			event.Msgf("GIN  | %s", path)
+		}
 
 		if tagCtx, err := tag.New(ctx,
 			tag.Upsert(metrics.StatusKey, strconv.Itoa(ctx.Writer.Status())),

--- a/sherlock/internal/boot/router.go
+++ b/sherlock/internal/boot/router.go
@@ -51,7 +51,11 @@ func buildRouter(ctx context.Context, db *gorm.DB) *gin.Engine {
 
 	router := gin.New()
 
-	router.Use(gin.Recovery(), middleware.Logger(), slack.ErrorReportingMiddleware(ctx), middleware.Headers())
+	router.Use(
+		gin.Recovery(),
+		middleware.Logger(config.Config.String("mode") == "debug"),
+		slack.ErrorReportingMiddleware(ctx),
+		middleware.Headers())
 
 	// /status, /version
 	misc.ConfigureRoutes(&router.RouterGroup)

--- a/sherlock/internal/config/config.go
+++ b/sherlock/internal/config/config.go
@@ -86,6 +86,7 @@ func configureLogging(infoMessages ...string) {
 	if Config.String("mode") == "debug" {
 		// Colored text for CLI
 		output := zerolog.ConsoleWriter{Out: os.Stderr, TimeFormat: time.Kitchen}
+		// If the call-site of the log message is included, format it nicely for human consumption
 		output.FormatCaller = func(i interface{}) string {
 			if i == nil {
 				return ""

--- a/sherlock/internal/metrics/metrics.go
+++ b/sherlock/internal/metrics/metrics.go
@@ -61,7 +61,7 @@ var (
 
 // Unique per replica
 var (
-	PagerdutyRequestCount = stats.Int64(
+	PagerdutyRequestCountMeasure = stats.Int64(
 		"sherlock/v2_pagerduty_request_count",
 		"count of outgoing requests to pagerduty",
 		"requests")
@@ -135,9 +135,9 @@ var (
 	}
 	PagerdutyRequestCountView = &view.View{
 		Name:        "v2_pagerduty_request_count",
-		Measure:     PagerdutyRequestCount,
+		Measure:     PagerdutyRequestCountMeasure,
 		TagKeys:     []tag.Key{PagerdutyRequestTypeKey, PagerdutyResponseCodeKey},
-		Description: PagerdutyRequestCount.Description(),
+		Description: PagerdutyRequestCountMeasure.Description(),
 		Aggregation: view.Count(),
 	}
 	EnvironmentStateCountView = &view.View{

--- a/sherlock/internal/metrics/metrics.go
+++ b/sherlock/internal/metrics/metrics.go
@@ -65,6 +65,10 @@ var (
 		"sherlock/v2_pagerduty_request_count",
 		"count of outgoing requests to pagerduty",
 		"requests")
+	ResponseLatencyMeasure = stats.Int64(
+		"sherlock/response_latency",
+		"the latency of responses served from sherlock",
+		"ms")
 )
 
 var (
@@ -83,6 +87,9 @@ var (
 	GithubActionsWorkflowFileKey  = tag.MustNewKey("gha_workflow_file")
 	GithubActionsOutcomeKey       = tag.MustNewKey("gha_outcome")
 	GithubActionsRetryKey         = tag.MustNewKey("gha_retry")
+	RouteKey                      = tag.MustNewKey("route")
+	MethodKey                     = tag.MustNewKey("method")
+	StatusKey                     = tag.MustNewKey("status")
 
 	ChangesetCountView = &view.View{
 		Name:        "v2_changeset_count",
@@ -175,6 +182,22 @@ var (
 		Description: GithubActions7DayTotalDurationMeasure.Description(),
 		Aggregation: view.LastValue(),
 	}
+	ResponseCountView = &view.View{
+		Name:        "response_count",
+		Measure:     ResponseLatencyMeasure,
+		TagKeys:     []tag.Key{RouteKey, MethodKey, StatusKey},
+		Description: "The number of responses served from Sherlock",
+		Aggregation: view.Count(),
+	}
+	ResponseLatencyView = &view.View{
+		Name:        "response_latency",
+		Measure:     ResponseLatencyMeasure,
+		TagKeys:     []tag.Key{RouteKey, MethodKey, StatusKey},
+		Description: "The distribution of the latencies of responses served from Sherlock",
+		// Latency in buckets:
+		// [>=0ms, >=25ms, >=50ms, >=75ms, >=100ms, >=200ms, >=400ms, >=600ms, >=800ms, >=1s, >=2s, >=4s, >=6s, >=8s, >=10s]
+		Aggregation: view.Distribution(0, 25, 50, 75, 100, 200, 400, 600, 800, 1000, 2000, 4000, 6000, 8000, 10000),
+	}
 )
 
 func RegisterViews() error {
@@ -192,5 +215,7 @@ func RegisterViews() error {
 		GithubActions7DayCompletionCountView,
 		GithubActions1HourTotalDurationView,
 		GithubActions7DayTotalDurationView,
+		ResponseCountView,
+		ResponseLatencyView,
 	)
 }

--- a/sherlock/internal/pagerduty/metrics.go
+++ b/sherlock/internal/pagerduty/metrics.go
@@ -23,5 +23,5 @@ func recordMetrics(ctx context.Context, requestType string, err error) {
 	} else {
 		ctx, _ = tag.New(ctx, tag.Upsert(metrics.PagerdutyResponseCodeKey, strconv.Itoa(http.StatusAccepted)))
 	}
-	stats.Record(ctx, metrics.PagerdutyRequestCount.M(1))
+	stats.Record(ctx, metrics.PagerdutyRequestCountMeasure.M(1))
 }


### PR DESCRIPTION
Adds metrics for response latency/count, by Gin's matched route.

Also touches up logging. Normal internal log messages are staying the same, but the Gin ones now take full advantage of Zerolog's JSON fields. Things like the status code, client IP, latency, etc are no longer logged in just a big string, they're logged as fields with Zerolog.

This makes the Gin logging slightly worse locally, but _way, way_ better through GCP. It's a balancing act and I think the Gin logs are primarily useful through GCP anyway, so I think it's okay. This also helps avoid logging things to console that we only need on GCP, like the client IP.

Before:
![Screenshot 2023-10-27 at 3 32 40 PM](https://github.com/broadinstitute/sherlock/assets/29168264/1d634829-a41c-451f-b294-80555c543daf)
After: 
![Screenshot 2023-10-27 at 3 52 42 PM](https://github.com/broadinstitute/sherlock/assets/29168264/f3ee5bc2-4083-4b8f-a195-0a194862efce)

## Testing

Screenshots above; visited /metrics to validate that part.

## Risk

Very low, no functionality changing, just logs