### PR TITLE
[DDO-3444] Fix accelerate metrics

### DIFF
--- a/sherlock/internal/models/metrics_cron.go
+++ b/sherlock/internal/models/metrics_cron.go
@@ -190,15 +190,20 @@ group by result_per_version.chart_release_id
 
 func reportDataTypeCounts(ctx context.Context, db *gorm.DB) error {
 	for dataType, model := range map[string]any{
-		"chart":         Chart{},
-		"environment":   Environment{},
-		"cluster":       Cluster{},
-		"app_version":   AppVersion{},
-		"chart_version": ChartVersion{},
-		"changeset":     Changeset{},
-		"chart_release": ChartRelease{},
-		"ci_identifier": CiIdentifier{},
-		"ci_run":        CiRun{},
+		"chart":                      Chart{},
+		"environment":                Environment{},
+		"cluster":                    Cluster{},
+		"app_version":                AppVersion{},
+		"chart_version":              ChartVersion{},
+		"changeset":                  Changeset{},
+		"chart_release":              ChartRelease{},
+		"ci_identifier":              CiIdentifier{},
+		"ci_run":                     CiRun{},
+		"github_actions_deploy_hook": GithubActionsDeployHook{},
+		"slack_deploy_hook":          SlackDeployHook{},
+		"deploy_hook_trigger_config": DeployHookTriggerConfig{},
+		"user":                       User{},
+		"pagerduty_integration":      PagerdutyIntegration{},
 	} {
 		var count int64
 		if err := db.
@@ -396,7 +401,7 @@ func UpdateMetrics(ctx context.Context, db *gorm.DB) error {
 		}
 
 		var chartReleases []ChartRelease
-		if err = db.Model(&ChartRelease{}).Where(&ChartRelease{ChartID: chart.ID}).Order("updated_at desc").Find(&chartReleases).Error; err != nil {
+		if err = db.Model(&ChartRelease{}).Preload("Environment").Where(&ChartRelease{ChartID: chart.ID}).Order("updated_at desc").Find(&chartReleases).Error; err != nil {
 			return err
 		}
 		if err != nil {


### PR DESCRIPTION
Missed a `Preload("Environment")` when converting this code to the refactored world, which means that `chartRelease.Environment` is always nil, which means that the "environment_lifecycle" tag was never getting added to the chart release metrics. The accelerate metrics dashboard filters everything for that equaling "static", so that's why Mike noticed the dashboard being blank yesterday.

Also added some of the more recent data types to the data type count metrics.

## Testing

Works locally. Testing this in an automatic way is very annoying because we don't really have any visibility into the OpenCensus library. Checked with Mike and he agreed that it's probably not worth it here.

## Risk

Very low