### PR TITLE
[DDO-3381] Improve error reporting to Slack

### DIFF
--- a/sherlock/internal/api/sherlock/ci_runs_v3_upsert.go
+++ b/sherlock/internal/api/sherlock/ci_runs_v3_upsert.go
@@ -415,7 +415,7 @@ WHERE
     AND ci_identifiers.resource_type = 'chart-release' 
     AND ci_identifiers.resource_id = ?
 `, status, result.ID, chartReleaseID).Error; err != nil {
-			slack.ReportError(ctx, fmt.Errorf("error recording chart release status in ci_runs_for_identifiers table for CiRun %d and ChartRelease %d: %w", result.ID, chartReleaseID, err))
+			slack.ReportError(ctx, fmt.Sprintf("error recording chart release status in ci_runs_for_identifiers table for CiRun %d and ChartRelease %d", result.ID, chartReleaseID), err)
 		}
 		// 2. The identifier is for a "changeset" where the changeset's chart release ID matches our chart release ID
 		//		(We have to do this one separately because this one needs a join, and the operation above shouldn't
@@ -435,7 +435,7 @@ WHERE
     AND changesets.chart_release_id = ?
 RETURNING changesets.id
 `, status, result.ID, chartReleaseID).Scan(&changesetIDs).Error; err != nil {
-			slack.ReportError(ctx, fmt.Errorf("error recording changeset status in ci_runs_for_identifiers table for CiRun %d and ChartRelease %d: %w", result.ID, chartReleaseID, err))
+			slack.ReportError(ctx, fmt.Sprintf("error recording changeset status in ci_runs_for_identifiers table for CiRun %d and ChartRelease %d", result.ID, chartReleaseID), err)
 		}
 		for _, changesetID := range changesetIDs {
 			// If there were changesets from step 2:
@@ -453,7 +453,7 @@ WHERE
     AND ci_identifiers.resource_type = 'app-version'
     AND changeset_new_app_versions.changeset_id = ?
 `, status, result.ID, changesetID).Error; err != nil {
-				slack.ReportError(ctx, fmt.Errorf("error recording app version status in ci_runs_for_identifiers table for CiRun %d and ChartRelease %d via Changeset %d: %w", result.ID, chartReleaseID, changesetID, err))
+				slack.ReportError(ctx, fmt.Sprintf("error recording app version status in ci_runs_for_identifiers table for CiRun %d and ChartRelease %d via Changeset %d", result.ID, chartReleaseID, changesetID), err)
 			}
 			// 4. The identifier is for a new chart version on that changeset
 			if err = db.Exec(
@@ -469,7 +469,7 @@ WHERE
     AND ci_identifiers.resource_type = 'chart-version'
     AND changeset_new_chart_versions.changeset_id = ?
 `, status, result.ID, changesetID).Error; err != nil {
-				slack.ReportError(ctx, fmt.Errorf("error recording chart version status in ci_runs_for_identifiers table for CiRun %d and ChartRelease %d via Changeset %d: %w", result.ID, chartReleaseID, changesetID, err))
+				slack.ReportError(ctx, fmt.Sprintf("error recording chart version status in ci_runs_for_identifiers table for CiRun %d and ChartRelease %d via Changeset %d", result.ID, chartReleaseID, changesetID), err)
 			}
 		}
 	}

--- a/sherlock/internal/authentication/gha_oidc/parse_header.go
+++ b/sherlock/internal/authentication/gha_oidc/parse_header.go
@@ -35,7 +35,7 @@ func ParseHeader(ctx *gin.Context) (*gha_oidc_claims.Claims, error) {
 		}
 	}
 	if !repositoryOwnerAccepted {
-		slack.ReportError(ctx, fmt.Errorf("observed a GHA OIDC JWT from %s and ignored it because %s was not an allowed organization in Sherlock's config", claims.Repository, claims.RepositoryOwner))
+		slack.ReportError[error](ctx, fmt.Sprintf("observed a GHA OIDC JWT from %s and ignored it because %s was not an allowed organization in Sherlock's config", claims.Repository, claims.RepositoryOwner))
 		return nil, nil
 	}
 	return &claims, nil

--- a/sherlock/internal/boot/middleware/logger_test.go
+++ b/sherlock/internal/boot/middleware/logger_test.go
@@ -1,0 +1,74 @@
+package middleware
+
+import (
+	"fmt"
+	"github.com/broadinstitute/sherlock/go-shared/pkg/utils"
+	"github.com/broadinstitute/sherlock/sherlock/internal/config"
+	"github.com/broadinstitute/sherlock/sherlock/internal/slack"
+	"github.com/broadinstitute/sherlock/sherlock/internal/slack/slack_mocks"
+	"github.com/gin-gonic/gin"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestLogger(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	config.LoadTestConfig()
+	zerolog.SetGlobalLevel(zerolog.Disabled)
+	router := gin.New()
+	router.Use(Logger())
+	router.GET("/:code", func(c *gin.Context) {
+		code, err := utils.ParseInt(c.Param("code"))
+		assert.NoError(t, err)
+		if code > 399 {
+			_ = c.Error(fmt.Errorf("code %d error", code))
+		}
+		c.JSON(code, gin.H{})
+	})
+
+	t.Run("400 doesn't send anything", func(t *testing.T) {
+		slack.UseMockedClient(t, func(_ *slack_mocks.MockMockableClient) {}, func() {
+			recorder := httptest.NewRecorder()
+			request := httptest.NewRequest("GET", "/400", nil)
+			router.ServeHTTP(recorder, request)
+
+			assert.Equal(t, http.StatusBadRequest, recorder.Code)
+		})
+	})
+	t.Run("407 sends", func(t *testing.T) {
+		slack.UseMockedClient(t, func(c *slack_mocks.MockMockableClient) {
+			c.On("SendMessageContext", mock.Anything, "channel 1",
+				mock.AnythingOfType("slack.MsgOption"),
+				mock.AnythingOfType("slack.MsgOption")).Return("", "", "", nil)
+			c.On("SendMessageContext", mock.Anything, "channel 2",
+				mock.AnythingOfType("slack.MsgOption"),
+				mock.AnythingOfType("slack.MsgOption")).Return("", "", "", nil)
+		}, func() {
+			recorder := httptest.NewRecorder()
+			request := httptest.NewRequest("GET", "/407", nil)
+			router.ServeHTTP(recorder, request)
+
+			assert.Equal(t, http.StatusProxyAuthRequired, recorder.Code)
+		})
+	})
+	t.Run("500 sends", func(t *testing.T) {
+		slack.UseMockedClient(t, func(c *slack_mocks.MockMockableClient) {
+			c.On("SendMessageContext", mock.Anything, "channel 1",
+				mock.AnythingOfType("slack.MsgOption"),
+				mock.AnythingOfType("slack.MsgOption")).Return("", "", "", nil)
+			c.On("SendMessageContext", mock.Anything, "channel 2",
+				mock.AnythingOfType("slack.MsgOption"),
+				mock.AnythingOfType("slack.MsgOption")).Return("", "", "", nil)
+		}, func() {
+			recorder := httptest.NewRecorder()
+			request := httptest.NewRequest("GET", "/500", nil)
+			router.ServeHTTP(recorder, request)
+
+			assert.Equal(t, http.StatusInternalServerError, recorder.Code)
+		})
+	})
+}

--- a/sherlock/internal/boot/router.go
+++ b/sherlock/internal/boot/router.go
@@ -14,7 +14,6 @@ import (
 	"github.com/broadinstitute/sherlock/sherlock/internal/deprecated_handlers/v2handlers"
 	"github.com/broadinstitute/sherlock/sherlock/internal/errors"
 	"github.com/broadinstitute/sherlock/sherlock/internal/metrics"
-	"github.com/broadinstitute/sherlock/sherlock/internal/slack"
 	"github.com/gin-gonic/gin"
 	swaggo_files "github.com/swaggo/files"
 	swaggo_gin "github.com/swaggo/gin-swagger"
@@ -52,8 +51,7 @@ func BuildRouter(ctx context.Context, db *gorm.DB) *gin.Engine {
 
 	router.Use(
 		gin.Recovery(),
-		middleware.Logger(config.Config.String("mode") == "debug"),
-		slack.ErrorReportingMiddleware(ctx),
+		middleware.Logger(),
 		middleware.Headers())
 
 	// Replace Gin's standard fallback responses with our standard error format for friendlier client behavior

--- a/sherlock/internal/hooks/dispatch.go
+++ b/sherlock/internal/hooks/dispatch.go
@@ -44,7 +44,7 @@ func dispatch(db *gorm.DB, ciRun models.CiRun) {
 	}
 
 	if len(errs) > 0 {
-		slack.ReportError(db.Statement.Context, append([]error{fmt.Errorf("encountered %d errors dispatching for CiRun %d", len(errs), ciRun.ID)}, errs...)...)
+		slack.ReportError(db.Statement.Context, fmt.Sprintf("encountered %d errors dispatching for CiRun %d", len(errs), ciRun.ID), errs...)
 	}
 }
 

--- a/sherlock/internal/slack/report_error.go
+++ b/sherlock/internal/slack/report_error.go
@@ -5,57 +5,26 @@ import (
 	"fmt"
 	"github.com/broadinstitute/sherlock/go-shared/pkg/utils"
 	"github.com/broadinstitute/sherlock/sherlock/internal/config"
-	"github.com/gin-gonic/gin"
 	"github.com/rs/zerolog/log"
 )
 
-func ReportError(ctx context.Context, errs ...error) {
-	if isEnabled() && config.Config.Bool("slack.behaviors.errors.enable") && len(errs) > 0 {
-
-		var messageText string
-		if len(errs) == 1 {
-			messageText = "Sherlock encountered an unexpected error:"
-			log.Info().Err(errs[0]).Msgf("SLCK | reporting error: %v", errs[0])
-		} else {
-			messageText = fmt.Sprintf("Sherlock encountered %d unexpected errors:", len(errs))
-			log.Info().Errs("errors", errs).Msgf("SLCK | reporting %d errors, starting with: %v", len(errs), errs[0])
-		}
-
-		attachments := utils.Map(errs, func(e error) Attachment { return RedBlock{Text: e.Error()} })
-
+// ReportError has a funky type to handle "fancy" errors returned by some packages like Gin.
+//
+// If you ever get compiler complaints about being unable to infer the generic type (usually
+// if you don't have a true error to pass in), you can do something like this:
+// slack.ReportError[error](ctx, "blah")
+func ReportError[E interface {
+	Error() string
+}](ctx context.Context, description string, errs ...E) {
+	strings := utils.Map(errs, func(e E) string { return e.Error() })
+	if isEnabled() && config.Config.Bool("slack.behaviors.errors.enable") {
+		log.Info().Strs("errors", strings).Str("description", description).Msgf("SLCK | reporting %d errors: %s", len(strings), description)
+		messageText := fmt.Sprintf("Sherlock error: %s", description)
+		attachments := utils.Map(strings, func(s string) Attachment { return RedBlock{Text: s} })
 		for _, channel := range config.Config.Strings("slack.behaviors.errors.channels") {
 			SendMessage(ctx, channel, messageText, attachments...)
 		}
 	} else if config.Config.String("mode") == "debug" {
-		log.Warn().Errs("errors", errs).Msg("Slack disabled in debug mode; would've reported errors if enabled")
-	}
-}
-
-func ErrorReportingMiddleware(outerCtx context.Context) gin.HandlerFunc {
-	return func(ctx *gin.Context) {
-		ctx.Next()
-
-		if utils.Contains(config.Config.Ints("slack.behaviors.errors.statusCodes"), ctx.Writer.Status()) &&
-			isEnabled() && config.Config.Bool("slack.behaviors.errors.enable") {
-
-			callback := func(ctx context.Context, status int, errors []*gin.Error) {
-				if len(errors) > 0 {
-					for _, err := range errors {
-						ReportError(ctx, err)
-					}
-				} else {
-					ReportError(ctx, fmt.Errorf("unknown %d error (handler didn't attach errors to Gin context)", status))
-				}
-			}
-
-			// Offline, call this synchronously so we can actually test it.
-			// We're using the outerCtx mainly for the goroutine case, where we're running this function outside
-			// the literal and figurative context of the handler.
-			if config.Config.String("mode") == "debug" {
-				callback(outerCtx, ctx.Writer.Status(), ctx.Errors)
-			} else {
-				go callback(outerCtx, ctx.Writer.Status(), ctx.Errors)
-			}
-		}
+		log.Warn().Strs("errors", strings).Str("description", description).Msg("Slack disabled in debug mode; would've reported errors if enabled")
 	}
 }

--- a/sherlock/internal/slack/report_error_test.go
+++ b/sherlock/internal/slack/report_error_test.go
@@ -36,9 +36,14 @@ func TestReportError(t *testing.T) {
 			},
 		},
 		{
-			name:       "sends no errors",
-			args:       args{errs: []error{}},
-			mockConfig: func(c *slack_mocks.MockMockableClient) {},
+			name: "sends no errors",
+			args: args{errs: []error{}},
+			mockConfig: func(c *slack_mocks.MockMockableClient) {
+				c.On("SendMessageContext", ctx, "channel 1",
+					mock.AnythingOfType("slack.MsgOption")).Return("", "", "", nil)
+				c.On("SendMessageContext", ctx, "channel 2",
+					mock.AnythingOfType("slack.MsgOption")).Return("", "", "", nil)
+			},
 		},
 		{
 			name: "sends multiple errors",

--- a/sherlock/internal/slack/report_error_test.go
+++ b/sherlock/internal/slack/report_error_test.go
@@ -3,15 +3,10 @@ package slack
 import (
 	"context"
 	"fmt"
-	"github.com/broadinstitute/sherlock/go-shared/pkg/utils"
 	"github.com/broadinstitute/sherlock/sherlock/internal/config"
 	"github.com/broadinstitute/sherlock/sherlock/internal/slack/slack_mocks"
-	"github.com/gin-gonic/gin"
 	"github.com/rs/zerolog"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	"net/http"
-	"net/http/httptest"
 	"testing"
 )
 
@@ -20,7 +15,8 @@ func TestReportError(t *testing.T) {
 	zerolog.SetGlobalLevel(zerolog.Disabled)
 	ctx := context.Background()
 	type args struct {
-		errs []error
+		description string
+		errs        []error
 	}
 	tests := []struct {
 		name       string
@@ -90,67 +86,8 @@ func TestReportError(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			UseMockedClient(t, tt.mockConfig, func() {
-				ReportError(ctx, tt.args.errs...)
+				ReportError(ctx, tt.args.description, tt.args.errs...)
 			})
 		})
 	}
-}
-
-func TestErrorReportingMiddleware(t *testing.T) {
-	gin.SetMode(gin.TestMode)
-	config.LoadTestConfig()
-	zerolog.SetGlobalLevel(zerolog.Disabled)
-	ctx := context.Background()
-	router := gin.New()
-	router.Use(ErrorReportingMiddleware(ctx))
-	router.GET("/:code", func(c *gin.Context) {
-		code, err := utils.ParseInt(c.Param("code"))
-		assert.NoError(t, err)
-		if code > 399 {
-			_ = c.Error(fmt.Errorf("code %d error", code))
-		}
-		c.JSON(code, gin.H{})
-	})
-
-	t.Run("400 doesn't send anything", func(t *testing.T) {
-		UseMockedClient(t, func(_ *slack_mocks.MockMockableClient) {}, func() {
-			recorder := httptest.NewRecorder()
-			request := httptest.NewRequest("GET", "/400", nil)
-			router.ServeHTTP(recorder, request)
-
-			assert.Equal(t, http.StatusBadRequest, recorder.Code)
-		})
-	})
-	t.Run("407 sends", func(t *testing.T) {
-		UseMockedClient(t, func(c *slack_mocks.MockMockableClient) {
-			c.On("SendMessageContext", ctx, "channel 1",
-				mock.AnythingOfType("slack.MsgOption"),
-				mock.AnythingOfType("slack.MsgOption")).Return("", "", "", nil)
-			c.On("SendMessageContext", ctx, "channel 2",
-				mock.AnythingOfType("slack.MsgOption"),
-				mock.AnythingOfType("slack.MsgOption")).Return("", "", "", nil)
-		}, func() {
-			recorder := httptest.NewRecorder()
-			request := httptest.NewRequest("GET", "/407", nil)
-			router.ServeHTTP(recorder, request)
-
-			assert.Equal(t, http.StatusProxyAuthRequired, recorder.Code)
-		})
-	})
-	t.Run("500 sends", func(t *testing.T) {
-		UseMockedClient(t, func(c *slack_mocks.MockMockableClient) {
-			c.On("SendMessageContext", ctx, "channel 1",
-				mock.AnythingOfType("slack.MsgOption"),
-				mock.AnythingOfType("slack.MsgOption")).Return("", "", "", nil)
-			c.On("SendMessageContext", ctx, "channel 2",
-				mock.AnythingOfType("slack.MsgOption"),
-				mock.AnythingOfType("slack.MsgOption")).Return("", "", "", nil)
-		}, func() {
-			recorder := httptest.NewRecorder()
-			request := httptest.NewRequest("GET", "/500", nil)
-			router.ServeHTTP(recorder, request)
-
-			assert.Equal(t, http.StatusInternalServerError, recorder.Code)
-		})
-	})
 }


### PR DESCRIPTION
Right now the errors are just dumped without context. This PR merges the error reporting middleware with the request-aware logging middleware so we can include request info in the error report without creating an import cycle.

## Testing

Added mocked testing for the logger middleware to validate that it indeed sends Slack messages how we'd want

## Risk

Very low