### PR TITLE
[DDO-3430] Deduplicate deploy hook triggers

### DIFF
--- a/sherlock/internal/hooks/dispatch.go
+++ b/sherlock/internal/hooks/dispatch.go
@@ -144,6 +144,8 @@ func collectDeployHookCallbacks(db *gorm.DB, ciRun models.CiRun) (callbacks []fu
 			deduplicatedDeployHookTriggers = append(deduplicatedDeployHookTriggers, potentialDeployHookTrigger)
 		}
 
+		slackHooks := make([]models.SlackDeployHook, 0)
+		githubActionsHooks := make([]models.GithubActionsDeployHook, 0)
 		for _, deployHookTrigger := range deduplicatedDeployHookTriggers {
 			if deployHookTrigger.HookType == "slack" {
 				var hook models.SlackDeployHook
@@ -155,9 +157,7 @@ func collectDeployHookCallbacks(db *gorm.DB, ciRun models.CiRun) (callbacks []fu
 					errs = append(errs, fmt.Errorf("failed to get SlackDeployHook for DeployHookTriggerConfig ID %d: %w", deployHookTrigger.ID, err))
 					continue
 				}
-				callbacks = append(callbacks, func() error {
-					return dispatcher.DispatchSlackDeployHook(db, hook, ciRun)
-				})
+				slackHooks = append(slackHooks, hook)
 			} else if deployHookTrigger.HookType == "github-actions" {
 				var hook models.GithubActionsDeployHook
 				if err := db.
@@ -168,12 +168,22 @@ func collectDeployHookCallbacks(db *gorm.DB, ciRun models.CiRun) (callbacks []fu
 					errs = append(errs, fmt.Errorf("failed to get GithubActionsDeployHook for DeployHookTriggerConfig ID %d: %w", deployHookTrigger.ID, err))
 					continue
 				}
-				callbacks = append(callbacks, func() error {
-					return dispatcher.DispatchGithubActionsDeployHook(db, hook, ciRun)
-				})
+				githubActionsHooks = append(githubActionsHooks, hook)
 			} else {
 				errs = append(errs, fmt.Errorf("unknown DeployHookTriggerConfig %d hook type '%s'", deployHookTrigger.ID, deployHookTrigger.HookType))
 			}
+		}
+		for _, unsafe := range models.DeduplicateSlackDeployHooks(slackHooks) {
+			slackHook := unsafe
+			callbacks = append(callbacks, func() error {
+				return dispatcher.DispatchSlackDeployHook(db, slackHook, ciRun)
+			})
+		}
+		for _, unsafe := range models.DeduplicateGithubActionsDeployHooks(githubActionsHooks) {
+			githubActionsHook := unsafe
+			callbacks = append(callbacks, func() error {
+				return dispatcher.DispatchGithubActionsDeployHook(db, githubActionsHook, ciRun)
+			})
 		}
 	}
 	return callbacks, errs

--- a/sherlock/internal/hooks/dispatch_test.go
+++ b/sherlock/internal/hooks/dispatch_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/broadinstitute/sherlock/sherlock/internal/config"
 	"github.com/broadinstitute/sherlock/sherlock/internal/hooks/hooks_mocks"
+	"github.com/broadinstitute/sherlock/sherlock/internal/models"
 	"github.com/broadinstitute/sherlock/sherlock/internal/slack"
 	"github.com/broadinstitute/sherlock/sherlock/internal/slack/slack_mocks"
 	"github.com/stretchr/testify/mock"
@@ -13,6 +14,63 @@ func (s *hooksSuite) TestDispatch_hooks() {
 	ciRun := s.TestData.CiRun_Deploy_LeonardoDev_V1toV3()
 	s.TestData.SlackDeployHook_Dev()
 	s.TestData.GithubActionsDeployHook_LeonardoDev()
+	completionText, errs := ciRun.SlackCompletionText(s.DB)
+	s.Empty(errs)
+	slack.UseMockedClient(s.T(), func(c *slack_mocks.MockMockableClient) {}, func() {
+		UseMockedDispatcher(s.T(), func(d *hooks_mocks.MockMockableDispatcher) {
+			for _, channel := range ciRun.NotifySlackChannelsUponSuccess {
+				d.EXPECT().DispatchSlackCompletionNotification(
+					mock.Anything,
+					channel,
+					completionText,
+					ciRun.Succeeded()).
+					Return(nil).Once()
+			}
+			d.EXPECT().DispatchSlackDeployHook(
+				mock.Anything,
+				mock.Anything,
+				ciRun).Return(nil).Once()
+			d.EXPECT().DispatchGithubActionsDeployHook(
+				mock.Anything,
+				mock.Anything,
+				ciRun).Return(nil).Once()
+		}, func() {
+			Dispatch(s.DB, ciRun)
+		})
+	})
+}
+
+func (s *hooksSuite) TestDispatch_duplicateHooks() {
+	ciRun := s.TestData.CiRun_Deploy_LeonardoDev_V1toV3()
+
+	// Create two Slack hooks
+	slackHook := s.TestData.SlackDeployHook_Dev()
+	s.NoError(s.DB.Create(&models.SlackDeployHook{
+		Trigger: models.DeployHookTriggerConfig{
+			OnEnvironmentID: slackHook.Trigger.OnEnvironmentID,
+			OnSuccess:       slackHook.Trigger.OnSuccess,
+			OnFailure:       slackHook.Trigger.OnFailure,
+		},
+		SlackChannel:  slackHook.SlackChannel,
+		MentionPeople: slackHook.MentionPeople,
+	}).Error)
+
+	// Create two Github Actions hooks
+	ghaHook := s.TestData.GithubActionsDeployHook_LeonardoDev()
+	s.NoError(s.DB.Create(&models.GithubActionsDeployHook{
+		Trigger: models.DeployHookTriggerConfig{
+			OnChartReleaseID: ghaHook.Trigger.OnChartReleaseID,
+			OnSuccess:        ghaHook.Trigger.OnSuccess,
+			OnFailure:        ghaHook.Trigger.OnFailure,
+		},
+		GithubActionsOwner:          ghaHook.GithubActionsOwner,
+		GithubActionsRepo:           ghaHook.GithubActionsRepo,
+		GithubActionsWorkflowPath:   ghaHook.GithubActionsWorkflowPath,
+		GithubActionsDefaultRef:     ghaHook.GithubActionsDefaultRef,
+		GithubActionsRefBehavior:    ghaHook.GithubActionsRefBehavior,
+		GithubActionsWorkflowInputs: ghaHook.GithubActionsWorkflowInputs,
+	}).Error)
+
 	completionText, errs := ciRun.SlackCompletionText(s.DB)
 	s.Empty(errs)
 	slack.UseMockedClient(s.T(), func(c *slack_mocks.MockMockableClient) {}, func() {

--- a/sherlock/internal/hooks/dispatch_test.go
+++ b/sherlock/internal/hooks/dispatch_test.go
@@ -82,7 +82,8 @@ func (s *hooksSuite) TestDispatch_duplicateHooks() {
 					mock.Anything,
 					channel,
 					completionText,
-					ciRun.Succeeded()).
+					ciRun.Succeeded(),
+					ciRun.NotifySlackCustomIcon).
 					Return(nil).Once()
 			}
 			d.EXPECT().DispatchSlackDeployHook(

--- a/sherlock/internal/models/github_actions_deploy_hook.go
+++ b/sherlock/internal/models/github_actions_deploy_hook.go
@@ -1,8 +1,10 @@
 package models
 
 import (
+	"encoding/json"
 	"gorm.io/datatypes"
 	"gorm.io/gorm"
+	"reflect"
 )
 
 type GithubActionsDeployHook struct {
@@ -22,4 +24,84 @@ func (g *GithubActionsDeployHook) AfterSave(tx *gorm.DB) error {
 
 func (g *GithubActionsDeployHook) AfterDelete(tx *gorm.DB) error {
 	return g.Trigger.ErrorIfForbidden(tx)
+}
+
+// DeduplicateGithubActionsDeployHooks tries to deduplicate GithubActionsDeployHooks so that the same workflow won't be
+// triggered twice. It checks for equality of basic fields, inputs, and ref (where the ref willalways be the same, by
+// comparing triggered-upon resource IDs, instead of trying to calculate the actual ref).
+// The stability isn't as important here as it is for DeduplicateSlackDeployHooks, because there's no replacement logic
+// going on here (so order doesn't matter).
+func DeduplicateGithubActionsDeployHooks(hooks []GithubActionsDeployHook) []GithubActionsDeployHook {
+	deduplicatedHooks := make([]GithubActionsDeployHook, 0)
+	for _, potentialNewHook := range hooks {
+		if potentialNewHook.GithubActionsOwner != nil &&
+			potentialNewHook.GithubActionsRepo != nil &&
+			potentialNewHook.GithubActionsWorkflowPath != nil &&
+			potentialNewHook.GithubActionsDefaultRef != nil &&
+			potentialNewHook.GithubActionsRefBehavior != nil {
+			shouldAppend := true
+			for _, existingHook := range deduplicatedHooks {
+				if existingHook.GithubActionsOwner != nil &&
+					existingHook.GithubActionsRepo != nil &&
+					existingHook.GithubActionsWorkflowPath != nil &&
+					existingHook.GithubActionsDefaultRef != nil &&
+					existingHook.GithubActionsRefBehavior != nil {
+
+					basicFieldsDoNotMatch := !(*existingHook.GithubActionsOwner == *potentialNewHook.GithubActionsOwner &&
+						*existingHook.GithubActionsRepo == *potentialNewHook.GithubActionsRepo &&
+						*existingHook.GithubActionsWorkflowPath == *potentialNewHook.GithubActionsWorkflowPath &&
+						*existingHook.GithubActionsDefaultRef == *potentialNewHook.GithubActionsDefaultRef &&
+						*existingHook.GithubActionsRefBehavior == *potentialNewHook.GithubActionsRefBehavior)
+
+					triggerDefinitelyMatches := (existingHook.Trigger.OnEnvironmentID != nil &&
+						potentialNewHook.Trigger.OnEnvironmentID != nil &&
+						*existingHook.Trigger.OnEnvironmentID == *potentialNewHook.Trigger.OnEnvironmentID) ||
+						(existingHook.Trigger.OnChartReleaseID != nil &&
+							potentialNewHook.Trigger.OnChartReleaseID != nil &&
+							*existingHook.Trigger.OnChartReleaseID == *potentialNewHook.Trigger.OnChartReleaseID)
+					triggerMattersAndMightNotMatch := *potentialNewHook.GithubActionsRefBehavior != "always-use-default-ref" &&
+						!triggerDefinitelyMatches
+
+					oneHasInputsAndOtherDoesNot := (existingHook.GithubActionsWorkflowInputs != nil &&
+						potentialNewHook.GithubActionsWorkflowInputs == nil) ||
+						(existingHook.GithubActionsWorkflowInputs == nil &&
+							potentialNewHook.GithubActionsWorkflowInputs != nil)
+
+					if basicFieldsDoNotMatch || triggerMattersAndMightNotMatch || oneHasInputsAndOtherDoesNot {
+						continue
+					}
+
+					// Now we do a comparatively-expensive check to see if the inputs are the same
+					if existingHook.GithubActionsWorkflowInputs != nil && potentialNewHook.GithubActionsWorkflowInputs != nil {
+						var existingInputBytes, potentialInputBytes []byte
+						var existingInputs, potentialInputs any
+						var err error
+						if existingInputBytes, err = existingHook.GithubActionsWorkflowInputs.MarshalJSON(); err != nil {
+							continue
+						} else if potentialInputBytes, err = potentialNewHook.GithubActionsWorkflowInputs.MarshalJSON(); err != nil {
+							continue
+						} else if len(existingInputBytes) > 0 || len(potentialInputBytes) > 0 {
+							// If both byte strings are empty, we don't want to try parsing those because that'll be an
+							// error, we just want to continue on to the duplicate case
+							if err = json.Unmarshal(existingInputBytes, &existingInputs); err != nil {
+								continue
+							} else if err = json.Unmarshal(potentialInputBytes, &potentialInputs); err != nil {
+								continue
+							} else if !reflect.DeepEqual(existingInputs, potentialInputs) {
+								continue
+							}
+						}
+					}
+
+					// If we get here, we have a duplicate!
+					shouldAppend = false
+					break
+				}
+			}
+			if shouldAppend {
+				deduplicatedHooks = append(deduplicatedHooks, potentialNewHook)
+			}
+		}
+	}
+	return deduplicatedHooks
 }

--- a/sherlock/internal/models/slack_deploy_hook.go
+++ b/sherlock/internal/models/slack_deploy_hook.go
@@ -18,3 +18,54 @@ func (s *SlackDeployHook) AfterSave(tx *gorm.DB) error {
 func (s *SlackDeployHook) AfterDelete(tx *gorm.DB) error {
 	return s.Trigger.ErrorIfForbidden(tx)
 }
+
+// DeduplicateSlackDeployHooks tries to deduplicate SlackDeployHooks in a stable fashion, so that the same channel
+// won't be notified twice. It prioritizes hooks triggered based on environments, hooks that mention users, and hooks
+// with later createdAt timestamps.
+// The stability is important here because SlackDeployHookState is joined between SlackDeployHook and CiRun (so we want
+// to always return the same SlackDeployHooks from this function given the same input, even if in different orders).
+func DeduplicateSlackDeployHooks(hooks []SlackDeployHook) []SlackDeployHook {
+	deduplicatedHooks := make([]SlackDeployHook, 0)
+	for _, potentialNewHook := range hooks {
+		if potentialNewHook.SlackChannel != nil {
+			shouldAppend := true
+			for existingIdx, existingHook := range deduplicatedHooks {
+				if existingHook.SlackChannel != nil && *existingHook.SlackChannel == *potentialNewHook.SlackChannel {
+					// Duplicate found!
+					// We definitely won't be appending now
+					shouldAppend = false
+
+					// Now we need to determine if the potential should replace the existing
+					// Rather than a bunch of boolean logic, we just assign a score to each and the highest score wins
+					potentialScore := potentialNewHook.dedupeWinnerScore()
+					existingScore := existingHook.dedupeWinnerScore()
+					if potentialNewHook.CreatedAt.After(existingHook.CreatedAt) {
+						potentialScore += 1
+					} else {
+						existingScore += 1
+					}
+					if potentialScore > existingScore {
+						deduplicatedHooks[existingIdx] = potentialNewHook
+					}
+
+					break
+				}
+			}
+			if shouldAppend {
+				deduplicatedHooks = append(deduplicatedHooks, potentialNewHook)
+			}
+		}
+	}
+	return deduplicatedHooks
+}
+
+func (s *SlackDeployHook) dedupeWinnerScore() uint {
+	var score uint
+	if s.Trigger.OnEnvironmentID != nil {
+		score += 5
+	}
+	if s.MentionPeople != nil && *s.MentionPeople {
+		score += 3
+	}
+	return score
+}


### PR DESCRIPTION
Currently, each deploy hook triggers upon a matching deploy hook. This PR adds a deduplication process, so that a given deployment won't send multiple messages to the same Slack channel or run the same GitHub Action multiple times the exact same way simultaneously.

This does _not_ worry about anything across multiple deployments (so concurrent deployments might run the same GHA concurrently or send messages to the same channel, but that's what we want).

This solves two important cases:
- Three chart releases in staging all have the same GHA configured as a deploy hook. The nightly dev -> staging currently causes it to be run three times. Now it'll just run once
- If you have one channel subscribed to messages for both alpha and staging, and something deploys to both environments simultaneously (like Beehive's app view page), that currently sends two messages. Now it'll just send one, since they have the same content anyway

## Testing

Unit tested deduplication functions and a top-level mocked test to make sure duplicates no longer result in duplicate external calls

## Risk

Technical risk very low, usability risk low (will communicate this change in behavior to the QA folks who will notice the lack of duplicate test invocations)