### PR TITLE
[DDO-3436] Allow customizing the Slack icon for CiRun completion messages

### DIFF
--- a/.github/workflows/client-report-workflow.yaml
+++ b/.github/workflows/client-report-workflow.yaml
@@ -7,7 +7,7 @@ name: Report GitHub Actions Workflow
 # "dsp-tools-iap-access@dsp-tools-k8s.iam.gserviceaccount.com" service account; steps 1 and 2 of the documentation:
 # https://docs.google.com/document/d/1bnhDmWQHAMat_Saoa_z28FHwXmGWw6kywjdbKf208h4/edit
 #
-# With that configured, here's an example of how you can call this workflow:
+# With that configured, here's an example of how you can call this workflow (all fields optional and many more available):
 # ```yaml
 # jobs:
 #
@@ -16,6 +16,7 @@ name: Report GitHub Actions Workflow
 #     with:
 #       relates-to-chart-releases: leonardo-dev
 #       notify-slack-channels-upon-workflow-completion: "#workbench-resilience-dev"
+#       notify-slack-custom-icon: ":terra:"
 #     permissions:
 #       id-token: write
 # ```
@@ -53,6 +54,15 @@ on:
           Slack channels that Beehive should notify when this workflow fails.
           
           Multiple slack channels can be provided by separating them with whitespace and/or commas.
+
+      notify-slack-custom-icon:
+        required: false
+        type: string
+        description: |
+          A custom icon to use for any of the above Slack notifications. Can be given either as a
+          public image URL or as a Slack emoji in colon-shortcode format (e.g. ":smiley:").
+          
+          If not provided, Beehive's icon will be used.
 
       #
       # Workflow relations
@@ -223,6 +233,7 @@ jobs:
               charts: process.env.CHARTS.split(/[\s,]+/).filter(Boolean),
               changesets: process.env.CHANGESETS.split(/[\s,]+/).filter(Boolean),
 
+              notifySlackCustomIcon: "${{ inputs.notify-slack-custom-icon }}",
               relateToChangesetNewVersions: "${{ inputs.relate-to-changeset-new-versions }}",
               ignoreBadSelectors: ${{ inputs.ignore-bad-selectors }},
 

--- a/sherlock/db/migrations/000072_add_ci_run_notification_icon.down.sql
+++ b/sherlock/db/migrations/000072_add_ci_run_notification_icon.down.sql
@@ -1,0 +1,2 @@
+alter table ci_runs
+    drop column if exists notify_slack_custom_icon;

--- a/sherlock/db/migrations/000072_add_ci_run_notification_icon.up.sql
+++ b/sherlock/db/migrations/000072_add_ci_run_notification_icon.up.sql
@@ -1,0 +1,2 @@
+alter table ci_runs
+    add column if not exists notify_slack_custom_icon text;

--- a/sherlock/internal/api/sherlock/ci_runs_v3.go
+++ b/sherlock/internal/api/sherlock/ci_runs_v3.go
@@ -33,6 +33,7 @@ type ciRunFields struct {
 	// Slack channels to notify if this CiRun fails. This field is always appended to when mutated.
 	NotifySlackChannelsUponFailure []string `json:"notifySlackChannelsUponFailure,omitempty" form:"notifySlackChannelsUponFailure"`
 	// Icon to use for success or failure Slack notifications. Can be given either as a URL to an image or as a Slack emoji (using colon shortcodes, like :smiley:).
+	// An empty string is ignored to facilitate calling from GitHub Actions (where it's easier to pass an empty string than not send the field at all).
 	NotifySlackCustomIcon *string `json:"notifySlackCustomIcon,omitempty" form:"notifySlackCustomIcon"`
 }
 

--- a/sherlock/internal/api/sherlock/ci_runs_v3.go
+++ b/sherlock/internal/api/sherlock/ci_runs_v3.go
@@ -32,6 +32,8 @@ type ciRunFields struct {
 	NotifySlackChannelsUponSuccess []string `json:"notifySlackChannelsUponSuccess,omitempty" form:"notifySlackChannelsUponSuccess"`
 	// Slack channels to notify if this CiRun fails. This field is always appended to when mutated.
 	NotifySlackChannelsUponFailure []string `json:"notifySlackChannelsUponFailure,omitempty" form:"notifySlackChannelsUponFailure"`
+	// Icon to use for success or failure Slack notifications. Can be given either as a URL to an image or as a Slack emoji (using colon shortcodes, like :smiley:).
+	NotifySlackCustomIcon *string `json:"notifySlackCustomIcon,omitempty" form:"notifySlackCustomIcon"`
 }
 
 func (c CiRunV3) toModel() models.CiRun {
@@ -50,6 +52,7 @@ func (c CiRunV3) toModel() models.CiRun {
 		StartedAt:                    c.StartedAt,
 		TerminalAt:                   c.TerminalAt,
 		Status:                       c.Status,
+		NotifySlackCustomIcon:        c.NotifySlackCustomIcon,
 	}
 }
 
@@ -78,6 +81,7 @@ func ciRunFromModel(model models.CiRun) CiRunV3 {
 			Status:                         model.Status,
 			NotifySlackChannelsUponSuccess: model.NotifySlackChannelsUponSuccess,
 			NotifySlackChannelsUponFailure: model.NotifySlackChannelsUponFailure,
+			NotifySlackCustomIcon:          model.NotifySlackCustomIcon,
 		},
 		TerminationHooksDispatchedAt: model.TerminationHooksDispatchedAt,
 		RelatedResources:             relatedResources,

--- a/sherlock/internal/api/sherlock/ci_runs_v3_upsert.go
+++ b/sherlock/internal/api/sherlock/ci_runs_v3_upsert.go
@@ -70,6 +70,13 @@ func ciRunsV3Upsert(ctx *gin.Context) {
 		return
 	}
 
+	// The notifySlackCustomIcon has some special handling noted in the API docs -- if it's empty, we ignore it here,
+	// so that GitHub Actions etc. can just always send the field and don't have to worry about doing conditional
+	// stuff to omit the field entirely.
+	if body.NotifySlackCustomIcon != nil && *body.NotifySlackCustomIcon == "" {
+		body.NotifySlackCustomIcon = nil
+	}
+
 	// Opportunistically fill empty fields with information passed in the GHA OIDC JWT
 	if body.Platform == "" || body.Platform == "github-actions" {
 		var claims *gha_oidc_claims.Claims

--- a/sherlock/internal/api/sherlock/ci_runs_v3_upsert.go
+++ b/sherlock/internal/api/sherlock/ci_runs_v3_upsert.go
@@ -383,9 +383,10 @@ addingToDeduplicatedRelatedResources:
 		ArgoWorkflowsName:          body.ArgoWorkflowsName,
 		ArgoWorkflowsTemplate:      body.ArgoWorkflowsTemplate,
 	}).Assign(&models.CiRun{
-		StartedAt:  body.StartedAt,
-		TerminalAt: body.TerminalAt,
-		Status:     body.Status,
+		StartedAt:             body.StartedAt,
+		TerminalAt:            body.TerminalAt,
+		Status:                body.Status,
+		NotifySlackCustomIcon: body.NotifySlackCustomIcon,
 	}).FirstOrCreate(&result).Error; err != nil {
 		errors.AbortRequest(ctx, err)
 		return

--- a/sherlock/internal/api/sherlock/ci_runs_v3_upsert_test.go
+++ b/sherlock/internal/api/sherlock/ci_runs_v3_upsert_test.go
@@ -41,6 +41,7 @@ func (s *handlerSuite) TestCiRunsV3Upsert_edits() {
 				GithubActionsAttemptNumber: 1,
 				GithubActionsWorkflowPath:  "workflow",
 				StartedAt:                  &startedAt,
+				NotifySlackCustomIcon:      utils.PointerTo(""),
 			},
 		}),
 		&got1)

--- a/sherlock/internal/api/sherlock/slack_deploy_hooks_v3_create.go
+++ b/sherlock/internal/api/sherlock/slack_deploy_hooks_v3_create.go
@@ -70,9 +70,9 @@ func slackDeployHooksV3Create(ctx *gin.Context) {
 	}
 	if result.SlackChannel != nil {
 		if result.Trigger.OnEnvironment != nil {
-			go slack.SendMessage(db.Statement.Context, *result.SlackChannel, fmt.Sprintf("This channel will now receive notifications for Beehive deployments in %s", result.Trigger.OnEnvironment.Name))
+			go slack.SendMessage(db.Statement.Context, *result.SlackChannel, fmt.Sprintf("This channel will now receive notifications for Beehive deployments in %s", result.Trigger.OnEnvironment.Name), nil)
 		} else if result.Trigger.OnChartRelease != nil {
-			go slack.SendMessage(db.Statement.Context, *result.SlackChannel, fmt.Sprintf("This channel will now receive notifications for Beehive deployments to %s", result.Trigger.OnChartRelease.Name))
+			go slack.SendMessage(db.Statement.Context, *result.SlackChannel, fmt.Sprintf("This channel will now receive notifications for Beehive deployments to %s", result.Trigger.OnChartRelease.Name), nil)
 		}
 	}
 	ctx.JSON(http.StatusCreated, slackDeployHookFromModel(result))

--- a/sherlock/internal/api/sherlock/slack_deploy_hooks_v3_delete.go
+++ b/sherlock/internal/api/sherlock/slack_deploy_hooks_v3_delete.go
@@ -46,9 +46,9 @@ func slackDeployHooksV3Delete(ctx *gin.Context) {
 	}
 	if result.SlackChannel != nil {
 		if result.Trigger.OnEnvironment != nil {
-			go slack.SendMessage(db.Statement.Context, *result.SlackChannel, fmt.Sprintf("This channel will no longer receive notifications for Beehive deployments in %s", result.Trigger.OnEnvironment.Name))
+			go slack.SendMessage(db.Statement.Context, *result.SlackChannel, fmt.Sprintf("This channel will no longer receive notifications for Beehive deployments in %s", result.Trigger.OnEnvironment.Name), nil)
 		} else if result.Trigger.OnChartRelease != nil {
-			go slack.SendMessage(db.Statement.Context, *result.SlackChannel, fmt.Sprintf("This channel will no longer receive notifications for Beehive deployments to %s", result.Trigger.OnChartRelease.Name))
+			go slack.SendMessage(db.Statement.Context, *result.SlackChannel, fmt.Sprintf("This channel will no longer receive notifications for Beehive deployments to %s", result.Trigger.OnChartRelease.Name), nil)
 		}
 	}
 	ctx.JSON(http.StatusOK, slackDeployHookFromModel(result))

--- a/sherlock/internal/api/sherlock/slack_deploy_hooks_v3_edit.go
+++ b/sherlock/internal/api/sherlock/slack_deploy_hooks_v3_edit.go
@@ -88,7 +88,7 @@ func slackDeployHooksV3Edit(ctx *gin.Context) {
 			triggerDescription = toEdit.Trigger.OnChartRelease.Name
 		}
 		message := fmt.Sprintf("This channel is set to receive notifications for Beehive deployments to %s", triggerDescription)
-		go slack.SendMessage(db.Statement.Context, *toEdit.SlackChannel, message)
+		go slack.SendMessage(db.Statement.Context, *toEdit.SlackChannel, message, nil)
 	}
 
 	ctx.JSON(http.StatusOK, slackDeployHookFromModel(toEdit))

--- a/sherlock/internal/api/sherlock/slack_deploy_hooks_v3_test_run.go
+++ b/sherlock/internal/api/sherlock/slack_deploy_hooks_v3_test_run.go
@@ -65,7 +65,7 @@ func slackDeployHooksV3TestRun(ctx *gin.Context) {
 		return
 	}
 	if err = slack.SendMessageReturnError(ctx, *hook.SlackChannel,
-		fmt.Sprintf("This is a deploy hook test message from Beehive, triggered by %s", user.SlackReference(true))); err != nil {
+		fmt.Sprintf("This is a deploy hook test message from Beehive, triggered by %s", user.SlackReference(true)), nil); err != nil {
 		errors.AbortRequest(ctx, fmt.Errorf("error between Sherlock and Slack: %w", err))
 		return
 	}

--- a/sherlock/internal/deprecated_models/v2models/changeset.go
+++ b/sherlock/internal/deprecated_models/v2models/changeset.go
@@ -183,7 +183,7 @@ func (s *internalChangesetStore) plan(db *gorm.DB, changesets []Changeset, user 
 			if err != nil && strings.Contains(err.Error(), "deadlock detected") {
 				planned, _, err = s.Create(db, changeset, user)
 				if err == nil {
-					go slack.SendMessage(db.Statement.Context, "#ap-k8s-monitor", fmt.Sprintf("Sherlock encountered a deadlock during changeset creation (index %d) but recovered", index+1))
+					go slack.SendMessage(db.Statement.Context, "#ap-k8s-monitor", fmt.Sprintf("Sherlock encountered a deadlock during changeset creation (index %d) but recovered", index+1), nil)
 				}
 			}
 			if err != nil {

--- a/sherlock/internal/hooks/dispatch.go
+++ b/sherlock/internal/hooks/dispatch.go
@@ -75,7 +75,7 @@ func collectSlackNotificationCallbacks(db *gorm.DB, ciRun models.CiRun) (callbac
 				channel := unsafeChannel
 				callbacks = append(callbacks, func() error {
 					return dispatcher.DispatchSlackCompletionNotification(
-						db.Statement.Context, channel, text, ciRun.Succeeded())
+						db.Statement.Context, channel, text, ciRun.Succeeded(), ciRun.NotifySlackCustomIcon)
 				})
 			}
 		}

--- a/sherlock/internal/hooks/dispatcher.go
+++ b/sherlock/internal/hooks/dispatcher.go
@@ -9,7 +9,7 @@ import (
 )
 
 type mockableDispatcher interface {
-	DispatchSlackCompletionNotification(ctx context.Context, channel string, text string, succeeded bool) error
+	DispatchSlackCompletionNotification(ctx context.Context, channel string, text string, succeeded bool, icon *string) error
 	DispatchSlackDeployHook(db *gorm.DB, hook models.SlackDeployHook, ciRun models.CiRun) error
 	DispatchGithubActionsDeployHook(db *gorm.DB, hook models.GithubActionsDeployHook, ciRun models.CiRun) error
 }

--- a/sherlock/internal/hooks/hooks_mocks/mock_mockable_dispatcher.go
+++ b/sherlock/internal/hooks/hooks_mocks/mock_mockable_dispatcher.go
@@ -69,13 +69,13 @@ func (_c *MockMockableDispatcher_DispatchGithubActionsDeployHook_Call) RunAndRet
 	return _c
 }
 
-// DispatchSlackCompletionNotification provides a mock function with given fields: ctx, channel, text, succeeded
-func (_m *MockMockableDispatcher) DispatchSlackCompletionNotification(ctx context.Context, channel string, text string, succeeded bool) error {
-	ret := _m.Called(ctx, channel, text, succeeded)
+// DispatchSlackCompletionNotification provides a mock function with given fields: ctx, channel, text, succeeded, icon
+func (_m *MockMockableDispatcher) DispatchSlackCompletionNotification(ctx context.Context, channel string, text string, succeeded bool, icon *string) error {
+	ret := _m.Called(ctx, channel, text, succeeded, icon)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, bool) error); ok {
-		r0 = rf(ctx, channel, text, succeeded)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, bool, *string) error); ok {
+		r0 = rf(ctx, channel, text, succeeded, icon)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -93,13 +93,14 @@ type MockMockableDispatcher_DispatchSlackCompletionNotification_Call struct {
 //   - channel string
 //   - text string
 //   - succeeded bool
-func (_e *MockMockableDispatcher_Expecter) DispatchSlackCompletionNotification(ctx interface{}, channel interface{}, text interface{}, succeeded interface{}) *MockMockableDispatcher_DispatchSlackCompletionNotification_Call {
-	return &MockMockableDispatcher_DispatchSlackCompletionNotification_Call{Call: _e.mock.On("DispatchSlackCompletionNotification", ctx, channel, text, succeeded)}
+//   - icon *string
+func (_e *MockMockableDispatcher_Expecter) DispatchSlackCompletionNotification(ctx interface{}, channel interface{}, text interface{}, succeeded interface{}, icon interface{}) *MockMockableDispatcher_DispatchSlackCompletionNotification_Call {
+	return &MockMockableDispatcher_DispatchSlackCompletionNotification_Call{Call: _e.mock.On("DispatchSlackCompletionNotification", ctx, channel, text, succeeded, icon)}
 }
 
-func (_c *MockMockableDispatcher_DispatchSlackCompletionNotification_Call) Run(run func(ctx context.Context, channel string, text string, succeeded bool)) *MockMockableDispatcher_DispatchSlackCompletionNotification_Call {
+func (_c *MockMockableDispatcher_DispatchSlackCompletionNotification_Call) Run(run func(ctx context.Context, channel string, text string, succeeded bool, icon *string)) *MockMockableDispatcher_DispatchSlackCompletionNotification_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(bool))
+		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(bool), args[4].(*string))
 	})
 	return _c
 }
@@ -109,7 +110,7 @@ func (_c *MockMockableDispatcher_DispatchSlackCompletionNotification_Call) Retur
 	return _c
 }
 
-func (_c *MockMockableDispatcher_DispatchSlackCompletionNotification_Call) RunAndReturn(run func(context.Context, string, string, bool) error) *MockMockableDispatcher_DispatchSlackCompletionNotification_Call {
+func (_c *MockMockableDispatcher_DispatchSlackCompletionNotification_Call) RunAndReturn(run func(context.Context, string, string, bool, *string) error) *MockMockableDispatcher_DispatchSlackCompletionNotification_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/sherlock/internal/hooks/slack_completion_notification.go
+++ b/sherlock/internal/hooks/slack_completion_notification.go
@@ -8,12 +8,12 @@ import (
 // DispatchSlackCompletionNotification is pretty much a re-export of slack.SendMessageReturnError.
 // It encapsulates the call to the slack package so we don't need to reach into it when mocking
 // callers of this package.
-func (_ *dispatcherImpl) DispatchSlackCompletionNotification(ctx context.Context, channel string, text string, succeeded bool) error {
+func (_ *dispatcherImpl) DispatchSlackCompletionNotification(ctx context.Context, channel string, text string, succeeded bool, icon *string) error {
 	var attachment slack.Attachment
 	if succeeded {
 		attachment = slack.GreenBlock{Text: text}
 	} else {
 		attachment = slack.RedBlock{Text: text}
 	}
-	return slack.SendMessageReturnError(ctx, channel, "", attachment)
+	return slack.SendMessageReturnError(ctx, channel, "", icon, attachment)
 }

--- a/sherlock/internal/hooks/slack_completion_notification_test.go
+++ b/sherlock/internal/hooks/slack_completion_notification_test.go
@@ -3,6 +3,7 @@ package hooks
 import (
 	"context"
 	"fmt"
+	"github.com/broadinstitute/sherlock/go-shared/pkg/utils"
 	"github.com/broadinstitute/sherlock/sherlock/internal/config"
 	"github.com/broadinstitute/sherlock/sherlock/internal/slack"
 	"github.com/broadinstitute/sherlock/sherlock/internal/slack/slack_mocks"
@@ -17,6 +18,7 @@ func Test_dispatcherImpl_DispatchSlackCompletionNotification(t *testing.T) {
 		channel   string
 		text      string
 		succeeded bool
+		icon      *string
 	}
 	tests := []struct {
 		name       string
@@ -63,12 +65,26 @@ func Test_dispatcherImpl_DispatchSlackCompletionNotification(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "icon",
+			args: args{
+				channel:   "channel",
+				text:      "text",
+				succeeded: true,
+				icon:      utils.PointerTo(":smiley:"),
+			},
+			mockConfig: func(c *slack_mocks.MockMockableClient) {
+				// We can't mock the type of MsgOption sent, unfortunately
+				c.EXPECT().SendMessageContext(ctx, "channel", mock.AnythingOfType("slack.MsgOption"), mock.AnythingOfType("slack.MsgOption")).Return("", "", "", nil)
+			},
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			di := &dispatcherImpl{}
 			slack.UseMockedClient(t, tt.mockConfig, func() {
-				if err := di.DispatchSlackCompletionNotification(ctx, tt.args.channel, tt.args.text, tt.args.succeeded); (err != nil) != tt.wantErr {
+				if err := di.DispatchSlackCompletionNotification(ctx, tt.args.channel, tt.args.text, tt.args.succeeded, tt.args.icon); (err != nil) != tt.wantErr {
 					t.Errorf("DispatchSlackCompletionNotification() error = %v, wantErr %v", err, tt.wantErr)
 				}
 			})

--- a/sherlock/internal/models/ci_run.go
+++ b/sherlock/internal/models/ci_run.go
@@ -50,6 +50,7 @@ type CiRun struct {
 	Status                         *string
 	NotifySlackChannelsUponSuccess datatypes.JSONSlice[string]
 	NotifySlackChannelsUponFailure datatypes.JSONSlice[string]
+	NotifySlackCustomIcon          *string
 
 	// ResourceStatus is ignored by Gorm and isn't stored in the database -- at least, not
 	// on the CiRun type itself. The data is actually stored on CiRunIdentifierJoin, and this

--- a/sherlock/internal/slack/report_error.go
+++ b/sherlock/internal/slack/report_error.go
@@ -22,7 +22,7 @@ func ReportError[E interface {
 		messageText := fmt.Sprintf("Sherlock error: %s", description)
 		attachments := utils.Map(strings, func(s string) Attachment { return RedBlock{Text: s} })
 		for _, channel := range config.Config.Strings("slack.behaviors.errors.channels") {
-			SendMessage(ctx, channel, messageText, attachments...)
+			SendMessage(ctx, channel, messageText, nil, attachments...)
 		}
 	} else if config.Config.String("mode") == "debug" {
 		log.Warn().Strs("errors", strings).Str("description", description).Msg("Slack disabled in debug mode; would've reported errors if enabled")

--- a/sherlock/internal/slack/send_message.go
+++ b/sherlock/internal/slack/send_message.go
@@ -6,6 +6,7 @@ import (
 	"github.com/broadinstitute/sherlock/sherlock/internal/config"
 	"github.com/rs/zerolog/log"
 	"github.com/slack-go/slack"
+	"strings"
 )
 
 type Attachment interface {
@@ -34,13 +35,13 @@ func (g RedBlock) toSlackAttachment() slack.Attachment {
 	}
 }
 
-func SendMessage(ctx context.Context, channel string, text string, attachments ...Attachment) {
-	if err := SendMessageReturnError(ctx, channel, text, attachments...); err != nil {
+func SendMessage(ctx context.Context, channel string, text string, icon *string, attachments ...Attachment) {
+	if err := SendMessageReturnError(ctx, channel, text, icon, attachments...); err != nil {
 		log.Warn().Err(err).Msgf("SLCK | unable to send message to %s: %v", channel, err)
 	}
 }
 
-func SendMessageReturnError(ctx context.Context, channel string, text string, attachments ...Attachment) error {
+func SendMessageReturnError(ctx context.Context, channel string, text string, icon *string, attachments ...Attachment) error {
 	if isEnabled() && (text != "" || len(attachments) > 0) {
 		var options []slack.MsgOption
 		if text != "" {
@@ -51,6 +52,14 @@ func SendMessageReturnError(ctx context.Context, channel string, text string, at
 				utils.Map(attachments, func(a Attachment) slack.Attachment { return a.toSlackAttachment() })...,
 			))
 		}
+		if icon != nil {
+			if strings.HasPrefix(*icon, ":") && strings.HasSuffix(*icon, ":") {
+				options = append(options, slack.MsgOptionIconEmoji(*icon))
+			} else {
+				options = append(options, slack.MsgOptionIconURL(*icon))
+			}
+		}
+
 		_, _, _, err := client.SendMessageContext(ctx, channel, options...)
 		return err
 	}

--- a/sherlock/internal/slack/send_message.go
+++ b/sherlock/internal/slack/send_message.go
@@ -55,7 +55,7 @@ func SendMessageReturnError(ctx context.Context, channel string, text string, ic
 		if icon != nil {
 			if strings.HasPrefix(*icon, ":") && strings.HasSuffix(*icon, ":") {
 				options = append(options, slack.MsgOptionIconEmoji(*icon))
-			} else {
+			} else if *icon != "" {
 				options = append(options, slack.MsgOptionIconURL(*icon))
 			}
 		}

--- a/sherlock/internal/slack/send_message_test.go
+++ b/sherlock/internal/slack/send_message_test.go
@@ -97,6 +97,17 @@ func TestSendMessage(t *testing.T) {
 					mock.AnythingOfType("slack.MsgOption")).Return("", "", "", nil)
 			},
 		},
+		{
+			name: "doesn't send empty icon",
+			args: args{channel: "foo", text: "text", icon: utils.PointerTo(""), attachments: []Attachment{
+				GreenBlock{Text: "blah"}, RedBlock{"bleh"},
+			}},
+			mockConfig: func(c *slack_mocks.MockMockableClient) {
+				c.On("SendMessageContext", ctx, "foo",
+					mock.AnythingOfType("slack.MsgOption"),
+					mock.AnythingOfType("slack.MsgOption")).Return("", "", "", nil)
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/sherlock/internal/slack/send_message_test.go
+++ b/sherlock/internal/slack/send_message_test.go
@@ -3,6 +3,7 @@ package slack
 import (
 	"context"
 	"fmt"
+	"github.com/broadinstitute/sherlock/go-shared/pkg/utils"
 	"github.com/broadinstitute/sherlock/sherlock/internal/config"
 	"github.com/broadinstitute/sherlock/sherlock/internal/slack/slack_mocks"
 	"github.com/rs/zerolog"
@@ -17,6 +18,7 @@ func TestSendMessage(t *testing.T) {
 	type args struct {
 		channel     string
 		text        string
+		icon        *string
 		attachments []Attachment
 	}
 	tests := []struct {
@@ -71,17 +73,41 @@ func TestSendMessage(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "sends emoji icon",
+			args: args{channel: "foo", text: "text", icon: utils.PointerTo(":smiley:"), attachments: []Attachment{
+				GreenBlock{Text: "blah"}, RedBlock{"bleh"},
+			}},
+			mockConfig: func(c *slack_mocks.MockMockableClient) {
+				c.On("SendMessageContext", ctx, "foo",
+					mock.AnythingOfType("slack.MsgOption"),
+					mock.AnythingOfType("slack.MsgOption"),
+					mock.AnythingOfType("slack.MsgOption")).Return("", "", "", nil)
+			},
+		},
+		{
+			name: "sends url icon",
+			args: args{channel: "foo", text: "text", icon: utils.PointerTo("https://example.com/favicon.ico"), attachments: []Attachment{
+				GreenBlock{Text: "blah"}, RedBlock{"bleh"},
+			}},
+			mockConfig: func(c *slack_mocks.MockMockableClient) {
+				c.On("SendMessageContext", ctx, "foo",
+					mock.AnythingOfType("slack.MsgOption"),
+					mock.AnythingOfType("slack.MsgOption"),
+					mock.AnythingOfType("slack.MsgOption")).Return("", "", "", nil)
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Run("swallow errors", func(t *testing.T) {
 				UseMockedClient(t, tt.mockConfig, func() {
-					SendMessage(ctx, tt.args.channel, tt.args.text, tt.args.attachments...)
+					SendMessage(ctx, tt.args.channel, tt.args.text, tt.args.icon, tt.args.attachments...)
 				})
 			})
 			t.Run("return errors", func(t *testing.T) {
 				UseMockedClient(t, tt.mockConfig, func() {
-					if err := SendMessageReturnError(ctx, tt.args.channel, tt.args.text, tt.args.attachments...); (err != nil) != tt.wantErr {
+					if err := SendMessageReturnError(ctx, tt.args.channel, tt.args.text, tt.args.icon, tt.args.attachments...); (err != nil) != tt.wantErr {
 						t.Errorf("error result unexpected: %v", err)
 					}
 				})


### PR DESCRIPTION
Does what it sends on the tin. Handles colons shortcodes and URLs. I just added a parameter to the SendMessage function rather than trying to come up with something fancier

## Testing

Added to all mocks and tests

## Risk

Very low