### PR TITLE
[DDO-3400] Remove Slack beta flag from database

### DIFF
--- a/sherlock/db/migrations/000070_remove_slack_beta_flag.down.sql
+++ b/sherlock/db/migrations/000070_remove_slack_beta_flag.down.sql
@@ -1,0 +1,2 @@
+alter table slack_deploy_hooks
+    add column if not exists beta bool;

--- a/sherlock/db/migrations/000070_remove_slack_beta_flag.up.sql
+++ b/sherlock/db/migrations/000070_remove_slack_beta_flag.up.sql
@@ -1,0 +1,2 @@
+alter table slack_deploy_hooks
+    drop column if exists beta;


### PR DESCRIPTION
Now that #428 is deployed, this flag can be removed

## Testing

Tests run fine without the column present in the database

## Risk

Very low