### PR TITLE
[DDO-3402] Address spurious duplicates when saving deploy hooks

### DIFF
--- a/sherlock/internal/api/sherlock/app_version_v3_edit.go
+++ b/sherlock/internal/api/sherlock/app_version_v3_edit.go
@@ -50,7 +50,7 @@ func appVersionsV3Edit(ctx *gin.Context) {
 		return
 	}
 
-	if err = db.Model(&toEdit).Updates(&edits).Error; err != nil {
+	if err = db.Model(&toEdit).Omit(clause.Associations).Updates(&edits).Error; err != nil {
 		errors.AbortRequest(ctx, err)
 		return
 	}

--- a/sherlock/internal/api/sherlock/chart_version_v3_edit.go
+++ b/sherlock/internal/api/sherlock/chart_version_v3_edit.go
@@ -50,7 +50,7 @@ func chartVersionsV3Edit(ctx *gin.Context) {
 		return
 	}
 
-	if err = db.Model(&toEdit).Updates(&edits).Error; err != nil {
+	if err = db.Model(&toEdit).Omit(clause.Associations).Updates(&edits).Error; err != nil {
 		errors.AbortRequest(ctx, err)
 		return
 	}

--- a/sherlock/internal/api/sherlock/charts_v3_edit.go
+++ b/sherlock/internal/api/sherlock/charts_v3_edit.go
@@ -46,7 +46,7 @@ func chartsV3Edit(ctx *gin.Context) {
 		return
 	}
 
-	if err = db.Model(&toEdit).Updates(&edits).Error; err != nil {
+	if err = db.Model(&toEdit).Omit(clause.Associations).Updates(&edits).Error; err != nil {
 		errors.AbortRequest(ctx, err)
 		return
 	}

--- a/sherlock/internal/api/sherlock/ci_runs_v3_upsert.go
+++ b/sherlock/internal/api/sherlock/ci_runs_v3_upsert.go
@@ -483,7 +483,7 @@ WHERE
 		if len(body.NotifySlackChannelsUponFailure) > 0 {
 			channelUpdates.NotifySlackChannelsUponFailure = utils.Dedupe(append(result.NotifySlackChannelsUponFailure, body.NotifySlackChannelsUponFailure...))
 		}
-		if err = db.Model(&result).Updates(&channelUpdates).Error; err != nil {
+		if err = db.Model(&result).Omit(clause.Associations).Updates(&channelUpdates).Error; err != nil {
 			errors.AbortRequest(ctx, err)
 			return
 		}

--- a/sherlock/internal/api/sherlock/clusters_v3_edit.go
+++ b/sherlock/internal/api/sherlock/clusters_v3_edit.go
@@ -46,7 +46,7 @@ func clustersV3Edit(ctx *gin.Context) {
 		return
 	}
 
-	if err = db.Model(&toEdit).Updates(&edits).Error; err != nil {
+	if err = db.Model(&toEdit).Omit(clause.Associations).Updates(&edits).Error; err != nil {
 		errors.AbortRequest(ctx, err)
 		return
 	}

--- a/sherlock/internal/api/sherlock/github_actions_deploy_hooks_v3_edit.go
+++ b/sherlock/internal/api/sherlock/github_actions_deploy_hooks_v3_edit.go
@@ -6,6 +6,7 @@ import (
 	"github.com/broadinstitute/sherlock/sherlock/internal/errors"
 	"github.com/broadinstitute/sherlock/sherlock/internal/models"
 	"github.com/gin-gonic/gin"
+	"gorm.io/gorm/clause"
 	"net/http"
 )
 
@@ -70,12 +71,12 @@ func githubActionsDeployHooksV3Edit(ctx *gin.Context) {
 		return
 	}
 
-	if err = db.Model(&toEdit).Updates(&edits).Error; err != nil {
+	if err = db.Model(&toEdit).Omit(clause.Associations).Updates(&edits).Error; err != nil {
 		errors.AbortRequest(ctx, err)
 		return
 	}
 
-	if err = db.Model(&toEdit.Trigger).Updates(&edits.Trigger).Error; err != nil {
+	if err = db.Model(&toEdit.Trigger).Omit(clause.Associations).Updates(&edits.Trigger).Error; err != nil {
 		errors.AbortRequest(ctx, err)
 		return
 	}

--- a/sherlock/internal/api/sherlock/slack_deploy_hooks_v3_edit.go
+++ b/sherlock/internal/api/sherlock/slack_deploy_hooks_v3_edit.go
@@ -7,6 +7,7 @@ import (
 	"github.com/broadinstitute/sherlock/sherlock/internal/models"
 	"github.com/broadinstitute/sherlock/sherlock/internal/slack"
 	"github.com/gin-gonic/gin"
+	"gorm.io/gorm/clause"
 	"net/http"
 )
 
@@ -68,12 +69,12 @@ func slackDeployHooksV3Edit(ctx *gin.Context) {
 		return
 	}
 
-	if err = db.Model(&toEdit).Updates(&edits).Error; err != nil {
+	if err = db.Model(&toEdit).Omit(clause.Associations).Updates(&edits).Error; err != nil {
 		errors.AbortRequest(ctx, err)
 		return
 	}
 
-	if err = db.Model(&toEdit.Trigger).Updates(&edits.Trigger).Error; err != nil {
+	if err = db.Model(&toEdit.Trigger).Omit(clause.Associations).Updates(&edits.Trigger).Error; err != nil {
 		errors.AbortRequest(ctx, err)
 		return
 	}

--- a/sherlock/internal/api/sherlock/slack_deploy_hooks_v3_edit_test.go
+++ b/sherlock/internal/api/sherlock/slack_deploy_hooks_v3_edit_test.go
@@ -211,3 +211,35 @@ func (s *handlerSuite) TestSlackDeployHooksV3Edit() {
 		}
 	})
 }
+
+func (s *handlerSuite) TestSlackDeployHooksV3Edit_SpuriousDuplicates() {
+	// DDO-3402
+
+	bee := s.TestData.Environment_Swatomation_DevBee()
+
+	// Create a deploy hook on the BEE
+	hook := models.SlackDeployHook{
+		Trigger: models.DeployHookTriggerConfig{
+			OnEnvironmentID: &bee.ID,
+		},
+		SlackChannel: utils.PointerTo("channel"),
+	}
+	s.NoError(s.DB.Create(&hook).Error)
+
+	// Number of chart releases in the BEE
+	var chartReleasesInBee []models.ChartRelease
+	s.NoError(s.DB.Unscoped().Where(&models.ChartRelease{EnvironmentID: &bee.ID}).Find(&chartReleasesInBee).Error)
+	startingChartReleases := len(chartReleasesInBee)
+	s.Greater(startingChartReleases, 0)
+
+	// No-op deploy hook edit
+	var got SlackDeployHookV3
+	code := s.HandleRequest(
+		s.NewRequest("PATCH", fmt.Sprintf("/api/deploy-hooks/slack/v3/%d", hook.ID), SlackDeployHookV3Edit{}),
+		&got)
+	s.Equal(http.StatusOK, code)
+
+	// No duplicate chart releases
+	s.NoError(s.DB.Unscoped().Where(&models.ChartRelease{EnvironmentID: &bee.ID}).Find(&chartReleasesInBee).Error)
+	s.Len(chartReleasesInBee, startingChartReleases)
+}


### PR DESCRIPTION
Gorm seems to be operating on data it shouldn't (data not referenced in the inputs it is being given). This is causing chart releases to be duplicated when saving deploy hooks. There's more data in the ticket but here we've got tests reproducing the problem, a fix for the problem, and a roll out of the fix to other semantically similar spots in Sherlock.

## Test

Failing test was added and then made to pass

## Risk

Low. Can't be worse than how it is currently lol