### PR TITLE
[DDO-3403] Filter out stub CiRuns by default #minor

### DIFF
--- a/sherlock/internal/api/sherlock/ci_identifiers_v3_get.go
+++ b/sherlock/internal/api/sherlock/ci_identifiers_v3_get.go
@@ -15,16 +15,17 @@ import (
 
 // ciIdentifiersV3Get godoc
 //
-//	@summary		Get CiRuns for a resource by its CiIdentifier
-//	@description	Get CiRuns for a resource by its CiIdentifier, which can be referenced by '{type}/{selector...}'.
-//	@tags			CiIdentifiers
-//	@produce		json
-//	@param			selector				path		string	true	"The selector of CiIdentifier, which can be referenced either by numeric ID or indirectly by '{type}/{selector...}'"
-//	@param			limitCiRuns				query		int		false	"Control how many CiRuns are returned (default 10)"
-//	@param			offsetCiRuns			query		int		false	"Control the offset for the returned CiRuns (default 0)"
-//	@success		200						{object}	CiIdentifierV3
-//	@failure		400,403,404,407,409,500	{object}	errors.ErrorResponse
-//	@router			/api/ci-identifiers/v3/{selector} [get]
+//		@summary		Get CiRuns for a resource by its CiIdentifier
+//		@description	Get CiRuns for a resource by its CiIdentifier, which can be referenced by '{type}/{selector...}'.
+//		@tags			CiIdentifiers
+//		@produce		json
+//		@param			selector				path		string	true	"The selector of CiIdentifier, which can be referenced either by numeric ID or indirectly by '{type}/{selector...}'"
+//		@param			limitCiRuns				query		int		false	"Control how many CiRuns are returned (default 10)"
+//		@param			offsetCiRuns			query		int		false	"Control the offset for the returned CiRuns (default 0)"
+//	    @param          allowStubCiRuns         query       bool    false   "Allow stub CiRuns potentially lacking fields like status or startedAt to be returned (default false)"
+//		@success		200						{object}	CiIdentifierV3
+//		@failure		400,403,404,407,409,500	{object}	errors.ErrorResponse
+//		@router			/api/ci-identifiers/v3/{selector} [get]
 func ciIdentifiersV3Get(ctx *gin.Context) {
 	db, err := authentication.MustUseDB(ctx)
 	if err != nil {
@@ -45,9 +46,14 @@ func ciIdentifiersV3Get(ctx *gin.Context) {
 		errors.AbortRequest(ctx, fmt.Errorf("(%s) %v", errors.BadRequest, err))
 		return
 	}
+	allowStubCiRuns := ctx.DefaultQuery("allowStubCiRuns", "false") == "true"
 	var result models.CiIdentifier
 	if err = db.Preload("CiRuns", func(tx *gorm.DB) *gorm.DB {
-		return tx.Limit(limitCiRuns).Offset(offsetCiRuns).Order("started_at desc")
+		if allowStubCiRuns {
+			return tx.Limit(limitCiRuns).Offset(offsetCiRuns).Order("created_at desc")
+		} else {
+			return tx.Where("status != '' AND status IS NOT NULL AND started_at IS NOT NULL").Limit(limitCiRuns).Offset(offsetCiRuns).Order("started_at desc")
+		}
 	}).Where(&query).First(&result).Error; err != nil {
 		errors.AbortRequest(ctx, err)
 		return

--- a/sherlock/internal/api/sherlock/ci_identifiers_v3_get.go
+++ b/sherlock/internal/api/sherlock/ci_identifiers_v3_get.go
@@ -15,17 +15,17 @@ import (
 
 // ciIdentifiersV3Get godoc
 //
-//		@summary		Get CiRuns for a resource by its CiIdentifier
-//		@description	Get CiRuns for a resource by its CiIdentifier, which can be referenced by '{type}/{selector...}'.
-//		@tags			CiIdentifiers
-//		@produce		json
-//		@param			selector				path		string	true	"The selector of CiIdentifier, which can be referenced either by numeric ID or indirectly by '{type}/{selector...}'"
-//		@param			limitCiRuns				query		int		false	"Control how many CiRuns are returned (default 10)"
-//		@param			offsetCiRuns			query		int		false	"Control the offset for the returned CiRuns (default 0)"
-//	    @param          allowStubCiRuns         query       bool    false   "Allow stub CiRuns potentially lacking fields like status or startedAt to be returned (default false)"
-//		@success		200						{object}	CiIdentifierV3
-//		@failure		400,403,404,407,409,500	{object}	errors.ErrorResponse
-//		@router			/api/ci-identifiers/v3/{selector} [get]
+//	@summary		Get CiRuns for a resource by its CiIdentifier
+//	@description	Get CiRuns for a resource by its CiIdentifier, which can be referenced by '{type}/{selector...}'.
+//	@tags			CiIdentifiers
+//	@produce		json
+//	@param			selector				path		string	true	"The selector of CiIdentifier, which can be referenced either by numeric ID or indirectly by '{type}/{selector...}'"
+//	@param			limitCiRuns				query		int		false	"Control how many CiRuns are returned (default 10)"
+//	@param			offsetCiRuns			query		int		false	"Control the offset for the returned CiRuns (default 0)"
+//	@param			allowStubCiRuns			query		bool	false	"Allow stub CiRuns potentially lacking fields like status or startedAt to be returned (default false)"
+//	@success		200						{object}	CiIdentifierV3
+//	@failure		400,403,404,407,409,500	{object}	errors.ErrorResponse
+//	@router			/api/ci-identifiers/v3/{selector} [get]
 func ciIdentifiersV3Get(ctx *gin.Context) {
 	db, err := authentication.MustUseDB(ctx)
 	if err != nil {

--- a/sherlock/internal/api/sherlock/ci_identifiers_v3_get_test.go
+++ b/sherlock/internal/api/sherlock/ci_identifiers_v3_get_test.go
@@ -283,6 +283,7 @@ func (s *handlerSuite) TestCiIdentifiersV3GetLimitRuns() {
 					GithubActionsWorkflowPath:  "workflow",
 					// Higher IDs started more recently, just for convenience in testing
 					StartedAt: utils.PointerTo(time.Now().Add(-time.Hour).Add(time.Minute * time.Duration(iteration))),
+					Status:    utils.PointerTo("in progress"),
 				},
 				Charts: []string{"leonardo"},
 			}),

--- a/sherlock/internal/api/sherlock/ci_identifiers_v3_get_test.go
+++ b/sherlock/internal/api/sherlock/ci_identifiers_v3_get_test.go
@@ -348,3 +348,23 @@ func (s *handlerSuite) TestCiIdentifiersV3Get_ResourceStatus() {
 		s.NotNil(cr.ResourceStatus)
 	}
 }
+
+func (s *handlerSuite) TestCiIdentifiersV3Get_allowStubCiRuns() {
+	s.TestData.CiRun_Deploy_LeonardoDev_V1toV3()
+	// Stub doesn't have status or started_at info
+	s.TestData.CiRun_Stub_LeonardoDev()
+	var got CiIdentifierV3
+	code := s.HandleRequest(
+		s.NewRequest(http.MethodGet, "/api/ci-identifiers/v3/chart-release/dev/leonardo?allowStubCiRuns=true", nil),
+		&got)
+	s.Equal(http.StatusOK, code)
+	s.Len(got.CiRuns, 2)
+	code = s.HandleRequest(
+		s.NewRequest(http.MethodGet, "/api/ci-identifiers/v3/chart-release/dev/leonardo?allowStubCiRuns=false", nil),
+		&got)
+	s.Len(got.CiRuns, 1)
+	code = s.HandleRequest(
+		s.NewRequest(http.MethodGet, "/api/ci-identifiers/v3/chart-release/dev/leonardo", nil),
+		&got)
+	s.Len(got.CiRuns, 1)
+}

--- a/sherlock/internal/api/sherlock/ci_identifiers_v3_get_test.go
+++ b/sherlock/internal/api/sherlock/ci_identifiers_v3_get_test.go
@@ -362,9 +362,11 @@ func (s *handlerSuite) TestCiIdentifiersV3Get_allowStubCiRuns() {
 	code = s.HandleRequest(
 		s.NewRequest(http.MethodGet, "/api/ci-identifiers/v3/chart-release/dev/leonardo?allowStubCiRuns=false", nil),
 		&got)
+	s.Equal(http.StatusOK, code)
 	s.Len(got.CiRuns, 1)
 	code = s.HandleRequest(
 		s.NewRequest(http.MethodGet, "/api/ci-identifiers/v3/chart-release/dev/leonardo", nil),
 		&got)
+	s.Equal(http.StatusOK, code)
 	s.Len(got.CiRuns, 1)
 }

--- a/sherlock/internal/models/test_data.go
+++ b/sherlock/internal/models/test_data.go
@@ -91,6 +91,7 @@ type TestData interface {
 	CiIdentifier_Changeset_LeonardoDev_V1toV3() CiIdentifier
 
 	CiRun_Deploy_LeonardoDev_V1toV3() CiRun
+	CiRun_Stub_LeonardoDev() CiRun
 
 	SlackDeployHook_Dev() SlackDeployHook
 
@@ -185,6 +186,7 @@ type testDataImpl struct {
 	ciIdentifier_changeset_leonardoDev_v1toV3 CiIdentifier
 
 	ciRun_deploy_leonardoDev_v1toV3 CiRun
+	ciRun_stub_leonardoDev          CiRun
 
 	slackDeployHook_dev SlackDeployHook
 
@@ -1265,6 +1267,26 @@ func (td *testDataImpl) CiRun_Deploy_LeonardoDev_V1toV3() CiRun {
 		}
 	}
 	return td.ciRun_deploy_leonardoDev_v1toV3
+}
+
+func (td *testDataImpl) CiRun_Stub_LeonardoDev() CiRun {
+	if td.ciRun_stub_leonardoDev.ID == 0 {
+		td.ciRun_stub_leonardoDev = CiRun{
+			Platform:                   "github-actions",
+			GithubActionsOwner:         "broadinstitute",
+			GithubActionsRepo:          "terra-github-workflows",
+			GithubActionsRunID:         111111111,
+			GithubActionsAttemptNumber: 1,
+			GithubActionsWorkflowPath:  ".github/workflows/some-weird-workflow.yaml",
+			RelatedResources: []CiIdentifier{
+				td.CiIdentifier_Cluster_TerraDev(),
+				td.CiIdentifier_Environment_Dev(),
+				td.CiIdentifier_ChartRelease_LeonardoDev(),
+			},
+		}
+		td.create(&td.ciRun_stub_leonardoDev)
+	}
+	return td.ciRun_stub_leonardoDev
 }
 
 func (td *testDataImpl) SlackDeployHook_Dev() SlackDeployHook {


### PR DESCRIPTION
It's technically valid for a CiRun to not have a status or startedAt field, but we _usually_ don't want to see those CiRuns in the API. This PR makes the /api/ci-identifiers/v3/{selector} [get] endpoint not return them by default. This is a breaking change technically but it's breaking in the way we want, so I'm judging it worthy of just a minor version bump and no fanfare.

## Testing

Added test data and a test for both sides of the flag and the default

## Risk

Very low