### PR TITLE
[DDO-3290] Stop escaping text sent to Slack's API

### DIFF
--- a/sherlock/internal/slack/send_message.go
+++ b/sherlock/internal/slack/send_message.go
@@ -38,7 +38,7 @@ func SendMessage(ctx context.Context, channel string, text string, attachments .
 	if isEnabled() && (text != "" || len(attachments) > 0) {
 		var options []slack.MsgOption
 		if text != "" {
-			options = append(options, slack.MsgOptionText(text, true))
+			options = append(options, slack.MsgOptionText(text, false))
 		}
 		if len(attachments) > 0 {
 			options = append(options, slack.MsgOptionAttachments(


### PR DESCRIPTION
All the mocks in the world don't help if you're explicitly telling the Slack library to escape the all-important `<` and `>` characters. Whatever.

<img width="622" alt="Screenshot 2023-11-03 at 12 43 40 PM" src="https://github.com/broadinstitute/sherlock/assets/29168264/5ec90a42-103c-4b03-bc0a-da5cb5acfba2">

## Testing

Well I dove into the library code to see that it was explicitly escaping "<" and ">". I don't know, I think trying to write tests around the library's outward HTTP behavior is more brittle than it is worth.

## Risk

Very low.