### PR TITLE
[DDO-3422] Handle base ref better for the API diff action

### DIFF
--- a/.github/workflows/sherlock-api-diff.yaml
+++ b/.github/workflows/sherlock-api-diff.yaml
@@ -28,7 +28,6 @@ jobs:
       - name: Checkout Base
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.base_ref }}
           path: base
           persist-credentials: false
 


### PR DESCRIPTION
By not specifying it, we'll use the automatic "merge commit" that GHA makes for pull_request workflows. This will avoid spurious "the API will remove the following endpoints!" in PRs that need their branch updated

## Testing

It works fine in this action, see below

## Risk

Very very low