### PR TITLE
[DDO-3384] Avoid nil pointer dereferences in Pact Broker code

### DIFF
--- a/sherlock/internal/deprecated_models/v2models/changeset.go
+++ b/sherlock/internal/deprecated_models/v2models/changeset.go
@@ -292,7 +292,9 @@ func (s *internalChangesetStore) apply(db *gorm.DB, changesets []Changeset, user
 				)
 			}
 			// Record app version to Pact broker
-			if chartRelease.Environment != nil && chartRelease.Chart.PactParticipant != nil && *chartRelease.Chart.PactParticipant && chartRelease.Environment.PactIdentifier != nil {
+			if chartRelease.Environment != nil && chartRelease.Environment.PactIdentifier != nil &&
+				chartRelease.Chart != nil && chartRelease.Chart.PactParticipant != nil && *chartRelease.Chart.PactParticipant &&
+				chartRelease.AppVersion != nil && chartRelease.AppVersion.AppVersion != "" {
 				go pactbroker.RecordDeployment(
 					chartRelease.Chart.Name,
 					chartRelease.AppVersion.AppVersion,


### PR DESCRIPTION
It's possible for chartRelease.AppVersion to be nil if the chartRelease doesn't correlate to an entry in the app version table -- for instance, [if a hotfixed version is being released](https://broadinstitute.slack.com/archives/C6DTFUCDD/p1702505132671549).

That means it isn't safe for this code to blindly use chartRelease.AppVersion.AppVersion. This was blocking promotions.