### PR TITLE
[DDO-3325] Remove hooks parallelism and fix callback variable reuse

### DIFF
--- a/sherlock/config/default_config.yaml
+++ b/sherlock/config/default_config.yaml
@@ -10,9 +10,7 @@ hooks:
   # to the third-party-specific flags elsewhere in this file.
   enable: true
   # If true, hooks will be run asynchronously after the initial call into the
-  # hooks package. This flag doesn't affect parallelism within the hooks package,
-  # it just changes whether hooks will be run before or possibly after the initial
-  # call returns.
+  # hooks package.
   asynchronous: true
 
 log:

--- a/sherlock/internal/hooks/dispatch.go
+++ b/sherlock/internal/hooks/dispatch.go
@@ -7,7 +7,6 @@ import (
 	"github.com/broadinstitute/sherlock/sherlock/internal/models"
 	"github.com/broadinstitute/sherlock/sherlock/internal/slack"
 	"gorm.io/gorm"
-	"sync"
 )
 
 // Dispatch runs hooks or other actions based on the given models.CiRun.
@@ -30,25 +29,18 @@ func Dispatch(db *gorm.DB, ciRun models.CiRun) {
 }
 
 func dispatch(db *gorm.DB, ciRun models.CiRun) {
-	slackCallbacks := collectSlackNotificationCallbacks(db, ciRun)
-	deployHookCallbacks, errs := collectDeployHookCallbacks(db, ciRun)
-	callbacks := append(slackCallbacks, deployHookCallbacks...)
+	slackCallbacks, slackCollectCallbackErrors := collectSlackNotificationCallbacks(db, ciRun)
+	deployHookCallbacks, deployHookCollectCallbackErrors := collectDeployHookCallbacks(db, ciRun)
+	errs := append(slackCollectCallbackErrors, deployHookCollectCallbackErrors...)
 
-	if len(callbacks) > 0 {
-		var waitGroup sync.WaitGroup
-		var errsMutex sync.Mutex
-		waitGroup.Add(len(callbacks))
-		for _, callback := range callbacks {
-			go func(callback func() error) {
-				defer waitGroup.Done()
-				if err := callback(); err != nil {
-					errsMutex.Lock()
-					errs = append(errs, err)
-					errsMutex.Unlock()
-				}
-			}(callback)
+	// You'd think that we could do this in parallel with Goroutines. You'd be mostly correct -- Gorm is
+	// Goroutine-safe -- except when we run tests, the *gorm.DB is actually a transaction, and transactions
+	// are not Goroutine-safe. PGX is what will actually complain, saying "conn busy". So we do this
+	// serially, which isn't a huge deal since Dispatch above will already be asynchronous.
+	for _, callback := range append(slackCallbacks, deployHookCallbacks...) {
+		if err := callback(); err != nil {
+			errs = append(errs, err)
 		}
-		waitGroup.Wait()
 	}
 
 	if len(errs) > 0 {
@@ -56,7 +48,7 @@ func dispatch(db *gorm.DB, ciRun models.CiRun) {
 	}
 }
 
-func collectSlackNotificationCallbacks(db *gorm.DB, ciRun models.CiRun) (callbacks []func() error) {
+func collectSlackNotificationCallbacks(db *gorm.DB, ciRun models.CiRun) (callbacks []func() error, errs []error) {
 	callbacks = make([]func() error, 0)
 	if ciRun.TerminalAt != nil {
 		var channelsToNotify []string
@@ -65,16 +57,19 @@ func collectSlackNotificationCallbacks(db *gorm.DB, ciRun models.CiRun) (callbac
 		} else {
 			channelsToNotify = ciRun.NotifySlackChannelsUponFailure
 		}
-		if len(channelsToNotify) > 0 {
-			for _, channel := range channelsToNotify {
+		var text string
+		text, errs = ciRun.SlackCompletionText(db)
+		if len(channelsToNotify) > 0 && text != "" {
+			for _, unsafeChannel := range channelsToNotify {
+				channel := unsafeChannel
 				callbacks = append(callbacks, func() error {
 					return dispatcher.DispatchSlackCompletionNotification(
-						db.Statement.Context, channel, ciRun.SlackCompletionText(db), ciRun.Succeeded())
+						db.Statement.Context, channel, text, ciRun.Succeeded())
 				})
 			}
 		}
 	}
-	return callbacks
+	return callbacks, errs
 }
 
 func collectDeployHookCallbacks(db *gorm.DB, ciRun models.CiRun) (callbacks []func() error, errs []error) {

--- a/sherlock/internal/hooks/dispatch.go
+++ b/sherlock/internal/hooks/dispatch.go
@@ -59,6 +59,7 @@ func collectSlackNotificationCallbacks(db *gorm.DB, ciRun models.CiRun) (callbac
 		}
 		var text string
 		text, errs = ciRun.SlackCompletionText(db)
+		// Even if we got errors, if we have text then send it
 		if len(channelsToNotify) > 0 && text != "" {
 			for _, unsafeChannel := range channelsToNotify {
 				channel := unsafeChannel

--- a/sherlock/internal/models/ci_run_test.go
+++ b/sherlock/internal/models/ci_run_test.go
@@ -622,7 +622,9 @@ func (s *modelSuite) TestCiRun_MakeCompletionNotificationText() {
 				NotifySlackChannelsUponFailure: tt.fields.NotifySlackChannelsUponFailure,
 				ResourceStatus:                 tt.fields.ResourceStatus,
 			}
-			s.Equalf(tt.want, c.SlackCompletionText(s.DB), "SlackCompletionText()")
+			got, errs := c.SlackCompletionText(s.DB)
+			s.Empty(errs)
+			s.Equalf(tt.want, got, "SlackCompletionText()")
 		})
 	}
 }

--- a/sherlock/internal/models/test_data.go
+++ b/sherlock/internal/models/test_data.go
@@ -1240,8 +1240,8 @@ func (td *testDataImpl) CiRun_Deploy_LeonardoDev_V1toV3() CiRun {
 			StartedAt:                      utils.PointerTo(td.Changeset_LeonardoDev_V1toV3().AppliedAt.Add(30 * time.Second)),
 			TerminalAt:                     utils.PointerTo(td.Changeset_LeonardoDev_V1toV3().AppliedAt.Add(10 * time.Minute)),
 			Status:                         utils.PointerTo("success"),
-			NotifySlackChannelsUponSuccess: []string{"#ap-k8s-monitor"},
-			NotifySlackChannelsUponFailure: []string{"#ap-k8s-monitor"},
+			NotifySlackChannelsUponSuccess: []string{"#dsde-qa", "#ap-k8s-monitor"},
+			NotifySlackChannelsUponFailure: []string{"#dsde-qa", "#ap-k8s-monitor"},
 		}
 		td.create(&td.ciRun_deploy_leonardoDev_v1toV3)
 


### PR DESCRIPTION
- Removes parallelism from deploy hook dispatching because it was causing test-only failures, see https://broadinstitute.slack.com/archives/CQ6SL4N5T/p1701185908549649. Note that this entire process will always run asynchronous to the request in release mode, so it running sequentially isn't a big deal.
- Properly treats variables initialized with `range` as unsafe for reference in callbacks, see https://github.com/broadinstitute/sherlock/compare/DDO-3325-fix-hooks?expand=1#diff-72f437d900a508a1a0357ad8a1115546d77593ad763bb809e92f6fcdb50b6677R64. This was causing any CiRuns with multiple channels configured to send multiple notifications to just one of those channels, because the `channel` variable was getting reassigned.
- Return errors from the function that calculates completion text -- those errors won't interrupt execution but by returning them they'll get reported like other dispatch errors

## Tests

Mocked tests have been updated to specifically cover this case

## Risk

Very low