### PR TITLE
[DDO-3289] Deploy Hook test mechanism

### DIFF
--- a/sherlock/internal/api/sherlock/chart_version_v3_edit.go
+++ b/sherlock/internal/api/sherlock/chart_version_v3_edit.go
@@ -16,8 +16,8 @@ import (
 //	@description	Edit an individual ChartVersion.
 //	@tags			ChartVersions
 //	@produce		json
-//	@param			selector				path		string		true	"The selector of the ChartVersion, which can be either a numeric ID or chart/version."
-//	@param			chartVersion					body		ChartVersionV3Edit	true	"The edits to make to the ChartVersion"
+//	@param			selector				path		string				true	"The selector of the ChartVersion, which can be either a numeric ID or chart/version."
+//	@param			chartVersion			body		ChartVersionV3Edit	true	"The edits to make to the ChartVersion"
 //	@success		200						{object}	ChartVersionV3
 //	@failure		400,403,404,407,409,500	{object}	errors.ErrorResponse
 //	@router			/api/chart-versions/v3/{selector} [patch]

--- a/sherlock/internal/api/sherlock/ci_runs_v3_upsert_test.go
+++ b/sherlock/internal/api/sherlock/ci_runs_v3_upsert_test.go
@@ -724,7 +724,7 @@ func (s *handlerSuite) TestCiRunsV3Upsert_slackNotifications() {
 	})
 }
 
-func (s *handlerSuite) TestCiRunsV3Upsert_makeSlackMessageTExt() {
+func (s *handlerSuite) TestCiRunsV3Upsert_makeSlackMessageText() {
 	user := s.SetSuitableTestUserForDB()
 
 	chart, created, err := v2models.InternalChartStore.Create(s.DB, v2models.Chart{

--- a/sherlock/internal/api/sherlock/github_actions_deploy_hooks_v3_test_run.go
+++ b/sherlock/internal/api/sherlock/github_actions_deploy_hooks_v3_test_run.go
@@ -26,8 +26,8 @@ type GithubActionsDeployHookTestRunResponse struct {
 //	@description	Run a GitHub Action to simulate a GithubActionsDeployHook
 //	@tags			DeployHooks
 //	@produce		json
-//	@param			selector				path		string	true	"The ID of the GithubActionsDeployHook"
-//	@param			request                 body GithubActionsDeployHookTestRunRequest true "Whether to fully execute the hook (JSON body helps with CSRF protection)"
+//	@param			selector				path		string									true	"The ID of the GithubActionsDeployHook"
+//	@param			request					body		GithubActionsDeployHookTestRunRequest	true	"Whether to fully execute the hook (JSON body helps with CSRF protection)"
 //	@success		200						{object}	GithubActionsDeployHookTestRunResponse
 //	@failure		400,403,404,407,409,500	{object}	errors.ErrorResponse
 //	@router			/api/deploy-hooks/github-actions/procedures/v3/test/{selector} [post]

--- a/sherlock/internal/api/sherlock/github_actions_deploy_hooks_v3_test_run.go
+++ b/sherlock/internal/api/sherlock/github_actions_deploy_hooks_v3_test_run.go
@@ -11,9 +11,13 @@ import (
 	"net/http"
 )
 
+type GithubActionsDeployHookTestRunRequest struct {
+	Execute *bool `json:"execute"` // Required, whether to fully run the GHA
+}
+
 type GithubActionsDeployHookTestRunResponse struct {
 	OK  bool   `json:"ok"`
-	URL string `json:"url"`
+	URL string `json:"url,omitempty"`
 }
 
 // githubActionsDeployHooksV3TestRun godoc
@@ -23,6 +27,7 @@ type GithubActionsDeployHookTestRunResponse struct {
 //	@tags			DeployHooks
 //	@produce		json
 //	@param			selector				path		string	true	"The ID of the GithubActionsDeployHook"
+//	@param			request                 body GithubActionsDeployHookTestRunRequest true "Whether to fully execute the hook (JSON body helps with CSRF protection)"
 //	@success		200						{object}	GithubActionsDeployHookTestRunResponse
 //	@failure		400,403,404,407,409,500	{object}	errors.ErrorResponse
 //	@router			/api/deploy-hooks/github-actions/procedures/v3/test/{selector} [post]
@@ -31,6 +36,16 @@ func githubActionsDeployHooksV3TestRun(ctx *gin.Context) {
 	if err != nil {
 		return
 	}
+
+	var body GithubActionsDeployHookTestRunRequest
+	if err = ctx.ShouldBindJSON(&body); err != nil {
+		errors.AbortRequest(ctx, fmt.Errorf("(%s) request validation error: %w", errors.BadRequest, err))
+		return
+	} else if body.Execute == nil {
+		errors.AbortRequest(ctx, fmt.Errorf("(%s) 'execute' is required", errors.BadRequest))
+		return
+	}
+
 	query, err := githubActionsDeployHookModelFromSelector(canonicalizeSelector(ctx.Param("selector")))
 	if err != nil {
 		errors.AbortRequest(ctx, err)
@@ -53,6 +68,12 @@ func githubActionsDeployHooksV3TestRun(ctx *gin.Context) {
 			return
 		}
 	}
+
+	if !*body.Execute {
+		ctx.JSON(http.StatusOK, GithubActionsDeployHookTestRunResponse{OK: true})
+		return
+	}
+
 	if err = github.DispatchWorkflow(ctx,
 		*hook.GithubActionsOwner,
 		*hook.GithubActionsRepo,

--- a/sherlock/internal/api/sherlock/github_actions_deploy_hooks_v3_test_run.go
+++ b/sherlock/internal/api/sherlock/github_actions_deploy_hooks_v3_test_run.go
@@ -1,0 +1,69 @@
+package sherlock
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/broadinstitute/sherlock/sherlock/internal/authentication"
+	"github.com/broadinstitute/sherlock/sherlock/internal/errors"
+	"github.com/broadinstitute/sherlock/sherlock/internal/github"
+	"github.com/broadinstitute/sherlock/sherlock/internal/models"
+	"github.com/gin-gonic/gin"
+	"net/http"
+)
+
+type GithubActionsDeployHookTestRunResponse struct {
+	OK  bool   `json:"ok"`
+	URL string `json:"url"`
+}
+
+// githubActionsDeployHooksV3TestRun godoc
+//
+//	@summary		Test a GithubActionsDeployHook
+//	@description	Run a GitHub Action to simulate a GithubActionsDeployHook
+//	@tags			DeployHooks
+//	@produce		json
+//	@param			selector				path		string	true	"The ID of the GithubActionsDeployHook"
+//	@success		200						{object}	GithubActionsDeployHookTestRunResponse
+//	@failure		400,403,404,407,409,500	{object}	errors.ErrorResponse
+//	@router			/api/deploy-hooks/github-actions/procedures/v3/test/{selector} [post]
+func githubActionsDeployHooksV3TestRun(ctx *gin.Context) {
+	db, err := authentication.MustUseDB(ctx)
+	if err != nil {
+		return
+	}
+	query, err := githubActionsDeployHookModelFromSelector(canonicalizeSelector(ctx.Param("selector")))
+	if err != nil {
+		errors.AbortRequest(ctx, err)
+		return
+	}
+	var hook models.GithubActionsDeployHook
+	if err = db.
+		Where(&query).
+		First(&hook).Error; err != nil {
+		errors.AbortRequest(ctx, err)
+		return
+	}
+	var workflowInputs map[string]any
+	if hook.GithubActionsWorkflowInputs != nil {
+		if bytes, err := hook.GithubActionsWorkflowInputs.MarshalJSON(); err != nil {
+			errors.AbortRequest(ctx, fmt.Errorf("error marshalling inputs: %w", err))
+			return
+		} else if err = json.Unmarshal(bytes, &workflowInputs); err != nil {
+			errors.AbortRequest(ctx, fmt.Errorf("error unmarshalling stored inputs: %w", err))
+			return
+		}
+	}
+	if err = github.DispatchWorkflow(ctx,
+		*hook.GithubActionsOwner,
+		*hook.GithubActionsRepo,
+		*hook.GithubActionsWorkflowPath,
+		*hook.GithubActionsDefaultRef,
+		workflowInputs); err != nil {
+		errors.AbortRequest(ctx, err)
+		return
+	}
+	ctx.JSON(http.StatusOK, GithubActionsDeployHookTestRunResponse{
+		OK:  true,
+		URL: fmt.Sprintf("https://github.com/%s/%s/actions", *hook.GithubActionsOwner, *hook.GithubActionsRepo),
+	})
+}

--- a/sherlock/internal/api/sherlock/github_actions_deploy_hooks_v3_test_run_test.go
+++ b/sherlock/internal/api/sherlock/github_actions_deploy_hooks_v3_test_run_test.go
@@ -1,0 +1,105 @@
+package sherlock
+
+import (
+	"fmt"
+	"github.com/broadinstitute/sherlock/go-shared/pkg/utils"
+	"github.com/broadinstitute/sherlock/sherlock/internal/deprecated_models/v2models"
+	"github.com/broadinstitute/sherlock/sherlock/internal/errors"
+	"github.com/broadinstitute/sherlock/sherlock/internal/github"
+	"github.com/broadinstitute/sherlock/sherlock/internal/models"
+	github2 "github.com/google/go-github/v50/github"
+	"github.com/stretchr/testify/mock"
+	"net/http"
+)
+
+func (s *handlerSuite) TestGithubActionsDeployHooksV3TestRun_badSelector() {
+	var got errors.ErrorResponse
+	code := s.HandleRequest(
+		s.NewRequest("POST", "/api/deploy-hooks/github-actions/procedures/v3/test/foo-bar", nil),
+		&got)
+	s.Equal(http.StatusBadRequest, code)
+	s.Equal(errors.BadRequest, got.Type)
+}
+
+func (s *handlerSuite) TestGithubActionsDeployHooksV3TestRun_notFound() {
+	var got errors.ErrorResponse
+	code := s.HandleRequest(
+		s.NewRequest("POST", "/api/deploy-hooks/github-actions/procedures/v3/test/0", nil),
+		&got)
+	s.Equal(http.StatusNotFound, code)
+	s.Equal(errors.NotFound, got.Type)
+}
+
+func (s *handlerSuite) TestGithubActionsDeployHooksV3TestRun() {
+	user := s.SetSuitableTestUserForDB()
+	cluster, created, err := v2models.InternalClusterStore.Create(s.DB, v2models.Cluster{
+		Name:                "terra-dev",
+		Provider:            "google",
+		GoogleProject:       "broad-dsde-dev",
+		Base:                utils.PointerTo("live"),
+		Address:             utils.PointerTo("0.0.0.0"),
+		RequiresSuitability: utils.PointerTo(false),
+		Location:            "us-central1-a",
+		HelmfileRef:         utils.PointerTo("HEAD"),
+	}, user)
+	s.NoError(err)
+	s.True(created)
+	environment, created, err := v2models.InternalEnvironmentStore.Create(s.DB, v2models.Environment{
+		Name:                       "dev",
+		Lifecycle:                  "static",
+		UniqueResourcePrefix:       "a1b2",
+		Base:                       "live",
+		DefaultClusterID:           &cluster.ID,
+		DefaultNamespace:           "terra-dev",
+		OwnerID:                    &user.ID,
+		RequiresSuitability:        utils.PointerTo(false),
+		HelmfileRef:                utils.PointerTo("HEAD"),
+		DefaultFirecloudDevelopRef: utils.PointerTo("dev"),
+		PreventDeletion:            utils.PointerTo(false),
+	}, user)
+	s.NoError(err)
+	s.True(created)
+
+	hook := models.GithubActionsDeployHook{
+		Trigger: models.DeployHookTriggerConfig{
+			OnEnvironmentID: &environment.ID,
+		},
+		GithubActionsOwner:        utils.PointerTo("owner"),
+		GithubActionsRepo:         utils.PointerTo("repo"),
+		GithubActionsWorkflowPath: utils.PointerTo("file.yaml"),
+		GithubActionsDefaultRef:   utils.PointerTo("head"),
+		GithubActionsRefBehavior:  utils.PointerTo("always-use-default-ref"),
+	}
+	s.NoError(s.DB.Create(&hook).Error)
+
+	s.Run("no error", func() {
+		var got GithubActionsDeployHookTestRunResponse
+		github.UseMockedClient(s.T(), func(c *github.MockClient) {
+			c.Actions.EXPECT().CreateWorkflowDispatchEventByFileName(
+				mock.Anything, "owner", "repo", "file.yaml", github2.CreateWorkflowDispatchEventRequest{
+					Ref: "head",
+				}).Return(nil, nil)
+		}, func() {
+			code := s.HandleRequest(
+				s.NewRequest("POST", fmt.Sprintf("/api/deploy-hooks/github-actions/procedures/v3/test/%d", hook.ID), nil),
+				&got)
+			s.Equal(http.StatusOK, code)
+		})
+	})
+	s.Run("returns error", func() {
+		var got errors.ErrorResponse
+		// We use errors.BadRequest so that a 500 doesn't get logged during the test
+		github.UseMockedClient(s.T(), func(c *github.MockClient) {
+			c.Actions.EXPECT().CreateWorkflowDispatchEventByFileName(
+				mock.Anything, "owner", "repo", "file.yaml", github2.CreateWorkflowDispatchEventRequest{
+					Ref: "head",
+				}).Return(nil, fmt.Errorf(errors.BadRequest))
+		}, func() {
+			code := s.HandleRequest(
+				s.NewRequest("POST", fmt.Sprintf("/api/deploy-hooks/github-actions/procedures/v3/test/%d", hook.ID), nil),
+				&got)
+			s.Equal(http.StatusBadRequest, code)
+			s.Equal(errors.BadRequest, got.Message)
+		})
+	})
+}

--- a/sherlock/internal/api/sherlock/routes.go
+++ b/sherlock/internal/api/sherlock/routes.go
@@ -83,9 +83,11 @@ func ConfigureRoutes(apiRouter gin.IRoutes) {
 	apiRouter.POST("deploy-hooks/slack/v3", slackDeployHooksV3Create)
 	apiRouter.PATCH("deploy-hooks/slack/v3/*selector", slackDeployHooksV3Edit)
 	apiRouter.DELETE("deploy-hooks/slack/v3/*selector", slackDeployHooksV3Delete)
+	apiRouter.POST("deploy-hooks/slack/procedures/v3/test/*selector", slackDeployHooksV3TestRun)
 	apiRouter.GET("deploy-hooks/github-actions/v3", githubActionsDeployHooksV3List)
 	apiRouter.GET("deploy-hooks/github-actions/v3/*selector", githubActionsDeployHooksV3Get)
 	apiRouter.POST("deploy-hooks/github-actions/v3", githubActionsDeployHooksV3Create)
 	apiRouter.PATCH("deploy-hooks/github-actions/v3/*selector", githubActionsDeployHooksV3Edit)
 	apiRouter.DELETE("deploy-hooks/github-actions/v3/*selector", githubActionsDeployHooksV3Delete)
+	apiRouter.POST("deploy-hooks/github-actions/procedures/v3/test/*selector", githubActionsDeployHooksV3TestRun)
 }

--- a/sherlock/internal/api/sherlock/slack_deploy_hooks_v3_test_run.go
+++ b/sherlock/internal/api/sherlock/slack_deploy_hooks_v3_test_run.go
@@ -24,8 +24,8 @@ type SlackDeployHookTestRunResponse struct {
 //	@description	Send a Slack message to simulate a SlackDeployHook
 //	@tags			DeployHooks
 //	@produce		json
-//	@param			selector				path		string	true	"The ID of the SlackDeployHook to test"
-//	@param			request                 body SlackDeployHookTestRunRequest true "Whether to fully execute the hook (JSON body helps with CSRF protection)"
+//	@param			selector				path		string							true	"The ID of the SlackDeployHook to test"
+//	@param			request					body		SlackDeployHookTestRunRequest	true	"Whether to fully execute the hook (JSON body helps with CSRF protection)"
 //	@success		200						{object}	SlackDeployHookTestResponse
 //	@failure		400,403,404,407,409,500	{object}	errors.ErrorResponse
 //	@router			/api/deploy-hooks/slack/procedures/v3/test/{selector} [post]

--- a/sherlock/internal/api/sherlock/slack_deploy_hooks_v3_test_run.go
+++ b/sherlock/internal/api/sherlock/slack_deploy_hooks_v3_test_run.go
@@ -1,0 +1,54 @@
+package sherlock
+
+import (
+	"fmt"
+	"github.com/broadinstitute/sherlock/sherlock/internal/authentication"
+	"github.com/broadinstitute/sherlock/sherlock/internal/errors"
+	"github.com/broadinstitute/sherlock/sherlock/internal/models"
+	"github.com/broadinstitute/sherlock/sherlock/internal/slack"
+	"github.com/gin-gonic/gin"
+	"net/http"
+)
+
+type SlackDeployHookTestRunResponse struct {
+	OK bool `json:"ok"`
+}
+
+// slackDeployHooksV3TestRun godoc
+//
+//	@summary		Test a SlackDeployHook
+//	@description	Send a Slack message to simulate a SlackDeployHook
+//	@tags			DeployHooks
+//	@produce		json
+//	@param			selector				path		string	true	"The ID of the SlackDeployHook to test"
+//	@success		200						{object}	SlackDeployHookTestResponse
+//	@failure		400,403,404,407,409,500	{object}	errors.ErrorResponse
+//	@router			/api/deploy-hooks/slack/procedures/v3/test/{selector} [post]
+func slackDeployHooksV3TestRun(ctx *gin.Context) {
+	user, err := authentication.MustUseUser(ctx)
+	if err != nil {
+		return
+	}
+	db, err := authentication.MustUseDB(ctx)
+	if err != nil {
+		return
+	}
+	query, err := slackDeployHookModelFromSelector(canonicalizeSelector(ctx.Param("selector")))
+	if err != nil {
+		errors.AbortRequest(ctx, err)
+		return
+	}
+	var hook models.SlackDeployHook
+	if err = db.
+		Where(&query).
+		First(&hook).Error; err != nil {
+		errors.AbortRequest(ctx, err)
+		return
+	}
+	if err = slack.SendMessageReturnError(ctx, *hook.SlackChannel,
+		fmt.Sprintf("This is a deploy hook test message from Beehive, triggered by %s", user.SlackReference())); err != nil {
+		errors.AbortRequest(ctx, err)
+		return
+	}
+	ctx.JSON(http.StatusOK, SlackDeployHookTestRunResponse{OK: true})
+}

--- a/sherlock/internal/api/sherlock/slack_deploy_hooks_v3_test_run.go
+++ b/sherlock/internal/api/sherlock/slack_deploy_hooks_v3_test_run.go
@@ -26,7 +26,7 @@ type SlackDeployHookTestRunResponse struct {
 //	@produce		json
 //	@param			selector				path		string							true	"The ID of the SlackDeployHook to test"
 //	@param			request					body		SlackDeployHookTestRunRequest	true	"Whether to fully execute the hook (JSON body helps with CSRF protection)"
-//	@success		200						{object}	SlackDeployHookTestResponse
+//	@success		200						{object}	SlackDeployHookTestRunResponse
 //	@failure		400,403,404,407,409,500	{object}	errors.ErrorResponse
 //	@router			/api/deploy-hooks/slack/procedures/v3/test/{selector} [post]
 func slackDeployHooksV3TestRun(ctx *gin.Context) {

--- a/sherlock/internal/api/sherlock/slack_deploy_hooks_v3_test_run_test.go
+++ b/sherlock/internal/api/sherlock/slack_deploy_hooks_v3_test_run_test.go
@@ -1,0 +1,97 @@
+package sherlock
+
+import (
+	"fmt"
+	"github.com/broadinstitute/sherlock/go-shared/pkg/utils"
+	"github.com/broadinstitute/sherlock/sherlock/internal/deprecated_models/v2models"
+	"github.com/broadinstitute/sherlock/sherlock/internal/errors"
+	"github.com/broadinstitute/sherlock/sherlock/internal/models"
+	"github.com/broadinstitute/sherlock/sherlock/internal/slack"
+	"github.com/broadinstitute/sherlock/sherlock/internal/slack/slack_mocks"
+	"github.com/stretchr/testify/mock"
+	"net/http"
+)
+
+func (s *handlerSuite) TestSlackDeployHooksV3TestRun_badSelector() {
+	var got errors.ErrorResponse
+	code := s.HandleRequest(
+		s.NewRequest("POST", "/api/deploy-hooks/slack/procedures/v3/test/foo-bar", nil),
+		&got)
+	s.Equal(http.StatusBadRequest, code)
+	s.Equal(errors.BadRequest, got.Type)
+}
+
+func (s *handlerSuite) TestSlackDeployHooksV3TestRun_notFound() {
+	var got errors.ErrorResponse
+	code := s.HandleRequest(
+		s.NewRequest("POST", "/api/deploy-hooks/slack/procedures/v3/test/0", nil),
+		&got)
+	s.Equal(http.StatusNotFound, code)
+	s.Equal(errors.NotFound, got.Type)
+}
+
+func (s *handlerSuite) TestSlackDeployHooksV3TestRun() {
+	user := s.SetSuitableTestUserForDB()
+	cluster, created, err := v2models.InternalClusterStore.Create(s.DB, v2models.Cluster{
+		Name:                "terra-dev",
+		Provider:            "google",
+		GoogleProject:       "broad-dsde-dev",
+		Base:                utils.PointerTo("live"),
+		Address:             utils.PointerTo("0.0.0.0"),
+		RequiresSuitability: utils.PointerTo(false),
+		Location:            "us-central1-a",
+		HelmfileRef:         utils.PointerTo("HEAD"),
+	}, user)
+	s.NoError(err)
+	s.True(created)
+	environment, created, err := v2models.InternalEnvironmentStore.Create(s.DB, v2models.Environment{
+		Name:                       "dev",
+		Lifecycle:                  "static",
+		UniqueResourcePrefix:       "a1b2",
+		Base:                       "live",
+		DefaultClusterID:           &cluster.ID,
+		DefaultNamespace:           "terra-dev",
+		OwnerID:                    &user.ID,
+		RequiresSuitability:        utils.PointerTo(false),
+		HelmfileRef:                utils.PointerTo("HEAD"),
+		DefaultFirecloudDevelopRef: utils.PointerTo("dev"),
+		PreventDeletion:            utils.PointerTo(false),
+	}, user)
+	s.NoError(err)
+	s.True(created)
+
+	hook := models.SlackDeployHook{
+		Trigger: models.DeployHookTriggerConfig{
+			OnEnvironmentID: &environment.ID,
+		},
+		SlackChannel: utils.PointerTo("channel"),
+	}
+	s.NoError(s.DB.Create(&hook).Error)
+
+	s.Run("no error", func() {
+		var got SlackDeployHookTestRunResponse
+		slack.UseMockedClient(s.T(), func(c *slack_mocks.MockMockableClient) {
+			c.On("SendMessageContext", mock.Anything, "channel",
+				mock.AnythingOfType("slack.MsgOption")).Return("", "", "", nil)
+		}, func() {
+			code := s.HandleRequest(
+				s.NewRequest("POST", fmt.Sprintf("/api/deploy-hooks/slack/procedures/v3/test/%d", hook.ID), nil),
+				&got)
+			s.Equal(http.StatusOK, code)
+		})
+	})
+	s.Run("returns error", func() {
+		var got errors.ErrorResponse
+		// We use errors.BadRequest so that a 500 doesn't get logged during the test
+		slack.UseMockedClient(s.T(), func(c *slack_mocks.MockMockableClient) {
+			c.On("SendMessageContext", mock.Anything, "channel",
+				mock.AnythingOfType("slack.MsgOption")).Return("", "", "", fmt.Errorf(errors.BadRequest))
+		}, func() {
+			code := s.HandleRequest(
+				s.NewRequest("POST", fmt.Sprintf("/api/deploy-hooks/slack/procedures/v3/test/%d", hook.ID), nil),
+				&got)
+			s.Equal(http.StatusBadRequest, code)
+			s.Equal(errors.BadRequest, got.Message)
+		})
+	})
+}

--- a/sherlock/internal/models/user.go
+++ b/sherlock/internal/models/user.go
@@ -128,3 +128,13 @@ func (u *User) AlphaNumericHyphenatedUsername() string {
 	}
 	return string(ret)
 }
+
+func (u *User) SlackReference() string {
+	if u.SlackID != nil {
+		return fmt.Sprintf("<@%s>", *u.SlackID)
+	} else if u.Name != nil {
+		return fmt.Sprintf("<https://broad.io/beehive/r/user/%s|%s>", u.Email, *u.Name)
+	} else {
+		return fmt.Sprintf("<https://broad.io/beehive/r/user/%s|%s>", u.Email, u.Email)
+	}
+}

--- a/sherlock/internal/slack/send_message.go
+++ b/sherlock/internal/slack/send_message.go
@@ -35,6 +35,12 @@ func (g RedBlock) toSlackAttachment() slack.Attachment {
 }
 
 func SendMessage(ctx context.Context, channel string, text string, attachments ...Attachment) {
+	if err := SendMessageReturnError(ctx, channel, text, attachments...); err != nil {
+		log.Warn().Err(err).Msgf("SLCK | unable to send message to %s: %v", channel, err)
+	}
+}
+
+func SendMessageReturnError(ctx context.Context, channel string, text string, attachments ...Attachment) error {
 	if isEnabled() && (text != "" || len(attachments) > 0) {
 		var options []slack.MsgOption
 		if text != "" {
@@ -45,8 +51,8 @@ func SendMessage(ctx context.Context, channel string, text string, attachments .
 				utils.Map(attachments, func(a Attachment) slack.Attachment { return a.toSlackAttachment() })...,
 			))
 		}
-		if _, _, _, err := client.SendMessageContext(ctx, channel, options...); err != nil {
-			log.Warn().Err(err).Msgf("SLCK | unable to send message to %s: %v", channel, err)
-		}
+		_, _, _, err := client.SendMessageContext(ctx, channel, options...)
+		return err
 	}
+	return nil
 }


### PR DESCRIPTION
Adds endpoints to manually trigger deploy hooks. This is really just intended for test purposes, though I recognize that it could be misused. The endpoints require a minimal JSON body as protection against CSRF.

## Testing

Mocked both Slack and GitHub to do this. Took quite a bit longer than writing the actual API endpoints, might not've bothered if I'd known it was going to take that long. Whatever, done now.

## Risk

Extremely low