### PR TITLE
[DDO-3440] Fix typo in message string

### DIFF
--- a/sherlock/internal/hooks/slack_deploy_hook.go
+++ b/sherlock/internal/hooks/slack_deploy_hook.go
@@ -64,7 +64,7 @@ func (_ *dispatcherImpl) DispatchSlackDeployHook(db *gorm.DB, hook models.SlackD
 				status))
 	}
 	if len(mainMessage.EntryLines) == 0 {
-		mainMessage.EntryLines = append(mainMessage.EntryLines, "(No changes listed`)")
+		mainMessage.EntryLines = append(mainMessage.EntryLines, "(No changes listed)")
 	}
 	var beehiveUrl string
 	if len(changesets) > 0 {


### PR DESCRIPTION
Removes an errant `. This is unfortunately from the part of the Slack hook codebase that doesn't have precise test coverage, but I think fixing the one-character typo is something we should just do rather than holding this up on trying to test this edge case.

## Risk

Extremely low