### PR TITLE
[DDO-3268] Bring back a bit of the old logging

### DIFF
--- a/sherlock/internal/boot/middleware/logger.go
+++ b/sherlock/internal/boot/middleware/logger.go
@@ -57,7 +57,8 @@ func Logger(consoleLogging bool) gin.HandlerFunc {
 			event.Dur("latency", latency)
 			event.Str("route", ctx.FullPath())
 			event.Str("client", ctx.ClientIP())
-			event.Msgf("GIN  | %s", path)
+			event.Msgf("GIN  | %3d | %14s | %40s | %-7s %s",
+				ctx.Writer.Status(), time.Since(t).String(), principal, ctx.Request.Method, path)
 		}
 
 		if tagCtx, err := tag.New(ctx,

--- a/sherlock/internal/boot/middleware/logger.go
+++ b/sherlock/internal/boot/middleware/logger.go
@@ -57,7 +57,7 @@ func Logger(consoleLogging bool) gin.HandlerFunc {
 			event.Dur("latency", latency)
 			event.Str("route", ctx.FullPath())
 			event.Str("client", ctx.ClientIP())
-			event.Msgf("GIN  | %3d | %14s | %40s | %-7s %s",
+			event.Msgf("GIN  | %3d | %14s | %50s | %-7s %s",
 				ctx.Writer.Status(), time.Since(t).String(), principal, ctx.Request.Method, path)
 		}
 


### PR DESCRIPTION
Okay so I went a bit too far on the JSON-ifying, and now the GCP logs are kinda unreadable when you first open the page.

![Screenshot 2023-10-27 at 4 29 54 PM](https://github.com/broadinstitute/sherlock/assets/29168264/acf8b069-11dd-4354-9abd-096020588446)

This tiny change just adds the most useful fields back to the message to improve readability in GCP.

## Testing

I trigger this locally, here's a sample message content:

> `GIN  | 200 |      361.667µs |                                        unevaluated | GET     /swagger/index.html`

## Risk

Very low