### PR TITLE
[DDO-3289] Improve error text in deploy hook test routes

### DIFF
--- a/sherlock/internal/api/sherlock/github_actions_deploy_hooks_v3_test_run.go
+++ b/sherlock/internal/api/sherlock/github_actions_deploy_hooks_v3_test_run.go
@@ -80,7 +80,7 @@ func githubActionsDeployHooksV3TestRun(ctx *gin.Context) {
 		*hook.GithubActionsWorkflowPath,
 		*hook.GithubActionsDefaultRef,
 		workflowInputs); err != nil {
-		errors.AbortRequest(ctx, err)
+		errors.AbortRequest(ctx, fmt.Errorf("error between Sherlock and GitHub: %w", err))
 		return
 	}
 	ctx.JSON(http.StatusOK, GithubActionsDeployHookTestRunResponse{

--- a/sherlock/internal/api/sherlock/github_actions_deploy_hooks_v3_test_run_test.go
+++ b/sherlock/internal/api/sherlock/github_actions_deploy_hooks_v3_test_run_test.go
@@ -123,7 +123,7 @@ func (s *handlerSuite) TestGithubActionsDeployHooksV3TestRun() {
 					GithubActionsDeployHookTestRunRequest{Execute: utils.PointerTo(true)}),
 				&got)
 			s.Equal(http.StatusBadRequest, code)
-			s.Equal(errors.BadRequest, got.Message)
+			s.Equal(fmt.Sprintf("error between Sherlock and GitHub: %s", errors.BadRequest), got.Message)
 		})
 	})
 }

--- a/sherlock/internal/api/sherlock/slack_deploy_hooks_v3_test_run.go
+++ b/sherlock/internal/api/sherlock/slack_deploy_hooks_v3_test_run.go
@@ -66,7 +66,7 @@ func slackDeployHooksV3TestRun(ctx *gin.Context) {
 	}
 	if err = slack.SendMessageReturnError(ctx, *hook.SlackChannel,
 		fmt.Sprintf("This is a deploy hook test message from Beehive, triggered by %s", user.SlackReference())); err != nil {
-		errors.AbortRequest(ctx, err)
+		errors.AbortRequest(ctx, fmt.Errorf("error between Sherlock and Slack: %w", err))
 		return
 	}
 	ctx.JSON(http.StatusOK, SlackDeployHookTestRunResponse{OK: true})

--- a/sherlock/internal/api/sherlock/slack_deploy_hooks_v3_test_run_test.go
+++ b/sherlock/internal/api/sherlock/slack_deploy_hooks_v3_test_run_test.go
@@ -115,7 +115,7 @@ func (s *handlerSuite) TestSlackDeployHooksV3TestRun() {
 					SlackDeployHookTestRunRequest{Execute: utils.PointerTo(true)}),
 				&got)
 			s.Equal(http.StatusBadRequest, code)
-			s.Equal(errors.BadRequest, got.Message)
+			s.Equal(fmt.Sprintf("error between Sherlock and Slack: %s", errors.BadRequest), got.Message)
 		})
 	})
 }


### PR DESCRIPTION
```diff
-		errors.AbortRequest(ctx, err)
+		errors.AbortRequest(ctx, fmt.Errorf("error between Sherlock and GitHub: %w", err))
```

## Testing

This case is fully covered by tests, updated them

## Risk

None