### PR TITLE
[DDO-3449] Read-only ChartRelease/Environment API methods

### DIFF
--- a/go-shared/pkg/utils/nil_or_call.go
+++ b/go-shared/pkg/utils/nil_or_call.go
@@ -1,0 +1,13 @@
+package utils
+
+// NilOrCall helps when you have a value *T and a field *R, but your conversion function is T => R.
+// If the value is nil, this function returns nil. Otherwise, it calls the conversion function on
+// the value and returns a pointer to the result.
+func NilOrCall[T any, R any](function func(T) R, value *T) *R {
+	if value == nil {
+		return nil
+	} else {
+		var ret = function(*value)
+		return &ret
+	}
+}

--- a/go-shared/pkg/utils/nil_or_call_test.go
+++ b/go-shared/pkg/utils/nil_or_call_test.go
@@ -1,0 +1,43 @@
+package utils
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestNilOrCall(t *testing.T) {
+	type args[T any, R any] struct {
+		function func(T) R
+		value    *T
+	}
+	type testCase[T any, R any] struct {
+		name string
+		args args[T, R]
+		want *R
+	}
+	tests := []testCase[uint, string]{
+		{
+			name: "nil",
+			args: args[uint, string]{
+				function: UintToString,
+				value:    nil,
+			},
+			want: nil,
+		},
+		{
+			name: "non-nil",
+			args: args[uint, string]{
+				function: UintToString,
+				value:    PointerTo[uint](1),
+			},
+			want: PointerTo("1"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NilOrCall(tt.args.function, tt.args.value); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("NilOrCall() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/sherlock/internal/api/sherlock/chart_releases_v3.go
+++ b/sherlock/internal/api/sherlock/chart_releases_v3.go
@@ -176,10 +176,12 @@ func (c ChartReleaseV3) toModel(db *gorm.DB) (models.ChartRelease, error) {
 	return ret, nil
 }
 
+//nolint:unused
 func (c ChartReleaseV3Create) toModel(db *gorm.DB) (models.ChartRelease, error) {
 	return ChartReleaseV3{ChartReleaseV3Create: c}.toModel(db)
 }
 
+//nolint:unused
 func (c ChartReleaseV3Edit) toModel(db *gorm.DB) (models.ChartRelease, error) {
 	return ChartReleaseV3Create{ChartReleaseV3Edit: c}.toModel(db)
 }

--- a/sherlock/internal/api/sherlock/chart_releases_v3.go
+++ b/sherlock/internal/api/sherlock/chart_releases_v3.go
@@ -1,0 +1,260 @@
+package sherlock
+
+import (
+	"fmt"
+	"github.com/broadinstitute/sherlock/go-shared/pkg/utils"
+	"github.com/broadinstitute/sherlock/sherlock/internal/models"
+	"gorm.io/gorm"
+	"time"
+)
+
+type ChartReleaseV3 struct {
+	CommonFields
+	CiIdentifier             *CiIdentifierV3         `json:"ciIdentifier,omitempty" form:"-"`
+	ChartInfo                *ChartV3                `json:"chartInfo,omitempty" form:"-"`
+	ClusterInfo              *ClusterV3              `json:"clusterInfo,omitempty" form:"-"`
+	EnvironmentInfo          *EnvironmentV3          `json:"environmentInfo,omitempty" form:"-"`
+	AppVersionReference      string                  `json:"appVersionReference,omitempty" form:"appVersionReference"`
+	AppVersionInfo           *AppVersionV3           `json:"appVersionInfo,omitempty" form:"-"`
+	ChartVersionReference    string                  `json:"chartVersionReference,omitempty" form:"chartVersionReference"`
+	ChartVersionInfo         *ChartVersionV3         `json:"chartVersionInfo,omitempty" form:"-"`
+	PagerdutyIntegrationInfo *PagerdutyIntegrationV3 `json:"pagerdutyIntegrationInfo,omitempty" form:"-"`
+	DestinationType          string                  `json:"destinationType" form:"destinationType" enum:"environment,cluster"` // Calculated field
+	ResolvedAt               *time.Time              `json:"resolvedAt,omitempty" form:"resolvedAt" format:"date-time"`
+	ChartReleaseV3Create
+}
+
+type ChartReleaseV3Create struct {
+	Chart       string `json:"chart" form:"chart"`             // Required when creating
+	Cluster     string `json:"cluster" form:"cluster"`         // When creating, will default the environment's default cluster, if provided. Either this or environment must be provided.
+	Environment string `json:"environment" form:"environment"` // Either this or cluster must be provided.
+	Name        string `json:"name" form:"name"`               // When creating, will be calculated if left empty
+	Namespace   string `json:"namespace" form:"namespace"`     // When creating, will default to the environment's default namespace, if provided
+
+	AppVersionResolver             *string `json:"appVersionResolver" form:"appVersionResolver" enums:"branch,commit,exact,follow,none"` // // When creating, will default to automatically reference any provided app version fields
+	AppVersionExact                *string `json:"appVersionExact" form:"appVersionExact"`
+	AppVersionBranch               *string `json:"appVersionBranch" form:"appVersionBranch"` // When creating, will default to the app's mainline branch if no other app version info is present
+	AppVersionCommit               *string `json:"appVersionCommit" form:"appVersionCommit"`
+	AppVersionFollowChartRelease   string  `json:"appVersionFollowChartRelease" form:"appVersionFollowChartRelease"`
+	ChartVersionResolver           *string `json:"chartVersionResolver" form:"chartVersionResolver" enums:"latest,exact,follow"` // When creating, will default to automatically reference any provided chart version
+	ChartVersionExact              *string `json:"chartVersionExact" form:"chartVersionExact"`
+	ChartVersionFollowChartRelease string  `json:"chartVersionFollowChartRelease" form:"chartVersionFollowChartRelease"`
+	HelmfileRef                    *string `json:"helmfileRef" form:"helmfileRef" default:"HEAD"`
+	HelmfileRefEnabled             *bool   `json:"helmfileRefEnabled" form:"helmfileRefEnabled" default:"false"`
+	FirecloudDevelopRef            *string `json:"firecloudDevelopRef" form:"firecloudDevelopRef"`
+	ChartReleaseV3Edit
+}
+
+type ChartReleaseV3Edit struct {
+	Subdomain               *string `json:"subdomain,omitempty" form:"subdomain"` // When creating, will use the chart's default if left empty
+	Protocol                *string `json:"protocol,omitempty" form:"protocol"`   // When creating, will use the chart's default if left empty
+	Port                    *uint   `json:"port,omitempty" form:"port"`           // When creating, will use the chart's default if left empty
+	PagerdutyIntegration    *string `json:"pagerdutyIntegration,omitempty" form:"pagerdutyIntegration"`
+	IncludeInBulkChangesets *bool   `json:"includedInBulkChangesets" form:"includedInBulkChangesets" default:"true"`
+}
+
+func (c ChartReleaseV3) toModel(db *gorm.DB) (models.ChartRelease, error) {
+	ret := models.ChartRelease{
+		Model:           c.CommonFields.toGormModel(),
+		DestinationType: c.DestinationType,
+		Name:            c.Name,
+		Namespace:       c.Namespace,
+		ChartReleaseVersion: models.ChartReleaseVersion{
+			ResolvedAt:           c.ResolvedAt,
+			AppVersionResolver:   c.AppVersionResolver,
+			AppVersionExact:      c.AppVersionExact,
+			AppVersionBranch:     c.AppVersionBranch,
+			AppVersionCommit:     c.AppVersionCommit,
+			ChartVersionResolver: c.ChartVersionResolver,
+			ChartVersionExact:    c.ChartVersionExact,
+			HelmfileRef:          c.HelmfileRef,
+			HelmfileRefEnabled:   c.HelmfileRefEnabled,
+			FirecloudDevelopRef:  c.FirecloudDevelopRef,
+		},
+		Subdomain:               c.Subdomain,
+		Protocol:                c.Protocol,
+		Port:                    c.Port,
+		PagerdutyIntegrationID:  nil, //
+		IncludeInBulkChangesets: c.IncludeInBulkChangesets,
+	}
+	if c.Chart != "" {
+		chartModel, err := chartModelFromSelector(c.Chart)
+		if err != nil {
+			return models.ChartRelease{}, err
+		}
+		var chart models.Chart
+		if err = db.Where(&chartModel).Select("id").First(&chart).Error; err != nil {
+			return models.ChartRelease{}, err
+		} else {
+			ret.ChartID = chart.ID
+		}
+	}
+	if c.Cluster != "" {
+		clusterModel, err := clusterModelFromSelector(c.Cluster)
+		if err != nil {
+			return models.ChartRelease{}, err
+		}
+		var cluster models.Cluster
+		if err = db.Where(&clusterModel).Select("id").First(&cluster).Error; err != nil {
+			return models.ChartRelease{}, err
+		} else {
+			ret.ClusterID = &cluster.ID
+		}
+	}
+	if c.Environment != "" {
+		environmentModel, err := environmentModelFromSelector(c.Environment)
+		if err != nil {
+			return models.ChartRelease{}, err
+		}
+		var environment models.Environment
+		if err = db.Where(&environmentModel).Select("id").First(&environment).Error; err != nil {
+			return models.ChartRelease{}, err
+		} else {
+			ret.EnvironmentID = &environment.ID
+		}
+	}
+	if c.AppVersionFollowChartRelease != "" {
+		chartReleaseModel, err := chartReleaseModelFromSelector(db, c.AppVersionFollowChartRelease)
+		if err != nil {
+			return models.ChartRelease{}, err
+		}
+		var chartRelease models.ChartRelease
+		if err = db.Where(&chartReleaseModel).Select("id").First(&chartRelease).Error; err != nil {
+			return models.ChartRelease{}, err
+		} else {
+			ret.AppVersionFollowChartReleaseID = &chartRelease.ID
+		}
+	}
+	if c.AppVersionReference != "" {
+		appVersionModel, err := appVersionModelFromSelector(db, c.AppVersionReference)
+		if err != nil {
+			return models.ChartRelease{}, err
+		}
+		var appVersion models.AppVersion
+		if err = db.Where(&appVersionModel).Select("id").First(&appVersion).Error; err != nil {
+			return models.ChartRelease{}, err
+		} else {
+			ret.AppVersionID = &appVersion.ID
+		}
+	}
+	if c.ChartVersionFollowChartRelease != "" {
+		chartReleaseModel, err := chartReleaseModelFromSelector(db, c.ChartVersionFollowChartRelease)
+		if err != nil {
+			return models.ChartRelease{}, err
+		}
+		var chartRelease models.ChartRelease
+		if err = db.Where(&chartReleaseModel).Select("id").First(&chartRelease).Error; err != nil {
+			return models.ChartRelease{}, err
+		} else {
+			ret.ChartVersionFollowChartReleaseID = &chartRelease.ID
+		}
+	}
+	if c.ChartVersionReference != "" {
+		chartVersionModel, err := chartVersionModelFromSelector(db, c.ChartVersionReference)
+		if err != nil {
+			return models.ChartRelease{}, err
+		}
+		var chartVersion models.ChartVersion
+		if err = db.Where(&chartVersionModel).Select("id").First(&chartVersion).Error; err != nil {
+			return models.ChartRelease{}, err
+		} else {
+			ret.ChartVersionID = &chartVersion.ID
+		}
+	}
+	if c.PagerdutyIntegration != nil {
+		pagerdutyIntegrationModel, err := pagerdutyIntegrationModelFromSelector(*c.PagerdutyIntegration)
+		if err != nil {
+			return models.ChartRelease{}, err
+		}
+		var pagerdutyIntegration models.PagerdutyIntegration
+		if err = db.Where(&pagerdutyIntegrationModel).Select("id").First(&pagerdutyIntegration).Error; err != nil {
+			return models.ChartRelease{}, err
+		} else {
+			ret.PagerdutyIntegrationID = &pagerdutyIntegration.ID
+		}
+	}
+	return ret, nil
+}
+
+func (c ChartReleaseV3Create) toModel(db *gorm.DB) (models.ChartRelease, error) {
+	return ChartReleaseV3{ChartReleaseV3Create: c}.toModel(db)
+}
+
+func (c ChartReleaseV3Edit) toModel(db *gorm.DB) (models.ChartRelease, error) {
+	return ChartReleaseV3Create{ChartReleaseV3Edit: c}.toModel(db)
+}
+
+func chartReleaseFromModel(model models.ChartRelease) ChartReleaseV3 {
+	ret := ChartReleaseV3{
+		CommonFields:             commonFieldsFromGormModel(model.Model),
+		CiIdentifier:             utils.NilOrCall(ciIdentifierFromModel, model.CiIdentifier),
+		ChartInfo:                utils.NilOrCall(chartFromModel, model.Chart),
+		ClusterInfo:              utils.NilOrCall(clusterFromModel, model.Cluster),
+		EnvironmentInfo:          utils.NilOrCall(environmentFromModel, model.Environment),
+		AppVersionInfo:           utils.NilOrCall(appVersionFromModel, model.AppVersion),
+		ChartVersionInfo:         utils.NilOrCall(chartVersionFromModel, model.ChartVersion),
+		PagerdutyIntegrationInfo: utils.NilOrCall(pagerdutyIntegrationFromModel, model.PagerdutyIntegration),
+		DestinationType:          model.DestinationType,
+		ResolvedAt:               model.ResolvedAt,
+		ChartReleaseV3Create: ChartReleaseV3Create{
+			Name:                 model.Name,
+			Namespace:            model.Namespace,
+			AppVersionResolver:   model.AppVersionResolver,
+			AppVersionExact:      model.AppVersionExact,
+			AppVersionBranch:     model.AppVersionBranch,
+			AppVersionCommit:     model.AppVersionCommit,
+			ChartVersionResolver: model.ChartVersionResolver,
+			ChartVersionExact:    model.ChartVersionExact,
+			HelmfileRef:          model.HelmfileRef,
+			HelmfileRefEnabled:   model.HelmfileRefEnabled,
+			FirecloudDevelopRef:  model.FirecloudDevelopRef,
+			ChartReleaseV3Edit: ChartReleaseV3Edit{
+				Subdomain:               model.Subdomain,
+				Protocol:                model.Protocol,
+				Port:                    model.Port,
+				IncludeInBulkChangesets: model.IncludeInBulkChangesets,
+			},
+		},
+	}
+	if model.AppVersion != nil && model.AppVersion.AppVersion != "" && model.Chart != nil && model.Chart.Name != "" {
+		ret.AppVersionReference = fmt.Sprintf("%s/%s", model.Chart.Name, *model.AppVersionExact)
+	} else if model.AppVersionID != nil {
+		ret.AppVersionReference = utils.UintToString(*model.AppVersionID)
+	}
+	if model.ChartVersion != nil && model.ChartVersion.ChartVersion != "" && model.Chart != nil && model.Chart.Name != "" {
+		ret.ChartVersionReference = fmt.Sprintf("%s/%s", model.Chart.Name, *model.ChartVersionExact)
+	} else if model.ChartVersionID != nil {
+		ret.ChartVersionReference = utils.UintToString(*model.ChartVersionID)
+	}
+	if model.Chart != nil && model.Chart.Name != "" {
+		ret.Chart = model.Chart.Name
+	} else if model.ChartID != 0 {
+		ret.Chart = utils.UintToString(model.ChartID)
+	}
+	if model.Cluster != nil && model.Cluster.Name != "" {
+		ret.Cluster = model.Cluster.Name
+	} else if model.ClusterID != nil {
+		ret.Cluster = utils.UintToString(*model.ClusterID)
+	}
+	if model.Environment != nil && model.Environment.Name != "" {
+		ret.Environment = model.Environment.Name
+	} else if model.EnvironmentID != nil {
+		ret.Environment = utils.UintToString(*model.EnvironmentID)
+	}
+	if model.AppVersionFollowChartRelease != nil && model.AppVersionFollowChartRelease.Name != "" {
+		ret.AppVersionFollowChartRelease = model.AppVersionFollowChartRelease.Name
+	} else if model.AppVersionFollowChartReleaseID != nil {
+		ret.AppVersionFollowChartRelease = utils.UintToString(*model.AppVersionFollowChartReleaseID)
+	}
+	if model.ChartVersionFollowChartRelease != nil && model.ChartVersionFollowChartRelease.Name != "" {
+		ret.ChartVersionFollowChartRelease = model.ChartVersionFollowChartRelease.Name
+	} else if model.ChartVersionFollowChartReleaseID != nil {
+		ret.ChartVersionFollowChartRelease = utils.UintToString(*model.ChartVersionFollowChartReleaseID)
+	}
+	if model.PagerdutyIntegration != nil && model.PagerdutyIntegration.PagerdutyID != "" {
+		ret.PagerdutyIntegration = utils.PointerTo(fmt.Sprintf("pd-id/%s", model.PagerdutyIntegration.PagerdutyID))
+	} else if model.PagerdutyIntegrationID != nil {
+		ret.PagerdutyIntegration = utils.PointerTo(utils.UintToString(*model.PagerdutyIntegrationID))
+	}
+	return ret
+}

--- a/sherlock/internal/api/sherlock/chart_releases_v3_get.go
+++ b/sherlock/internal/api/sherlock/chart_releases_v3_get.go
@@ -1,0 +1,125 @@
+package sherlock
+
+import (
+	"fmt"
+	"github.com/broadinstitute/sherlock/go-shared/pkg/utils"
+	"github.com/broadinstitute/sherlock/sherlock/internal/authentication"
+	"github.com/broadinstitute/sherlock/sherlock/internal/errors"
+	"github.com/broadinstitute/sherlock/sherlock/internal/models"
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+// chartReleasesV3Get godoc
+//
+//	@summary		Get an individual ChartRelease
+//	@description	Get an individual ChartRelease.
+//	@tags			ChartReleases
+//	@produce		json
+//	@param			selector				path		string	true	"The selector of the ChartRelease, which can be either a numeric ID, the name, environment + '/' + chart, or cluster + '/' + namespace + '/' + chart."
+//	@success		200						{object}	ChartReleaseV3
+//	@failure		400,403,404,407,409,500	{object}	errors.ErrorResponse
+//	@router			/api/chart-releases/v3/{selector} [get]
+func chartReleasesV3Get(ctx *gin.Context) {
+	db, err := authentication.MustUseDB(ctx)
+	if err != nil {
+		return
+	}
+	query, err := chartReleaseModelFromSelector(db, canonicalizeSelector(ctx.Param("selector")))
+	if err != nil {
+		errors.AbortRequest(ctx, err)
+		return
+	}
+	var result models.ChartRelease
+	if err = db.Preload(clause.Associations).Where(&query).First(&result).Error; err != nil {
+		errors.AbortRequest(ctx, err)
+		return
+	}
+	ctx.JSON(http.StatusOK, chartReleaseFromModel(result))
+}
+
+func chartReleaseModelFromSelector(db *gorm.DB, selector string) (query models.ChartRelease, err error) {
+	if len(selector) == 0 {
+		return models.ChartRelease{}, fmt.Errorf("(%s) chart release selector cannot be empty", errors.BadRequest)
+	}
+	if utils.IsNumeric(selector) { // ID
+		id, err := strconv.Atoi(selector)
+		if err != nil {
+			return models.ChartRelease{}, fmt.Errorf("(%s) string to int conversion error of '%s': %w", errors.BadRequest, selector, err)
+		}
+		query.ID = uint(id)
+		return query, nil
+	} else if strings.Count(selector, "/") == 1 { // environment + chart
+		parts := strings.Split(selector, "/")
+
+		// environment
+		environmentSubQuery, err := environmentModelFromSelector(parts[0])
+		if err != nil {
+			return models.ChartRelease{}, fmt.Errorf("error handling environment sub-selector %s: %w", parts[0], err)
+		}
+		var environmentSubResult models.Environment
+		if err = db.Where(&environmentSubQuery).Select("id").First(&environmentSubResult).Error; err != nil {
+			return models.ChartRelease{}, fmt.Errorf("error querying for environment sub-selector %s: %w", parts[0], err)
+		}
+		query.EnvironmentID = &environmentSubResult.ID
+
+		// chart
+		chartSubQuery, err := chartModelFromSelector(parts[1])
+		if err != nil {
+			return models.ChartRelease{}, fmt.Errorf("error handling chart sub-selector %s: %w", parts[1], err)
+		}
+		var chartSubResult models.Chart
+		if err = db.Where(&chartSubQuery).Select("id").First(&chartSubResult).Error; err != nil {
+			return models.ChartRelease{}, fmt.Errorf("error querying for chart sub-selector %s: %w", parts[1], err)
+		}
+		query.ChartID = chartSubResult.ID
+
+		return query, nil
+	} else if strings.Count(selector, "/") == 2 { // cluster + namespace + chart
+		parts := strings.Split(selector, "/")
+
+		// cluster
+		clusterSubQuery, err := clusterModelFromSelector(parts[0])
+		if err != nil {
+			return models.ChartRelease{}, fmt.Errorf("error handling cluster sub-selector %s: %w", parts[0], err)
+		}
+		var clusterSubResult models.Cluster
+		if err = db.Where(&clusterSubQuery).Select("id").First(&clusterSubResult).Error; err != nil {
+			return models.ChartRelease{}, fmt.Errorf("error querying for cluster sub-selector %s: %w", parts[0], err)
+		}
+		query.ClusterID = &clusterSubResult.ID
+
+		// namespace
+		namespace := parts[1]
+		if !(utils.IsAlphaNumericWithHyphens(namespace) &&
+			len(namespace) > 0 &&
+			utils.IsStartingWithLetter(namespace) &&
+			utils.IsEndingWithAlphaNumeric(namespace)) {
+			return models.ChartRelease{}, fmt.Errorf("(%s) invalid chart release selector %s, namespace sub-selector %s was invalid", errors.BadRequest, selector, namespace)
+		}
+		query.Namespace = namespace
+
+		// chart
+		chartSubQuery, err := chartModelFromSelector(parts[2])
+		if err != nil {
+			return models.ChartRelease{}, fmt.Errorf("error handling chart sub-selector %s: %w", parts[2], err)
+		}
+		var chartSubResult models.Chart
+		if err = db.Where(&chartSubQuery).Select("id").First(&chartSubResult).Error; err != nil {
+			return models.ChartRelease{}, fmt.Errorf("error querying for chart sub-selector %s: %w", parts[2], err)
+		}
+		query.ChartID = chartSubResult.ID
+
+		return query, nil
+	} else if utils.IsAlphaNumericWithHyphens(selector) &&
+		utils.IsStartingWithLetter(selector) &&
+		utils.IsEndingWithAlphaNumeric(selector) { // name
+		query.Name = selector
+		return query, nil
+	}
+	return models.ChartRelease{}, fmt.Errorf("(%s) invalid chart release selector '%s'", errors.BadRequest, selector)
+}

--- a/sherlock/internal/api/sherlock/chart_releases_v3_get_test.go
+++ b/sherlock/internal/api/sherlock/chart_releases_v3_get_test.go
@@ -1,0 +1,201 @@
+package sherlock
+
+import (
+	"fmt"
+	"github.com/broadinstitute/sherlock/go-shared/pkg/testutils"
+	"github.com/broadinstitute/sherlock/go-shared/pkg/utils"
+	"github.com/broadinstitute/sherlock/sherlock/internal/errors"
+	"github.com/broadinstitute/sherlock/sherlock/internal/models"
+	"github.com/stretchr/testify/assert"
+	"gorm.io/gorm"
+	"net/http"
+)
+
+func (s *handlerSuite) TestChartReleaseV3Get_badSelector() {
+	var got errors.ErrorResponse
+	code := s.HandleRequest(
+		s.NewRequest("GET", "/api/chart-releases/v3/something/with/too/many/slashes", nil),
+		&got)
+	s.Equal(http.StatusBadRequest, code)
+	s.Equal(errors.BadRequest, got.Type)
+}
+
+func (s *handlerSuite) TestChartReleaseV3Get_notFound() {
+	var got errors.ErrorResponse
+	code := s.HandleRequest(
+		s.NewRequest("GET", "/api/chart-releases/v3/123", nil),
+		&got)
+	s.Equal(http.StatusNotFound, code)
+	s.Equal(errors.NotFound, got.Type)
+}
+
+func (s *handlerSuite) TestChartReleaseV3Get() {
+	chartRelease := s.TestData.ChartRelease_LeonardoDev()
+
+	var got ChartReleaseV3
+	code := s.HandleRequest(
+		s.NewRequest("GET", "/api/chart-releases/v3/"+chartRelease.Name, nil),
+		&got)
+	s.Equal(http.StatusOK, code)
+	s.Equal(chartRelease.Name, got.Name)
+}
+
+func (s *handlerSuite) Test_chartReleaseModelFromSelector() {
+	type args struct {
+		selector string
+	}
+	tests := []struct {
+		name      string
+		args      args
+		wantQuery models.ChartRelease
+		wantErr   assert.ErrorAssertionFunc
+	}{
+		{
+			name:    "empty",
+			args:    args{selector: ""},
+			wantErr: assert.Error,
+		},
+		{
+			name:    "invalid",
+			args:    args{selector: "something obviously invalid!"},
+			wantErr: assert.Error,
+		},
+		{
+			name:    "valid id",
+			args:    args{selector: "123"},
+			wantErr: assert.NoError,
+			wantQuery: models.ChartRelease{
+				Model: gorm.Model{ID: 123},
+			},
+		},
+		{
+			name:    "invalid id",
+			args:    args{selector: testutils.StringNumberTooBigForInt},
+			wantErr: assert.Error,
+		},
+		{
+			name:    "environment + chart",
+			args:    args{selector: s.TestData.Environment_Prod().Name + "/" + s.TestData.Chart_Leonardo().Name},
+			wantErr: assert.NoError,
+			wantQuery: models.ChartRelease{
+				EnvironmentID: utils.PointerTo(s.TestData.Environment_Prod().ID),
+				ChartID:       s.TestData.Chart_Leonardo().ID,
+			},
+		},
+		{
+			name:    "environment + chart, empty environment",
+			args:    args{selector: "/" + s.TestData.Chart_Leonardo().Name},
+			wantErr: assert.Error,
+		},
+		{
+			name:    "environment + chart, invalid environment",
+			args:    args{selector: "!!!!!!!/" + s.TestData.Chart_Leonardo().Name},
+			wantErr: assert.Error,
+		},
+		{
+			name:    "environment + chart, not found environment",
+			args:    args{selector: "not-found/" + s.TestData.Chart_Leonardo().Name},
+			wantErr: assert.Error,
+		},
+		{
+			name:    "environment + chart, empty chart",
+			args:    args{selector: s.TestData.Environment_Prod().Name + "/"},
+			wantErr: assert.Error,
+		},
+		{
+			name:    "environment + chart, invalid chart",
+			args:    args{selector: s.TestData.Environment_Prod().Name + "/!!!!!!!"},
+			wantErr: assert.Error,
+		},
+		{
+			name:    "environment + chart, not found chart",
+			args:    args{selector: s.TestData.Environment_Prod().Name + "/not-found"},
+			wantErr: assert.Error,
+		},
+		{
+			name: "cluster + namespace + chart",
+			args: args{
+				selector: s.TestData.Cluster_TerraProd().Name + "/" + "terra-prod" + "/" + s.TestData.Chart_Leonardo().Name,
+			},
+			wantErr: assert.NoError,
+			wantQuery: models.ChartRelease{
+				ClusterID: utils.PointerTo(s.TestData.Cluster_TerraProd().ID),
+				Namespace: "terra-prod",
+				ChartID:   s.TestData.Chart_Leonardo().ID,
+			},
+		},
+		{
+			name: "cluster + namespace + chart, empty cluster",
+			args: args{
+				selector: "/" + "terra-prod" + "/" + s.TestData.Chart_Leonardo().Name,
+			},
+			wantErr: assert.Error,
+		},
+		{
+			name: "cluster + namespace + chart, invalid cluster",
+			args: args{
+				selector: "!!!!!!/" + "terra-prod" + "/" + s.TestData.Chart_Leonardo().Name,
+			},
+			wantErr: assert.Error,
+		},
+		{
+			name: "cluster + namespace + chart, not found cluster",
+			args: args{
+				selector: "not-found/" + "terra-prod" + "/" + s.TestData.Chart_Leonardo().Name,
+			},
+			wantErr: assert.Error,
+		},
+		{
+			name: "cluster + namespace + chart, empty namespace",
+			args: args{
+				selector: s.TestData.Cluster_TerraProd().Name + "/" + "/" + s.TestData.Chart_Leonardo().Name,
+			},
+			wantErr: assert.Error,
+		},
+		{
+			name: "cluster + namespace + chart, invalid namespace",
+			args: args{
+				selector: s.TestData.Cluster_TerraProd().Name + "/" + "!!!!!!" + "/" + s.TestData.Chart_Leonardo().Name,
+			},
+			wantErr: assert.Error,
+		},
+		{
+			name: "cluster + namespace + chart, empty chart",
+			args: args{
+				selector: s.TestData.Cluster_TerraProd().Name + "/" + "terra-prod" + "/",
+			},
+			wantErr: assert.Error,
+		},
+		{
+			name: "cluster + namespace + chart, invalid chart",
+			args: args{
+				selector: s.TestData.Cluster_TerraProd().Name + "/" + "terra-prod" + "/!!!!!!",
+			},
+			wantErr: assert.Error,
+		},
+		{
+			name: "cluster + namespace + chart, not found chart",
+			args: args{
+				selector: s.TestData.Cluster_TerraProd().Name + "/" + "terra-prod" + "/not-found",
+			},
+			wantErr: assert.Error,
+		},
+		{
+			name:    "name",
+			args:    args{selector: "a-name"},
+			wantErr: assert.NoError,
+			wantQuery: models.ChartRelease{
+				Name: "a-name",
+			},
+		},
+	}
+	for _, tt := range tests {
+		s.Run(tt.name, func() {
+			gotQuery, err := chartReleaseModelFromSelector(s.DB, tt.args.selector)
+			if !tt.wantErr(s.T(), err, fmt.Sprintf("chartReleaseModelFromSelector(%v)", tt.args.selector)) {
+				return
+			}
+			s.Equalf(tt.wantQuery, gotQuery, "chartReleaseModelFromSelector(%v)", tt.args.selector)
+		})
+	}
+}

--- a/sherlock/internal/api/sherlock/chart_releases_v3_list.go
+++ b/sherlock/internal/api/sherlock/chart_releases_v3_list.go
@@ -1,0 +1,65 @@
+package sherlock
+
+import (
+	"fmt"
+	"github.com/broadinstitute/sherlock/go-shared/pkg/utils"
+	"github.com/broadinstitute/sherlock/sherlock/internal/authentication"
+	"github.com/broadinstitute/sherlock/sherlock/internal/errors"
+	"github.com/broadinstitute/sherlock/sherlock/internal/models"
+	"github.com/gin-gonic/gin"
+	"net/http"
+)
+
+// chartReleasesV3List godoc
+//
+//	@summary		List ChartReleases matching a filter
+//	@description	List ChartReleases matching a filter.
+//	@tags			ChartReleases
+//	@produce		json
+//	@param			filter					query		ChartReleaseV3	false	"Filter the returned ChartReleases"
+//	@param			limit					query		int				false	"Control how many ChartReleases are returned (default 0, meaning all)"
+//	@param			offset					query		int				false	"Control the offset for the returned ChartReleases (default 0)"
+//	@success		200						{array}		ChartReleaseV3
+//	@failure		400,403,404,407,409,500	{object}	errors.ErrorResponse
+//	@router			/api/chart-releases/v3 [get]
+func chartReleasesV3List(ctx *gin.Context) {
+	db, err := authentication.MustUseDB(ctx)
+	if err != nil {
+		return
+	}
+	var filter ChartReleaseV3
+	if err = ctx.ShouldBindQuery(&filter); err != nil {
+		errors.AbortRequest(ctx, err)
+		return
+	}
+	modelFilter, err := filter.toModel(db)
+	if err != nil {
+		errors.AbortRequest(ctx, err)
+		return
+	}
+
+	limit, err := utils.ParseInt(ctx.DefaultQuery("limit", "0"))
+	if err != nil {
+		errors.AbortRequest(ctx, fmt.Errorf("(%s) %v", errors.BadRequest, err))
+		return
+	}
+	offset, err := utils.ParseInt(ctx.DefaultQuery("offset", "0"))
+	if err != nil {
+		errors.AbortRequest(ctx, fmt.Errorf("(%s) %v", errors.BadRequest, err))
+		return
+	}
+	var results []models.ChartRelease
+	chain := db.
+		Where(&modelFilter)
+	if limit > 0 {
+		chain = chain.Limit(limit)
+	}
+	if err = chain.
+		Offset(offset).
+		Order("name asc").
+		Find(&results).Error; err != nil {
+		errors.AbortRequest(ctx, err)
+		return
+	}
+	ctx.JSON(http.StatusOK, utils.Map(results, chartReleaseFromModel))
+}

--- a/sherlock/internal/api/sherlock/chart_releases_v3_list_test.go
+++ b/sherlock/internal/api/sherlock/chart_releases_v3_list_test.go
@@ -1,0 +1,88 @@
+package sherlock
+
+import (
+	"github.com/broadinstitute/sherlock/sherlock/internal/errors"
+	"net/http"
+)
+
+func (s *handlerSuite) TestChartReleasesV3List_none() {
+	var got []ChartReleaseV3
+	code := s.HandleRequest(
+		s.NewRequest("GET", "/api/chart-releases/v3", nil),
+		&got)
+	s.Equal(http.StatusOK, code)
+	s.Len(got, 0)
+}
+
+func (s *handlerSuite) TestChartReleasesV3List_badFilter() {
+	var got errors.ErrorResponse
+	code := s.HandleRequest(
+		s.NewRequest("GET", "/api/chart-releases/v3?id=foo", nil),
+		&got)
+	s.Equal(http.StatusBadRequest, code)
+	s.Equal(errors.BadRequest, got.Type)
+}
+
+func (s *handlerSuite) TestChartReleasesV3List_badLimit() {
+	var got errors.ErrorResponse
+	code := s.HandleRequest(
+		s.NewRequest("GET", "/api/chart-releases/v3?limit=foo", nil),
+		&got)
+	s.Equal(http.StatusBadRequest, code)
+	s.Equal(errors.BadRequest, got.Type)
+}
+
+func (s *handlerSuite) TestChartReleasesV3List_badOffset() {
+	var got errors.ErrorResponse
+	code := s.HandleRequest(
+		s.NewRequest("GET", "/api/chart-releases/v3?offset=foo", nil),
+		&got)
+	s.Equal(http.StatusBadRequest, code)
+	s.Equal(errors.BadRequest, got.Type)
+}
+
+func (s *handlerSuite) TestChartReleasesV3List() {
+	s.TestData.ChartRelease_LeonardoDev()
+	s.TestData.ChartRelease_LeonardoProd()
+	s.TestData.ChartRelease_D2pDdpAzureDev()
+
+	s.Run("all", func() {
+		var got []ChartReleaseV3
+		code := s.HandleRequest(
+			s.NewRequest("GET", "/api/chart-releases/v3", nil),
+			&got)
+		s.Equal(http.StatusOK, code)
+		s.Len(got, 3)
+	})
+	s.Run("none", func() {
+		var got []ChartReleaseV3
+		code := s.HandleRequest(
+			s.NewRequest("GET", "/api/chart-releases/v3?name=foo", nil),
+			&got)
+		s.Equal(http.StatusOK, code)
+		s.Len(got, 0)
+	})
+	s.Run("some", func() {
+		var got []ChartReleaseV3
+		code := s.HandleRequest(
+			s.NewRequest("GET", "/api/chart-releases/v3?name=leonardo-prod", nil),
+			&got)
+		s.Equal(http.StatusOK, code)
+		s.Len(got, 1)
+	})
+	s.Run("limit and offset", func() {
+		var got1 []ChartReleaseV3
+		code := s.HandleRequest(
+			s.NewRequest("GET", "/api/chart-releases/v3?limit=1", nil),
+			&got1)
+		s.Equal(http.StatusOK, code)
+		s.Len(got1, 1)
+		var got2 []ChartReleaseV3
+		code = s.HandleRequest(
+			s.NewRequest("GET", "/api/chart-releases/v3?limit=1&offset=1", nil),
+			&got2)
+		s.Equal(http.StatusOK, code)
+		s.Len(got2, 1)
+		s.NotEqual(got1[0].ID, got2[0].ID)
+	})
+}

--- a/sherlock/internal/api/sherlock/chart_releases_v3_test.go
+++ b/sherlock/internal/api/sherlock/chart_releases_v3_test.go
@@ -266,7 +266,7 @@ func (s *handlerSuite) TestChartReleaseV3_toModel() {
 				ChartReleaseV3Create:  tt.fields.ChartReleaseV3Create,
 			}
 			got, err := c.toModel(s.DB)
-			if !tt.wantErr(s.T(), err, fmt.Sprintf("toModel()")) {
+			if !tt.wantErr(s.T(), err, "toModel()") {
 				return
 			}
 			s.Equalf(tt.want, got, "toModel()")

--- a/sherlock/internal/api/sherlock/chart_releases_v3_test.go
+++ b/sherlock/internal/api/sherlock/chart_releases_v3_test.go
@@ -1,0 +1,400 @@
+package sherlock
+
+import (
+	"fmt"
+	"github.com/broadinstitute/sherlock/go-shared/pkg/utils"
+	"github.com/broadinstitute/sherlock/sherlock/internal/models"
+	"github.com/stretchr/testify/assert"
+	"gorm.io/gorm"
+	"testing"
+	"time"
+)
+
+func (s *handlerSuite) TestChartReleaseV3_toModel() {
+	now := time.Now()
+	chart := s.TestData.Chart_Leonardo()
+	cluster := s.TestData.Cluster_TerraProd()
+	environment := s.TestData.Environment_Prod()
+	chartReleaseDev := s.TestData.ChartRelease_LeonardoDev()
+	chartReleaseStaging := s.TestData.ChartRelease_LeonardoStaging()
+	appVersion := s.TestData.AppVersion_Leonardo_V1()
+	chartVersion := s.TestData.ChartVersion_Leonardo_V1()
+	pagerdutyIntegration := s.TestData.PagerdutyIntegration_ManuallyTriggeredTerraIncident()
+	type fields struct {
+		CommonFields          CommonFields
+		AppVersionReference   string
+		ChartVersionReference string
+		DestinationType       string
+		ResolvedAt            *time.Time
+		ChartReleaseV3Create  ChartReleaseV3Create
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		want    models.ChartRelease
+		wantErr assert.ErrorAssertionFunc
+	}{
+		{
+			name:    "empty",
+			fields:  fields{},
+			wantErr: assert.NoError,
+			want:    models.ChartRelease{},
+		},
+		{
+			name: "invalid chart selector",
+			fields: fields{
+				ChartReleaseV3Create: ChartReleaseV3Create{
+					Chart: "!!!!",
+				},
+			},
+			wantErr: assert.Error,
+		},
+		{
+			name: "not found chart",
+			fields: fields{
+				ChartReleaseV3Create: ChartReleaseV3Create{
+					Chart: "not-found",
+				},
+			},
+			wantErr: assert.Error,
+		},
+		{
+			name: "invalid cluster selector",
+			fields: fields{
+				ChartReleaseV3Create: ChartReleaseV3Create{
+					Cluster: "!!!!!",
+				},
+			},
+			wantErr: assert.Error,
+		},
+		{
+			name: "not found cluster",
+			fields: fields{
+				ChartReleaseV3Create: ChartReleaseV3Create{
+					Cluster: "not-found",
+				},
+			},
+			wantErr: assert.Error,
+		},
+		{
+			name: "invalid environment selector",
+			fields: fields{
+				ChartReleaseV3Create: ChartReleaseV3Create{
+					Environment: "!!!!",
+				},
+			},
+			wantErr: assert.Error,
+		},
+		{
+			name: "not found environment",
+			fields: fields{
+				ChartReleaseV3Create: ChartReleaseV3Create{
+					Environment: "not-found",
+				},
+			},
+			wantErr: assert.Error,
+		},
+		{
+			name: "invalid chart release for app version follow",
+			fields: fields{
+				ChartReleaseV3Create: ChartReleaseV3Create{
+					AppVersionFollowChartRelease: "!!!!!",
+				},
+			},
+			wantErr: assert.Error,
+		},
+		{
+			name: "not found chart release for app version follow",
+			fields: fields{
+				ChartReleaseV3Create: ChartReleaseV3Create{
+					AppVersionFollowChartRelease: "not-found",
+				},
+			},
+			wantErr: assert.Error,
+		},
+		{
+			name: "invalid chart release for chart version follow",
+			fields: fields{
+				ChartReleaseV3Create: ChartReleaseV3Create{
+					ChartVersionFollowChartRelease: "!!!!!",
+				},
+			},
+			wantErr: assert.Error,
+		},
+		{
+			name: "not found chart release for chart version follow",
+			fields: fields{
+				ChartReleaseV3Create: ChartReleaseV3Create{
+					ChartVersionFollowChartRelease: "not-found",
+				},
+			},
+			wantErr: assert.Error,
+		},
+		{
+			name: "invalid app version reference",
+			fields: fields{
+				AppVersionReference: "!!!!",
+			},
+			wantErr: assert.Error,
+		},
+		{
+			name: "not found app version",
+			fields: fields{
+				AppVersionReference: "leonardo/not-found",
+			},
+			wantErr: assert.Error,
+		},
+		{
+			name: "invalid chart version reference",
+			fields: fields{
+				ChartVersionReference: "!!!!",
+			},
+			wantErr: assert.Error,
+		},
+		{
+			name: "not found chart version",
+			fields: fields{
+				ChartVersionReference: "leonardo/not-found",
+			},
+			wantErr: assert.Error,
+		},
+		{
+			name: "invalid pagerduty integration",
+			fields: fields{
+				ChartReleaseV3Create: ChartReleaseV3Create{
+					ChartReleaseV3Edit: ChartReleaseV3Edit{
+						PagerdutyIntegration: utils.PointerTo("!!!!!"),
+					},
+				},
+			},
+			wantErr: assert.Error,
+		},
+		{
+			name: "not found pagerduty integration",
+			fields: fields{
+				ChartReleaseV3Create: ChartReleaseV3Create{
+					ChartReleaseV3Edit: ChartReleaseV3Edit{
+						PagerdutyIntegration: utils.PointerTo("pd-id/not-found"),
+					},
+				},
+			},
+			wantErr: assert.Error,
+		},
+		{
+			name: "valid",
+			fields: fields{
+				CommonFields: CommonFields{
+					ID:        1,
+					CreatedAt: now.Add(-time.Hour),
+					UpdatedAt: now.Add(-time.Minute),
+				},
+				AppVersionReference:   fmt.Sprintf("leonardo/%s", appVersion.AppVersion),
+				ChartVersionReference: fmt.Sprintf("leonardo/%s", chartVersion.ChartVersion),
+				DestinationType:       "environment",
+				ResolvedAt:            &now,
+				ChartReleaseV3Create: ChartReleaseV3Create{
+					Chart:                          chart.Name,
+					Cluster:                        cluster.Name,
+					Environment:                    environment.Name,
+					Name:                           "name",
+					Namespace:                      "namespace",
+					AppVersionResolver:             utils.PointerTo("exact"),
+					AppVersionExact:                utils.PointerTo("v1.0.0"),
+					AppVersionBranch:               utils.PointerTo("branch"),
+					AppVersionCommit:               utils.PointerTo("commit"),
+					AppVersionFollowChartRelease:   chartReleaseDev.Name,
+					ChartVersionResolver:           utils.PointerTo("exact"),
+					ChartVersionExact:              utils.PointerTo("2.0.0"),
+					ChartVersionFollowChartRelease: chartReleaseStaging.Name,
+					HelmfileRef:                    utils.PointerTo("HEAD"),
+					HelmfileRefEnabled:             utils.PointerTo(true),
+					FirecloudDevelopRef:            utils.PointerTo("develop"),
+					ChartReleaseV3Edit: ChartReleaseV3Edit{
+						Subdomain:               utils.PointerTo("subdomain"),
+						Protocol:                utils.PointerTo("https"),
+						Port:                    utils.PointerTo[uint](443),
+						PagerdutyIntegration:    utils.PointerTo(utils.UintToString(pagerdutyIntegration.ID)),
+						IncludeInBulkChangesets: utils.PointerTo(true),
+					},
+				},
+			},
+			wantErr: assert.NoError,
+			want: models.ChartRelease{
+				Model: gorm.Model{
+					ID:        1,
+					CreatedAt: now.Add(-time.Hour),
+					UpdatedAt: now.Add(-time.Minute),
+				},
+				ChartID:         chart.ID,
+				ClusterID:       &cluster.ID,
+				DestinationType: "environment",
+				EnvironmentID:   &environment.ID,
+				Name:            "name",
+				Namespace:       "namespace",
+				ChartReleaseVersion: models.ChartReleaseVersion{
+					ResolvedAt:                       &now,
+					AppVersionResolver:               utils.PointerTo("exact"),
+					AppVersionExact:                  utils.PointerTo("v1.0.0"),
+					AppVersionBranch:                 utils.PointerTo("branch"),
+					AppVersionCommit:                 utils.PointerTo("commit"),
+					AppVersionFollowChartReleaseID:   &chartReleaseDev.ID,
+					AppVersionID:                     &appVersion.ID,
+					ChartVersionResolver:             utils.PointerTo("exact"),
+					ChartVersionExact:                utils.PointerTo("2.0.0"),
+					ChartVersionFollowChartReleaseID: &chartReleaseStaging.ID,
+					ChartVersionID:                   &chartVersion.ID,
+					HelmfileRef:                      utils.PointerTo("HEAD"),
+					HelmfileRefEnabled:               utils.PointerTo(true),
+					FirecloudDevelopRef:              utils.PointerTo("develop"),
+				},
+				Subdomain:               utils.PointerTo("subdomain"),
+				Protocol:                utils.PointerTo("https"),
+				Port:                    utils.PointerTo[uint](443),
+				PagerdutyIntegrationID:  &pagerdutyIntegration.ID,
+				IncludeInBulkChangesets: utils.PointerTo(true),
+			},
+		},
+	}
+	for _, tt := range tests {
+		s.Run(tt.name, func() {
+			c := ChartReleaseV3{
+				CommonFields:          tt.fields.CommonFields,
+				AppVersionReference:   tt.fields.AppVersionReference,
+				ChartVersionReference: tt.fields.ChartVersionReference,
+				DestinationType:       tt.fields.DestinationType,
+				ResolvedAt:            tt.fields.ResolvedAt,
+				ChartReleaseV3Create:  tt.fields.ChartReleaseV3Create,
+			}
+			got, err := c.toModel(s.DB)
+			if !tt.wantErr(s.T(), err, fmt.Sprintf("toModel()")) {
+				return
+			}
+			s.Equalf(tt.want, got, "toModel()")
+		})
+	}
+}
+
+func Test_chartReleaseFromModel(t *testing.T) {
+	now := time.Now()
+	type args struct {
+		model models.ChartRelease
+	}
+	tests := []struct {
+		name string
+		args args
+		want ChartReleaseV3
+	}{
+		{
+			name: "empty",
+			args: args{},
+			want: ChartReleaseV3{},
+		},
+		{
+			name: "full",
+			args: args{model: models.ChartRelease{
+				Model: gorm.Model{
+					ID:        1,
+					CreatedAt: now.Add(-time.Hour),
+					UpdatedAt: now.Add(-time.Minute),
+				},
+				CiIdentifier:            &models.CiIdentifier{Model: gorm.Model{ID: 2}},
+				Chart:                   &models.Chart{Model: gorm.Model{ID: 3}, Name: "leonardo"},
+				ChartID:                 3,
+				Cluster:                 &models.Cluster{Model: gorm.Model{ID: 4}, Name: "terra-prod"},
+				ClusterID:               utils.PointerTo[uint](4),
+				DestinationType:         "environment",
+				Environment:             &models.Environment{Model: gorm.Model{ID: 5}, Name: "prod"},
+				EnvironmentID:           utils.PointerTo[uint](5),
+				Name:                    "name",
+				Namespace:               "namespace",
+				Subdomain:               utils.PointerTo("subdomain"),
+				Protocol:                utils.PointerTo("https"),
+				Port:                    utils.PointerTo[uint](443),
+				PagerdutyIntegration:    &models.PagerdutyIntegration{Model: gorm.Model{ID: 6}, PagerdutyID: "blah"},
+				PagerdutyIntegrationID:  utils.PointerTo[uint](6),
+				IncludeInBulkChangesets: utils.PointerTo(true),
+				ChartReleaseVersion: models.ChartReleaseVersion{
+					ResolvedAt:                       &now,
+					AppVersionResolver:               utils.PointerTo("exact"),
+					AppVersionExact:                  utils.PointerTo("v1.0.0"),
+					AppVersionBranch:                 utils.PointerTo("branch"),
+					AppVersionCommit:                 utils.PointerTo("commit"),
+					AppVersionFollowChartRelease:     &models.ChartRelease{Model: gorm.Model{ID: 7}, Name: "leonardo-dev"},
+					AppVersionFollowChartReleaseID:   utils.PointerTo[uint](7),
+					AppVersion:                       &models.AppVersion{Model: gorm.Model{ID: 8}, AppVersion: "v1.0.0"},
+					AppVersionID:                     utils.PointerTo[uint](8),
+					ChartVersionResolver:             utils.PointerTo("exact"),
+					ChartVersionExact:                utils.PointerTo("2.0.0"),
+					ChartVersionFollowChartRelease:   &models.ChartRelease{Model: gorm.Model{ID: 9}, Name: "leonardo-staging"},
+					ChartVersionFollowChartReleaseID: utils.PointerTo[uint](9),
+					ChartVersion:                     &models.ChartVersion{Model: gorm.Model{ID: 10}, ChartVersion: "2.0.0"},
+					ChartVersionID:                   utils.PointerTo[uint](10),
+					HelmfileRef:                      utils.PointerTo("HEAD"),
+					HelmfileRefEnabled:               utils.PointerTo(true),
+					FirecloudDevelopRef:              utils.PointerTo("develop"),
+				},
+			}},
+			want: ChartReleaseV3{
+				CommonFields: CommonFields{
+					ID:        1,
+					CreatedAt: now.Add(-time.Hour),
+					UpdatedAt: now.Add(-time.Minute),
+				},
+				CiIdentifier:             &CiIdentifierV3{CommonFields: CommonFields{ID: 2}},
+				ChartInfo:                &ChartV3{CommonFields: CommonFields{ID: 3}, ChartV3Create: ChartV3Create{Name: "leonardo"}},
+				ClusterInfo:              &ClusterV3{CommonFields: CommonFields{ID: 4}, ClusterV3Create: ClusterV3Create{Name: "terra-prod"}},
+				EnvironmentInfo:          &EnvironmentV3{CommonFields: CommonFields{ID: 5}, EnvironmentV3Create: EnvironmentV3Create{Name: "prod"}},
+				AppVersionReference:      "leonardo/v1.0.0",
+				AppVersionInfo:           &AppVersionV3{CommonFields: CommonFields{ID: 8}, AppVersionV3Create: AppVersionV3Create{AppVersion: "v1.0.0"}},
+				ChartVersionReference:    "leonardo/2.0.0",
+				ChartVersionInfo:         &ChartVersionV3{CommonFields: CommonFields{ID: 10}, ChartVersionV3Create: ChartVersionV3Create{ChartVersion: "2.0.0"}},
+				PagerdutyIntegrationInfo: &PagerdutyIntegrationV3{CommonFields: CommonFields{ID: 6}, PagerdutyID: "blah"},
+				DestinationType:          "environment",
+				ResolvedAt:               &now,
+				ChartReleaseV3Create: ChartReleaseV3Create{
+					Chart:                          "leonardo",
+					Cluster:                        "terra-prod",
+					Environment:                    "prod",
+					Name:                           "name",
+					Namespace:                      "namespace",
+					AppVersionResolver:             utils.PointerTo("exact"),
+					AppVersionExact:                utils.PointerTo("v1.0.0"),
+					AppVersionBranch:               utils.PointerTo("branch"),
+					AppVersionCommit:               utils.PointerTo("commit"),
+					AppVersionFollowChartRelease:   "leonardo-dev",
+					ChartVersionResolver:           utils.PointerTo("exact"),
+					ChartVersionExact:              utils.PointerTo("2.0.0"),
+					ChartVersionFollowChartRelease: "leonardo-staging",
+					HelmfileRef:                    utils.PointerTo("HEAD"),
+					HelmfileRefEnabled:             utils.PointerTo(true),
+					FirecloudDevelopRef:            utils.PointerTo("develop"),
+					ChartReleaseV3Edit: ChartReleaseV3Edit{
+						Subdomain:               utils.PointerTo("subdomain"),
+						Protocol:                utils.PointerTo("https"),
+						Port:                    utils.PointerTo[uint](443),
+						PagerdutyIntegration:    utils.PointerTo("pd-id/blah"),
+						IncludeInBulkChangesets: utils.PointerTo(true),
+					},
+				},
+			},
+		},
+		{
+			name: "pagerduty ID case",
+			args: args{model: models.ChartRelease{
+				PagerdutyIntegrationID: utils.PointerTo[uint](6),
+			}},
+			want: ChartReleaseV3{
+				ChartReleaseV3Create: ChartReleaseV3Create{
+					ChartReleaseV3Edit: ChartReleaseV3Edit{
+						PagerdutyIntegration: utils.PointerTo("6"),
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, chartReleaseFromModel(tt.args.model), "chartReleaseFromModel(%v)", tt.args.model)
+		})
+	}
+}

--- a/sherlock/internal/api/sherlock/environments_v3.go
+++ b/sherlock/internal/api/sherlock/environments_v3.go
@@ -1,0 +1,201 @@
+package sherlock
+
+import (
+	"database/sql"
+	"github.com/broadinstitute/sherlock/go-shared/pkg/utils"
+	"github.com/broadinstitute/sherlock/sherlock/internal/models"
+	"github.com/google/uuid"
+	"github.com/rs/zerolog/log"
+	"gorm.io/gorm"
+	"time"
+)
+
+type EnvironmentV3 struct {
+	CommonFields
+	CiIdentifier             *CiIdentifierV3         `json:"ciIdentifier,omitempty" form:"-"`
+	TemplateEnvironmentInfo  *EnvironmentV3          `json:"templateEnvironmentInfo,omitempty" swaggertype:"object" form:"-"`
+	DefaultClusterInfo       *ClusterV3              `json:"defaultClusterInfo,omitempty" form:"-"`
+	PagerdutyIntegrationInfo *PagerdutyIntegrationV3 `json:"pagerdutyIntegrationInfo,omitempty" form:"-"`
+	OwnerInfo                *UserV3                 `json:"ownerInfo,omitempty" form:"-"`
+	EnvironmentV3Create
+}
+
+type EnvironmentV3Create struct {
+	Base                      string `json:"base" form:"base"`                                                          // Required when creating
+	AutoPopulateChartReleases *bool  `json:"autoPopulateChartReleases" form:"autoPopulateChartReleases" default:"true"` // If true when creating, dynamic environments copy from template and template environments get the honeycomb chart
+	Lifecycle                 string `json:"lifecycle" form:"lifecycle" default:"dynamic"`
+	Name                      string `json:"name" form:"name"`                                 // When creating, will be calculated if dynamic, required otherwise
+	TemplateEnvironment       string `json:"templateEnvironment" form:"templateEnvironment"`   // Required for dynamic environments
+	UniqueResourcePrefix      string `json:"uniqueResourcePrefix" form:"uniqueResourcePrefix"` // When creating, will be calculated if left empty
+	DefaultNamespace          string `json:"defaultNamespace" form:"defaultNamespace"`         // When creating, will be calculated if left empty
+	NamePrefix                string `json:"namePrefix" form:"namePrefix"`                     // Used for dynamic environment name generation only, to override using the owner email handle and template name
+	ValuesName                string `json:"valuesName" form:"valuesName"`                     // When creating, defaults to template name or environment name
+	EnvironmentV3Edit
+}
+
+type EnvironmentV3Edit struct {
+	DefaultCluster              *string    `json:"defaultCluster" form:"defaultCluster"`
+	DefaultFirecloudDevelopRef  *string    `json:"defaultFirecloudDevelopRef" form:"defaultFirecloudDevelopRef" default:"dev"` // should be the environment branch for live envs. Is usually dev for template/dynamic but not necessarily
+	Owner                       *string    `json:"owner" form:"owner"`                                                         // When creating, will default to you
+	RequiresSuitability         *bool      `json:"requiresSuitability" form:"requiresSuitability" default:"false"`
+	BaseDomain                  *string    `json:"baseDomain" form:"baseDomain" default:"bee.envs-terra.bio"`
+	NamePrefixesDomain          *bool      `json:"namePrefixesDomain" form:"namePrefixesDomain" default:"true"`
+	HelmfileRef                 *string    `json:"helmfileRef" form:"helmfileRef" default:"HEAD"`
+	PreventDeletion             *bool      `json:"preventDeletion" form:"preventDeletion" default:"false"` // Used to protect specific BEEs from deletion (thelma checks this field)
+	DeleteAfter                 *time.Time `json:"deleteAfter,omitempty" form:"deleteAfter"`               // If set, the BEE will be automatically deleted after this time (thelma checks this field)
+	Description                 *string    `json:"description" form:"description"`
+	PactIdentifier              *uuid.UUID `json:"pactIdentifier" form:"PactIdentifier"`
+	PagerdutyIntegration        *string    `json:"pagerdutyIntegration,omitempty" form:"pagerdutyIntegration"`
+	Offline                     *bool      `json:"offline" form:"offline" default:"false"`                                                 // Applicable for BEEs only, whether Thelma should render the BEE as "offline" zero replicas (this field is a target state, not a status)
+	OfflineScheduleBeginEnabled *bool      `json:"offlineScheduleBeginEnabled,omitempty" form:"offlineScheduleBeginEnabled"`               // When enabled, the BEE will be slated to go offline around the begin time each day
+	OfflineScheduleBeginTime    *time.Time `json:"offlineScheduleBeginTime,omitempty" form:"offlineScheduleBeginTime"  format:"date-time"` // Stored with timezone to determine day of the week
+	OfflineScheduleEndEnabled   *bool      `json:"offlineScheduleEndEnabled,omitempty" form:"offlineScheduleEndEnabled"`                   // When enabled, the BEE will be slated to come online around the end time each weekday (each day if weekends enabled)
+	OfflineScheduleEndTime      *time.Time `json:"offlineScheduleEndTime,omitempty" form:"offlineScheduleEndTime"  format:"date-time"`     // Stored with timezone to determine day of the week
+	OfflineScheduleEndWeekends  *bool      `json:"offlineScheduleEndWeekends,omitempty" form:"offlineScheduleEndWeekends"`
+}
+
+func (e EnvironmentV3) toModel(db *gorm.DB) (models.Environment, error) {
+	ret := models.Environment{
+		Model:                       e.CommonFields.toGormModel(),
+		Base:                        e.Base,
+		Lifecycle:                   e.Lifecycle,
+		Name:                        e.Name,
+		ValuesName:                  e.ValuesName,
+		AutoPopulateChartReleases:   e.AutoPopulateChartReleases,
+		UniqueResourcePrefix:        e.UniqueResourcePrefix,
+		DefaultNamespace:            e.DefaultNamespace,
+		DefaultFirecloudDevelopRef:  e.DefaultFirecloudDevelopRef,
+		RequiresSuitability:         e.RequiresSuitability,
+		BaseDomain:                  e.BaseDomain,
+		NamePrefixesDomain:          e.NamePrefixesDomain,
+		HelmfileRef:                 e.HelmfileRef,
+		PreventDeletion:             e.PreventDeletion,
+		Description:                 e.Description,
+		Offline:                     e.Offline,
+		OfflineScheduleBeginEnabled: e.OfflineScheduleBeginEnabled,
+		OfflineScheduleBeginTime:    utils.TimePtrToISO8601(e.OfflineScheduleBeginTime),
+		OfflineScheduleEndEnabled:   e.OfflineScheduleEndEnabled,
+		OfflineScheduleEndTime:      utils.TimePtrToISO8601(e.OfflineScheduleEndTime),
+		OfflineScheduleEndWeekends:  e.OfflineScheduleEndWeekends,
+		PactIdentifier:              e.PactIdentifier,
+	}
+	if e.DeleteAfter != nil {
+		ret.DeleteAfter = sql.NullTime{Time: *e.DeleteAfter, Valid: true}
+	}
+	if e.TemplateEnvironment != "" {
+		templateEnvironmentModel, err := environmentModelFromSelector(e.TemplateEnvironment)
+		if err != nil {
+			return models.Environment{}, err
+		}
+		var templateEnvironment models.Environment
+		if err = db.Where(&templateEnvironmentModel).Select("id").First(&templateEnvironment).Error; err != nil {
+			return models.Environment{}, err
+		} else {
+			ret.TemplateEnvironmentID = &templateEnvironment.ID
+		}
+	}
+	if e.DefaultCluster != nil && *e.DefaultCluster != "" {
+		defaultClusterModel, err := clusterModelFromSelector(*e.DefaultCluster)
+		if err != nil {
+			return models.Environment{}, err
+		}
+		var defaultCluster models.Cluster
+		if err = db.Where(&defaultClusterModel).Select("id").First(&defaultCluster).Error; err != nil {
+			return models.Environment{}, err
+		} else {
+			ret.DefaultClusterID = &defaultCluster.ID
+		}
+	}
+	if e.PagerdutyIntegration != nil && *e.PagerdutyIntegration != "" {
+		pagerdutyIntegrationModel, err := pagerdutyIntegrationModelFromSelector(*e.PagerdutyIntegration)
+		if err != nil {
+			return models.Environment{}, err
+		}
+		var pagerdutyIntegration models.PagerdutyIntegration
+		if err = db.Where(&pagerdutyIntegrationModel).Select("id").First(&pagerdutyIntegration).Error; err != nil {
+			return models.Environment{}, err
+		} else {
+			ret.PagerdutyIntegrationID = &pagerdutyIntegration.ID
+		}
+	}
+	if e.Owner != nil && *e.Owner != "" {
+		ownerModel, err := userModelFromSelector(*e.Owner)
+		if err != nil {
+			return models.Environment{}, err
+		}
+		var owner models.User
+		if err = db.Where(&ownerModel).Select("id").First(&owner).Error; err != nil {
+			return models.Environment{}, err
+		} else {
+			ret.OwnerID = &owner.ID
+		}
+	}
+	return ret, nil
+}
+
+func (e EnvironmentV3Create) toModel(db *gorm.DB) (models.Environment, error) {
+	return EnvironmentV3{EnvironmentV3Create: e}.toModel(db)
+}
+
+func (e EnvironmentV3Edit) toModel(db *gorm.DB) (models.Environment, error) {
+	return EnvironmentV3Create{EnvironmentV3Edit: e}.toModel(db)
+}
+
+func environmentFromModel(model models.Environment) EnvironmentV3 {
+	ret := EnvironmentV3{
+		CommonFields:             commonFieldsFromGormModel(model.Model),
+		CiIdentifier:             utils.NilOrCall(ciIdentifierFromModel, model.CiIdentifier),
+		TemplateEnvironmentInfo:  utils.NilOrCall(environmentFromModel, model.TemplateEnvironment),
+		DefaultClusterInfo:       utils.NilOrCall(clusterFromModel, model.DefaultCluster),
+		PagerdutyIntegrationInfo: utils.NilOrCall(pagerdutyIntegrationFromModel, model.PagerdutyIntegration),
+		OwnerInfo:                utils.NilOrCall(userFromModel, model.Owner),
+		EnvironmentV3Create: EnvironmentV3Create{
+			Base:                      model.Base,
+			AutoPopulateChartReleases: model.AutoPopulateChartReleases,
+			Lifecycle:                 model.Lifecycle,
+			Name:                      model.Name,
+			UniqueResourcePrefix:      model.UniqueResourcePrefix,
+			DefaultNamespace:          model.DefaultNamespace,
+			ValuesName:                model.ValuesName,
+			EnvironmentV3Edit: EnvironmentV3Edit{
+				DefaultFirecloudDevelopRef:  model.DefaultFirecloudDevelopRef,
+				RequiresSuitability:         model.RequiresSuitability,
+				BaseDomain:                  model.BaseDomain,
+				NamePrefixesDomain:          model.NamePrefixesDomain,
+				HelmfileRef:                 model.HelmfileRef,
+				PreventDeletion:             model.PreventDeletion,
+				Description:                 model.Description,
+				PactIdentifier:              model.PactIdentifier,
+				Offline:                     model.Offline,
+				OfflineScheduleBeginEnabled: model.OfflineScheduleBeginEnabled,
+				OfflineScheduleEndEnabled:   model.OfflineScheduleEndEnabled,
+				OfflineScheduleEndWeekends:  model.OfflineScheduleEndWeekends,
+			},
+		},
+	}
+	if model.TemplateEnvironment != nil {
+		ret.TemplateEnvironment = model.TemplateEnvironment.Name
+	}
+	if model.DefaultCluster != nil {
+		ret.DefaultCluster = &model.DefaultCluster.Name
+	}
+	if model.Owner != nil {
+		ret.Owner = &model.Owner.Email
+	}
+	if model.DeleteAfter.Valid {
+		ret.DeleteAfter = &model.DeleteAfter.Time
+	}
+	if model.PagerdutyIntegration != nil {
+		ret.PagerdutyIntegration = utils.PointerTo(utils.UintToString(model.PagerdutyIntegration.ID))
+	}
+	var err error
+	if ret.OfflineScheduleBeginTime, err = utils.ISO8601PtrToTime(model.OfflineScheduleBeginTime); err != nil {
+		log.Error().Uint("environment", model.ID).Err(err).Msg("failed to parse offline schedule begin time")
+		ret.OfflineScheduleBeginTime = nil
+	}
+	if ret.OfflineScheduleEndTime, err = utils.ISO8601PtrToTime(model.OfflineScheduleEndTime); err != nil {
+		log.Error().Uint("environment", model.ID).Err(err).Msg("failed to parse offline schedule end time")
+		ret.OfflineScheduleEndTime = nil
+	}
+	return ret
+}

--- a/sherlock/internal/api/sherlock/environments_v3.go
+++ b/sherlock/internal/api/sherlock/environments_v3.go
@@ -2,6 +2,7 @@ package sherlock
 
 import (
 	"database/sql"
+	"fmt"
 	"github.com/broadinstitute/sherlock/go-shared/pkg/utils"
 	"github.com/broadinstitute/sherlock/sherlock/internal/models"
 	"github.com/google/uuid"
@@ -185,8 +186,10 @@ func environmentFromModel(model models.Environment) EnvironmentV3 {
 	if model.DeleteAfter.Valid {
 		ret.DeleteAfter = &model.DeleteAfter.Time
 	}
-	if model.PagerdutyIntegration != nil {
-		ret.PagerdutyIntegration = utils.PointerTo(utils.UintToString(model.PagerdutyIntegration.ID))
+	if model.PagerdutyIntegration != nil && model.PagerdutyIntegration.PagerdutyID != "" {
+		ret.PagerdutyIntegration = utils.PointerTo(fmt.Sprintf("pd-id/%s", model.PagerdutyIntegration.PagerdutyID))
+	} else if model.PagerdutyIntegrationID != nil {
+		ret.PagerdutyIntegration = utils.PointerTo(utils.UintToString(*model.PagerdutyIntegrationID))
 	}
 	var err error
 	if ret.OfflineScheduleBeginTime, err = utils.ISO8601PtrToTime(model.OfflineScheduleBeginTime); err != nil {

--- a/sherlock/internal/api/sherlock/environments_v3.go
+++ b/sherlock/internal/api/sherlock/environments_v3.go
@@ -134,10 +134,12 @@ func (e EnvironmentV3) toModel(db *gorm.DB) (models.Environment, error) {
 	return ret, nil
 }
 
+//nolint:unused
 func (e EnvironmentV3Create) toModel(db *gorm.DB) (models.Environment, error) {
 	return EnvironmentV3{EnvironmentV3Create: e}.toModel(db)
 }
 
+//nolint:unused
 func (e EnvironmentV3Edit) toModel(db *gorm.DB) (models.Environment, error) {
 	return EnvironmentV3Create{EnvironmentV3Edit: e}.toModel(db)
 }

--- a/sherlock/internal/api/sherlock/environments_v3_get.go
+++ b/sherlock/internal/api/sherlock/environments_v3_get.go
@@ -1,0 +1,79 @@
+package sherlock
+
+import (
+	"fmt"
+	"github.com/broadinstitute/sherlock/go-shared/pkg/utils"
+	"github.com/broadinstitute/sherlock/sherlock/internal/authentication"
+	"github.com/broadinstitute/sherlock/sherlock/internal/errors"
+	"github.com/broadinstitute/sherlock/sherlock/internal/models"
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm/clause"
+	"net/http"
+	"strings"
+)
+
+// environmentsV3Get godoc
+//
+//	@summary		Get an individual Environment
+//	@description	Get an individual Environment.
+//	@tags			Environments
+//	@produce		json
+//	@param			selector				path		string	true	"The selector of the Environment, which can be either a numeric ID, the name, or 'resource-prefix' + / + the unique resource prefix."
+//	@success		200						{object}	EnvironmentV3
+//	@failure		400,403,404,407,409,500	{object}	errors.ErrorResponse
+//	@router			/api/environments/v3/{selector} [get]
+func environmentsV3Get(ctx *gin.Context) {
+	db, err := authentication.MustUseDB(ctx)
+	if err != nil {
+		return
+	}
+	query, err := environmentModelFromSelector(canonicalizeSelector(ctx.Param("selector")))
+	if err != nil {
+		errors.AbortRequest(ctx, err)
+		return
+	}
+	var result models.Environment
+	if err = db.Preload(clause.Associations).Where(&query).First(&result).Error; err != nil {
+		errors.AbortRequest(ctx, err)
+		return
+	}
+	ctx.JSON(http.StatusOK, environmentFromModel(result))
+}
+
+func environmentModelFromSelector(selector string) (query models.Environment, err error) {
+	if len(selector) == 0 {
+		return models.Environment{}, fmt.Errorf("(%s) selector cannot be empty", errors.BadRequest)
+	} else if utils.IsNumeric(selector) { // ID
+		query.ID, err = utils.ParseUint(selector)
+		return query, err
+	} else if utils.IsAlphaNumericWithHyphens(selector) &&
+		utils.IsStartingWithLetter(selector) &&
+		utils.IsEndingWithAlphaNumeric(selector) { // Name
+		query.Name = selector
+		return query, nil
+	} else if strings.Count(selector, "/") == 1 { // "resource-prefix" + unique resource prefix
+		parts := strings.Split(selector, "/")
+
+		// "resource-prefix"
+		// The reason we have this at all is so that we can differentiate resource prefix selectors from name selectors.
+		// In other words, a name can't have the slash that "resource-prefix/<blah>" has, so that's our hack to tell
+		// incoming selectors apart
+		selectorLabel := parts[0]
+		if selectorLabel != "resource-prefix" {
+			return models.Environment{}, fmt.Errorf("(%s) invalid environment selector %s, unique resource prefix selector needed to start with 'resource-prefix/' but was '%s/'", errors.BadRequest, selector, selectorLabel)
+		}
+
+		// unique resource prefix
+		uniqueResourcePrefix := parts[1]
+		if !(utils.IsLowerAlphaNumeric(uniqueResourcePrefix) &&
+			utils.IsStartingWithLetter(uniqueResourcePrefix) &&
+			utils.IsEndingWithAlphaNumeric(uniqueResourcePrefix) &&
+			len(uniqueResourcePrefix) == 4) {
+			return models.Environment{}, fmt.Errorf("(%s) invalid environment selector %s, unique resource prefix sub-selector %s was invalid", errors.BadRequest, selector, uniqueResourcePrefix)
+		}
+		query.UniqueResourcePrefix = uniqueResourcePrefix
+		return query, nil
+	} else {
+		return models.Environment{}, fmt.Errorf("(%s) invalid environment selector '%s'", errors.BadRequest, selector)
+	}
+}

--- a/sherlock/internal/api/sherlock/environments_v3_get_test.go
+++ b/sherlock/internal/api/sherlock/environments_v3_get_test.go
@@ -1,0 +1,112 @@
+package sherlock
+
+import (
+	"fmt"
+	"github.com/broadinstitute/sherlock/go-shared/pkg/testutils"
+	"github.com/broadinstitute/sherlock/sherlock/internal/errors"
+	"github.com/broadinstitute/sherlock/sherlock/internal/models"
+	"github.com/stretchr/testify/assert"
+	"gorm.io/gorm"
+	"net/http"
+	"testing"
+)
+
+func (s *handlerSuite) TestEnvironmentV3Get_badSelector() {
+	var got errors.ErrorResponse
+	code := s.HandleRequest(
+		s.NewRequest("GET", "/api/environments/v3/something/with/too/many/slashes", nil),
+		&got)
+	s.Equal(http.StatusBadRequest, code)
+	s.Equal(errors.BadRequest, got.Type)
+}
+
+func (s *handlerSuite) TestEnvironmentV3Get_notFound() {
+	var got errors.ErrorResponse
+	code := s.HandleRequest(
+		s.NewRequest("GET", "/api/environments/v3/123", nil),
+		&got)
+	s.Equal(http.StatusNotFound, code)
+	s.Equal(errors.NotFound, got.Type)
+}
+
+func (s *handlerSuite) TestEnvironmentV3Get() {
+	environment := s.TestData.Environment_Prod()
+
+	var got EnvironmentV3
+	code := s.HandleRequest(
+		s.NewRequest("GET", "/api/environments/v3/"+environment.Name, nil),
+		&got)
+	s.Equal(http.StatusOK, code)
+	s.Equal(environment.Name, got.Name)
+}
+
+func Test_environmentModelFromSelector(t *testing.T) {
+	type args struct {
+		selector string
+	}
+	tests := []struct {
+		name      string
+		args      args
+		wantQuery models.Environment
+		wantErr   assert.ErrorAssertionFunc
+	}{
+		{
+			name:    "empty",
+			args:    args{selector: ""},
+			wantErr: assert.Error,
+		},
+		{
+			name:    "invalid",
+			args:    args{selector: "something obviously invalid!"},
+			wantErr: assert.Error,
+		},
+		{
+			name: "valid id",
+			args: args{selector: "123"},
+			wantQuery: models.Environment{
+				Model: gorm.Model{ID: 123},
+			},
+			wantErr: assert.NoError,
+		},
+		{
+			name:    "invalid id",
+			args:    args{selector: testutils.StringNumberTooBigForInt},
+			wantErr: assert.Error,
+		},
+		{
+			name: "name",
+			args: args{selector: "prod"},
+			wantQuery: models.Environment{
+				Name: "prod",
+			},
+			wantErr: assert.NoError,
+		},
+		{
+			name: "unique resource prefix",
+			args: args{selector: "resource-prefix/abcd"},
+			wantQuery: models.Environment{
+				UniqueResourcePrefix: "abcd",
+			},
+			wantErr: assert.NoError,
+		},
+		{
+			name:    "invalid unique resource prefix",
+			args:    args{selector: "resource-prefix/abcde"},
+			wantErr: assert.Error,
+		},
+		{
+			name:    "invalid differentiator on selector",
+			args:    args{selector: "something-else/abcd"},
+			wantErr: assert.Error,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotQuery, err := environmentModelFromSelector(tt.args.selector)
+			if !tt.wantErr(t, err, fmt.Sprintf("environmentModelFromSelector(%v)", tt.args.selector)) {
+				return
+			}
+			assert.Equalf(t, tt.wantQuery, gotQuery, "environmentModelFromSelector(%v)", tt.args.selector)
+		})
+	}
+}

--- a/sherlock/internal/api/sherlock/environments_v3_list.go
+++ b/sherlock/internal/api/sherlock/environments_v3_list.go
@@ -1,0 +1,65 @@
+package sherlock
+
+import (
+	"fmt"
+	"github.com/broadinstitute/sherlock/go-shared/pkg/utils"
+	"github.com/broadinstitute/sherlock/sherlock/internal/authentication"
+	"github.com/broadinstitute/sherlock/sherlock/internal/errors"
+	"github.com/broadinstitute/sherlock/sherlock/internal/models"
+	"github.com/gin-gonic/gin"
+	"net/http"
+)
+
+// environmentsV3List godoc
+//
+//	@summary		List Environments matching a filter
+//	@description	List Environments matching a filter.
+//	@tags			Environments
+//	@produce		json
+//	@param			filter					query		EnvironmentV3	false	"Filter the returned Environments"
+//	@param			limit					query		int				false	"Control how many Environments are returned (default 0, meaning all)"
+//	@param			offset					query		int				false	"Control the offset for the returned Environments (default 0)"
+//	@success		200						{array}		EnvironmentV3
+//	@failure		400,403,404,407,409,500	{object}	errors.ErrorResponse
+//	@router			/api/environments/v3 [get]
+func environmentsV3List(ctx *gin.Context) {
+	db, err := authentication.MustUseDB(ctx)
+	if err != nil {
+		return
+	}
+	var filter EnvironmentV3
+	if err = ctx.ShouldBindQuery(&filter); err != nil {
+		errors.AbortRequest(ctx, err)
+		return
+	}
+	modelFilter, err := filter.toModel(db)
+	if err != nil {
+		errors.AbortRequest(ctx, err)
+		return
+	}
+
+	limit, err := utils.ParseInt(ctx.DefaultQuery("limit", "0"))
+	if err != nil {
+		errors.AbortRequest(ctx, fmt.Errorf("(%s) %v", errors.BadRequest, err))
+		return
+	}
+	offset, err := utils.ParseInt(ctx.DefaultQuery("offset", "0"))
+	if err != nil {
+		errors.AbortRequest(ctx, fmt.Errorf("(%s) %v", errors.BadRequest, err))
+		return
+	}
+	var results []models.Environment
+	chain := db.
+		Where(&modelFilter)
+	if limit > 0 {
+		chain = chain.Limit(limit)
+	}
+	if err = chain.
+		Offset(offset).
+		Order("name asc").
+		Find(&results).Error; err != nil {
+		errors.AbortRequest(ctx, err)
+		return
+	}
+	ctx.JSON(http.StatusOK, utils.Map(results, environmentFromModel))
+}

--- a/sherlock/internal/api/sherlock/environments_v3_list_test.go
+++ b/sherlock/internal/api/sherlock/environments_v3_list_test.go
@@ -1,0 +1,89 @@
+package sherlock
+
+import (
+	"github.com/broadinstitute/sherlock/sherlock/internal/errors"
+	"net/http"
+)
+
+func (s *handlerSuite) TestEnvironmentsV3List_none() {
+	var got []EnvironmentV3
+	code := s.HandleRequest(
+		s.NewRequest("GET", "/api/environments/v3", nil),
+		&got)
+	s.Equal(http.StatusOK, code)
+	s.Len(got, 0)
+}
+
+func (s *handlerSuite) TestEnvironmentsV3List_badFilter() {
+	var got errors.ErrorResponse
+	code := s.HandleRequest(
+		s.NewRequest("GET", "/api/environments/v3?id=foo", nil),
+		&got)
+	s.Equal(http.StatusBadRequest, code)
+	s.Equal(errors.BadRequest, got.Type)
+}
+
+func (s *handlerSuite) TestEnvironmentsV3List_badLimit() {
+	var got errors.ErrorResponse
+	code := s.HandleRequest(
+		s.NewRequest("GET", "/api/environments/v3?limit=foo", nil),
+		&got)
+	s.Equal(http.StatusBadRequest, code)
+	s.Equal(errors.BadRequest, got.Type)
+}
+
+func (s *handlerSuite) TestEnvironmentsV3List_badOffset() {
+	var got errors.ErrorResponse
+	code := s.HandleRequest(
+		s.NewRequest("GET", "/api/environments/v3?offset=foo", nil),
+		&got)
+	s.Equal(http.StatusBadRequest, code)
+	s.Equal(errors.BadRequest, got.Type)
+}
+
+func (s *handlerSuite) TestEnvironmentsV3List() {
+	s.TestData.Environment_Prod()
+	s.TestData.Environment_Dev()
+	s.TestData.Environment_Swatomation()
+	s.TestData.Environment_Swatomation_DevBee()
+
+	s.Run("all", func() {
+		var got []EnvironmentV3
+		code := s.HandleRequest(
+			s.NewRequest("GET", "/api/environments/v3", nil),
+			&got)
+		s.Equal(http.StatusOK, code)
+		s.Len(got, 4)
+	})
+	s.Run("none", func() {
+		var got []EnvironmentV3
+		code := s.HandleRequest(
+			s.NewRequest("GET", "/api/environments/v3?name=foo", nil),
+			&got)
+		s.Equal(http.StatusOK, code)
+		s.Len(got, 0)
+	})
+	s.Run("some", func() {
+		var got []EnvironmentV3
+		code := s.HandleRequest(
+			s.NewRequest("GET", "/api/environments/v3?name=prod", nil),
+			&got)
+		s.Equal(http.StatusOK, code)
+		s.Len(got, 1)
+	})
+	s.Run("limit and offset", func() {
+		var got1 []EnvironmentV3
+		code := s.HandleRequest(
+			s.NewRequest("GET", "/api/environments/v3?limit=1", nil),
+			&got1)
+		s.Equal(http.StatusOK, code)
+		s.Len(got1, 1)
+		var got2 []EnvironmentV3
+		code = s.HandleRequest(
+			s.NewRequest("GET", "/api/environments/v3?limit=1&offset=1", nil),
+			&got2)
+		s.Equal(http.StatusOK, code)
+		s.Len(got2, 1)
+		s.NotEqual(got1[0].ID, got2[0].ID)
+	})
+}

--- a/sherlock/internal/api/sherlock/environments_v3_test.go
+++ b/sherlock/internal/api/sherlock/environments_v3_test.go
@@ -1,0 +1,346 @@
+package sherlock
+
+import (
+	"database/sql"
+	"fmt"
+	"github.com/broadinstitute/sherlock/go-shared/pkg/utils"
+	"github.com/broadinstitute/sherlock/sherlock/internal/models"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"gorm.io/gorm"
+	"testing"
+	"time"
+)
+
+func (s *handlerSuite) TestEnvironmentV3_toModel() {
+	now := time.Now()
+	templateEnvironment := s.TestData.Environment_Swatomation()
+	defaultCluster := s.TestData.Cluster_TerraQaBees()
+	pagerdutyIntegration := s.TestData.PagerdutyIntegration_ManuallyTriggeredTerraIncident()
+	owner := s.TestData.User_Suitable()
+	pactUuid := uuid.New()
+	type fields struct {
+		CommonFields        CommonFields
+		EnvironmentV3Create EnvironmentV3Create
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		want    models.Environment
+		wantErr assert.ErrorAssertionFunc
+	}{
+		{
+			name:    "empty",
+			fields:  fields{},
+			wantErr: assert.NoError,
+			want:    models.Environment{},
+		},
+		{
+			name: "delete after",
+			fields: fields{
+				EnvironmentV3Create: EnvironmentV3Create{
+					EnvironmentV3Edit: EnvironmentV3Edit{
+						DeleteAfter: &now,
+					},
+				},
+			},
+			wantErr: assert.NoError,
+			want: models.Environment{
+				DeleteAfter: sql.NullTime{
+					Time:  now,
+					Valid: true,
+				},
+			},
+		},
+		{
+			name: "invalid template env selector",
+			fields: fields{
+				EnvironmentV3Create: EnvironmentV3Create{
+					TemplateEnvironment: "!!!!!",
+				},
+			},
+			wantErr: assert.Error,
+		},
+		{
+			name: "not found template env",
+			fields: fields{
+				EnvironmentV3Create: EnvironmentV3Create{
+					TemplateEnvironment: "not-found",
+				},
+			},
+			wantErr: assert.Error,
+		},
+		{
+			name: "invalid cluster selector",
+			fields: fields{
+				EnvironmentV3Create: EnvironmentV3Create{
+					EnvironmentV3Edit: EnvironmentV3Edit{
+						DefaultCluster: utils.PointerTo("!!!!!"),
+					},
+				},
+			},
+			wantErr: assert.Error,
+		},
+		{
+			name: "not found cluster",
+			fields: fields{
+				EnvironmentV3Create: EnvironmentV3Create{
+					EnvironmentV3Edit: EnvironmentV3Edit{
+						DefaultCluster: utils.PointerTo("not-found"),
+					},
+				},
+			},
+			wantErr: assert.Error,
+		},
+		{
+			name: "invalid pagerduty integration selector",
+			fields: fields{
+				EnvironmentV3Create: EnvironmentV3Create{
+					EnvironmentV3Edit: EnvironmentV3Edit{
+						PagerdutyIntegration: utils.PointerTo("!!!!!"),
+					},
+				},
+			},
+			wantErr: assert.Error,
+		},
+		{
+			name: "not found pagerduty integration",
+			fields: fields{
+				EnvironmentV3Create: EnvironmentV3Create{
+					EnvironmentV3Edit: EnvironmentV3Edit{
+						PagerdutyIntegration: utils.PointerTo("pd-id/not-found"),
+					},
+				},
+			},
+			wantErr: assert.Error,
+		},
+		{
+			name: "invalid owner selector",
+			fields: fields{
+				EnvironmentV3Create: EnvironmentV3Create{
+					EnvironmentV3Edit: EnvironmentV3Edit{
+						Owner: utils.PointerTo("!!!!!"),
+					},
+				},
+			},
+			wantErr: assert.Error,
+		},
+		{
+			name: "not found owner",
+			fields: fields{
+				EnvironmentV3Create: EnvironmentV3Create{
+					EnvironmentV3Edit: EnvironmentV3Edit{
+						Owner: utils.PointerTo("not-found@example.com"),
+					},
+				},
+			},
+			wantErr: assert.Error,
+		},
+		{
+			name: "valid",
+			fields: fields{
+				CommonFields: CommonFields{
+					ID:        1,
+					CreatedAt: now.Add(-time.Hour),
+					UpdatedAt: now.Add(-time.Minute),
+				},
+				EnvironmentV3Create: EnvironmentV3Create{
+					Base:                      "base",
+					AutoPopulateChartReleases: utils.PointerTo(true),
+					Lifecycle:                 "lifecycle",
+					Name:                      "name",
+					TemplateEnvironment:       templateEnvironment.Name,
+					UniqueResourcePrefix:      "unique-resource-prefix",
+					DefaultNamespace:          "default-namespace",
+					NamePrefix:                "name-prefix",
+					ValuesName:                "values-name",
+					EnvironmentV3Edit: EnvironmentV3Edit{
+						DefaultCluster:              utils.PointerTo(defaultCluster.Name),
+						DefaultFirecloudDevelopRef:  utils.PointerTo("develop"),
+						Owner:                       utils.PointerTo(owner.Email),
+						RequiresSuitability:         utils.PointerTo(true),
+						BaseDomain:                  utils.PointerTo("base-domain"),
+						NamePrefixesDomain:          utils.PointerTo(true),
+						HelmfileRef:                 utils.PointerTo("HEAD"),
+						PreventDeletion:             utils.PointerTo(true),
+						DeleteAfter:                 utils.PointerTo(now),
+						Description:                 utils.PointerTo("description"),
+						PactIdentifier:              utils.PointerTo(pactUuid),
+						PagerdutyIntegration:        utils.PointerTo(utils.UintToString(pagerdutyIntegration.ID)),
+						Offline:                     utils.PointerTo(true),
+						OfflineScheduleBeginEnabled: utils.PointerTo(true),
+						OfflineScheduleBeginTime:    utils.PointerTo(now),
+						OfflineScheduleEndEnabled:   utils.PointerTo(true),
+						OfflineScheduleEndTime:      utils.PointerTo(now),
+						OfflineScheduleEndWeekends:  utils.PointerTo(true),
+					},
+				},
+			},
+			wantErr: assert.NoError,
+			want: models.Environment{
+				Model: gorm.Model{
+					ID:        1,
+					CreatedAt: now.Add(-time.Hour),
+					UpdatedAt: now.Add(-time.Minute),
+				},
+				Base:                       "base",
+				Lifecycle:                  "lifecycle",
+				Name:                       "name",
+				TemplateEnvironmentID:      &templateEnvironment.ID,
+				ValuesName:                 "values-name",
+				AutoPopulateChartReleases:  utils.PointerTo(true),
+				UniqueResourcePrefix:       "unique-resource-prefix",
+				DefaultNamespace:           "default-namespace",
+				DefaultClusterID:           &defaultCluster.ID,
+				DefaultFirecloudDevelopRef: utils.PointerTo("develop"),
+				OwnerID:                    &owner.ID,
+				RequiresSuitability:        utils.PointerTo(true),
+				BaseDomain:                 utils.PointerTo("base-domain"),
+				NamePrefixesDomain:         utils.PointerTo(true),
+				HelmfileRef:                utils.PointerTo("HEAD"),
+				PreventDeletion:            utils.PointerTo(true),
+				DeleteAfter: sql.NullTime{
+					Time:  now,
+					Valid: true,
+				},
+				Description:                 utils.PointerTo("description"),
+				PagerdutyIntegrationID:      &pagerdutyIntegration.ID,
+				Offline:                     utils.PointerTo(true),
+				OfflineScheduleBeginEnabled: utils.PointerTo(true),
+				OfflineScheduleBeginTime:    utils.TimePtrToISO8601(&now),
+				OfflineScheduleEndEnabled:   utils.PointerTo(true),
+				OfflineScheduleEndTime:      utils.TimePtrToISO8601(&now),
+				OfflineScheduleEndWeekends:  utils.PointerTo(true),
+				PactIdentifier:              &pactUuid,
+			},
+		},
+	}
+	for _, tt := range tests {
+		s.Run(tt.name, func() {
+			e := EnvironmentV3{
+				CommonFields:        tt.fields.CommonFields,
+				EnvironmentV3Create: tt.fields.EnvironmentV3Create,
+			}
+			got, err := e.toModel(s.DB)
+			if !tt.wantErr(s.T(), err, fmt.Sprintf("toModel()")) {
+				return
+			}
+			s.Equalf(tt.want, got, "toModel()")
+		})
+	}
+}
+
+func Test_environmentFromModel(t *testing.T) {
+	now := time.Now()
+	nowString := utils.TimePtrToISO8601(&now)
+	nowTimeParsedAgain, err := utils.ISO8601PtrToTime(nowString)
+	assert.NoError(t, err)
+	pactUuid := uuid.New()
+	type args struct {
+		model models.Environment
+	}
+	tests := []struct {
+		name string
+		args args
+		want EnvironmentV3
+	}{
+		{
+			name: "empty",
+			args: args{},
+			want: EnvironmentV3{},
+		},
+		{
+			name: "full",
+			args: args{model: models.Environment{
+				Model: gorm.Model{
+					ID:        1,
+					CreatedAt: now.Add(-time.Hour),
+					UpdatedAt: now.Add(-time.Minute),
+				},
+				CiIdentifier:               &models.CiIdentifier{Model: gorm.Model{ID: 2}},
+				Base:                       "base",
+				Lifecycle:                  "lifecycle",
+				Name:                       "name",
+				TemplateEnvironment:        &models.Environment{Model: gorm.Model{ID: 3}, Name: "name-3"},
+				TemplateEnvironmentID:      utils.PointerTo[uint](3),
+				ValuesName:                 "values-name",
+				AutoPopulateChartReleases:  utils.PointerTo(true),
+				UniqueResourcePrefix:       "unique-resource-prefix",
+				DefaultNamespace:           "default-namespace",
+				DefaultCluster:             &models.Cluster{Model: gorm.Model{ID: 4}, Name: "name-4"},
+				DefaultClusterID:           utils.PointerTo[uint](4),
+				DefaultFirecloudDevelopRef: utils.PointerTo("develop"),
+				Owner:                      &models.User{Model: gorm.Model{ID: 5}, Email: "example@example.com"},
+				OwnerID:                    utils.PointerTo[uint](5),
+				RequiresSuitability:        utils.PointerTo(true),
+				BaseDomain:                 utils.PointerTo("base-domain"),
+				NamePrefixesDomain:         utils.PointerTo(true),
+				HelmfileRef:                utils.PointerTo("HEAD"),
+				PreventDeletion:            utils.PointerTo(true),
+				DeleteAfter: sql.NullTime{
+					Time:  now,
+					Valid: true,
+				},
+				Description:                 utils.PointerTo("description"),
+				PagerdutyIntegration:        &models.PagerdutyIntegration{Model: gorm.Model{ID: 6}, PagerdutyID: "pagerduty-id"},
+				PagerdutyIntegrationID:      utils.PointerTo[uint](6),
+				Offline:                     utils.PointerTo(true),
+				OfflineScheduleBeginEnabled: utils.PointerTo(true),
+				OfflineScheduleBeginTime:    utils.TimePtrToISO8601(&now),
+				OfflineScheduleEndEnabled:   utils.PointerTo(true),
+				OfflineScheduleEndTime:      utils.TimePtrToISO8601(&now),
+				OfflineScheduleEndWeekends:  utils.PointerTo(true),
+				PactIdentifier:              &pactUuid,
+			}},
+			want: EnvironmentV3{
+				CommonFields: CommonFields{
+					ID:        1,
+					CreatedAt: now.Add(-time.Hour),
+					UpdatedAt: now.Add(-time.Minute),
+				},
+				CiIdentifier:             &CiIdentifierV3{CommonFields: CommonFields{ID: 2}},
+				TemplateEnvironmentInfo:  &EnvironmentV3{CommonFields: CommonFields{ID: 3}, EnvironmentV3Create: EnvironmentV3Create{Name: "name-3"}},
+				DefaultClusterInfo:       &ClusterV3{CommonFields: CommonFields{ID: 4}, ClusterV3Create: ClusterV3Create{Name: "name-4"}},
+				PagerdutyIntegrationInfo: &PagerdutyIntegrationV3{CommonFields: CommonFields{ID: 6}, PagerdutyID: "pagerduty-id"},
+				OwnerInfo: &UserV3{CommonFields: CommonFields{ID: 5}, Email: "example@example.com", Suitable: utils.PointerTo(false),
+					SuitabilityDescription: utils.PointerTo("user example@example.com lacks production suitability")},
+				EnvironmentV3Create: EnvironmentV3Create{
+					Base:                      "base",
+					AutoPopulateChartReleases: utils.PointerTo(true),
+					Lifecycle:                 "lifecycle",
+					Name:                      "name",
+					TemplateEnvironment:       "name-3",
+					UniqueResourcePrefix:      "unique-resource-prefix",
+					DefaultNamespace:          "default-namespace",
+					NamePrefix:                "",
+					ValuesName:                "values-name",
+					EnvironmentV3Edit: EnvironmentV3Edit{
+						DefaultCluster:              utils.PointerTo("name-4"),
+						DefaultFirecloudDevelopRef:  utils.PointerTo("develop"),
+						Owner:                       utils.PointerTo("example@example.com"),
+						RequiresSuitability:         utils.PointerTo(true),
+						BaseDomain:                  utils.PointerTo("base-domain"),
+						NamePrefixesDomain:          utils.PointerTo(true),
+						HelmfileRef:                 utils.PointerTo("HEAD"),
+						PreventDeletion:             utils.PointerTo(true),
+						DeleteAfter:                 utils.PointerTo(now),
+						Description:                 utils.PointerTo("description"),
+						PactIdentifier:              utils.PointerTo(pactUuid),
+						PagerdutyIntegration:        utils.PointerTo("6"),
+						Offline:                     utils.PointerTo(true),
+						OfflineScheduleBeginEnabled: utils.PointerTo(true),
+						OfflineScheduleBeginTime:    nowTimeParsedAgain,
+						OfflineScheduleEndEnabled:   utils.PointerTo(true),
+						OfflineScheduleEndTime:      nowTimeParsedAgain,
+						OfflineScheduleEndWeekends:  utils.PointerTo(true),
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, environmentFromModel(tt.args.model), "environmentFromModel(%v)", tt.args.model)
+		})
+	}
+}

--- a/sherlock/internal/api/sherlock/environments_v3_test.go
+++ b/sherlock/internal/api/sherlock/environments_v3_test.go
@@ -282,7 +282,7 @@ func Test_environmentFromModel(t *testing.T) {
 					Valid: true,
 				},
 				Description:                 utils.PointerTo("description"),
-				PagerdutyIntegration:        &models.PagerdutyIntegration{Model: gorm.Model{ID: 6}, PagerdutyID: "pagerduty-id"},
+				PagerdutyIntegration:        &models.PagerdutyIntegration{Model: gorm.Model{ID: 6}, PagerdutyID: "blah"},
 				PagerdutyIntegrationID:      utils.PointerTo[uint](6),
 				Offline:                     utils.PointerTo(true),
 				OfflineScheduleBeginEnabled: utils.PointerTo(true),
@@ -301,7 +301,7 @@ func Test_environmentFromModel(t *testing.T) {
 				CiIdentifier:             &CiIdentifierV3{CommonFields: CommonFields{ID: 2}},
 				TemplateEnvironmentInfo:  &EnvironmentV3{CommonFields: CommonFields{ID: 3}, EnvironmentV3Create: EnvironmentV3Create{Name: "name-3"}},
 				DefaultClusterInfo:       &ClusterV3{CommonFields: CommonFields{ID: 4}, ClusterV3Create: ClusterV3Create{Name: "name-4"}},
-				PagerdutyIntegrationInfo: &PagerdutyIntegrationV3{CommonFields: CommonFields{ID: 6}, PagerdutyID: "pagerduty-id"},
+				PagerdutyIntegrationInfo: &PagerdutyIntegrationV3{CommonFields: CommonFields{ID: 6}, PagerdutyID: "blah"},
 				OwnerInfo: &UserV3{CommonFields: CommonFields{ID: 5}, Email: "example@example.com", Suitable: utils.PointerTo(false),
 					SuitabilityDescription: utils.PointerTo("user example@example.com lacks production suitability")},
 				EnvironmentV3Create: EnvironmentV3Create{
@@ -326,13 +326,26 @@ func Test_environmentFromModel(t *testing.T) {
 						DeleteAfter:                 utils.PointerTo(now),
 						Description:                 utils.PointerTo("description"),
 						PactIdentifier:              utils.PointerTo(pactUuid),
-						PagerdutyIntegration:        utils.PointerTo("6"),
+						PagerdutyIntegration:        utils.PointerTo("pd-id/blah"),
 						Offline:                     utils.PointerTo(true),
 						OfflineScheduleBeginEnabled: utils.PointerTo(true),
 						OfflineScheduleBeginTime:    nowTimeParsedAgain,
 						OfflineScheduleEndEnabled:   utils.PointerTo(true),
 						OfflineScheduleEndTime:      nowTimeParsedAgain,
 						OfflineScheduleEndWeekends:  utils.PointerTo(true),
+					},
+				},
+			},
+		},
+		{
+			name: "pagerduty ID case",
+			args: args{model: models.Environment{
+				PagerdutyIntegrationID: utils.PointerTo[uint](6),
+			}},
+			want: EnvironmentV3{
+				EnvironmentV3Create: EnvironmentV3Create{
+					EnvironmentV3Edit: EnvironmentV3Edit{
+						PagerdutyIntegration: utils.PointerTo("6"),
 					},
 				},
 			},

--- a/sherlock/internal/api/sherlock/environments_v3_test.go
+++ b/sherlock/internal/api/sherlock/environments_v3_test.go
@@ -2,7 +2,6 @@ package sherlock
 
 import (
 	"database/sql"
-	"fmt"
 	"github.com/broadinstitute/sherlock/go-shared/pkg/utils"
 	"github.com/broadinstitute/sherlock/sherlock/internal/models"
 	"github.com/google/uuid"
@@ -222,7 +221,7 @@ func (s *handlerSuite) TestEnvironmentV3_toModel() {
 				EnvironmentV3Create: tt.fields.EnvironmentV3Create,
 			}
 			got, err := e.toModel(s.DB)
-			if !tt.wantErr(s.T(), err, fmt.Sprintf("toModel()")) {
+			if !tt.wantErr(s.T(), err, "toModel()") {
 				return
 			}
 			s.Equalf(tt.want, got, "toModel()")

--- a/sherlock/internal/api/sherlock/routes.go
+++ b/sherlock/internal/api/sherlock/routes.go
@@ -104,6 +104,7 @@ func ConfigureRoutes(apiRouter gin.IRoutes) {
 	apiRouter.PATCH("pagerduty-integrations/v3/*selector", pagerdutyIntegrationsV3Edit)
 	apiRouter.DELETE("pagerduty-integrations/v3/*selector", pagerdutyIntegrationsV3Delete)
 	apiRouter.POST("pagerduty-integrations/v3", pagerdutyIntegrationsV3Create)
+
 	apiRouter.GET("environments/v3/*selector", environmentsV3Get)
 	apiRouter.GET("environments/v3", environmentsV3List)
 

--- a/sherlock/internal/api/sherlock/routes.go
+++ b/sherlock/internal/api/sherlock/routes.go
@@ -104,4 +104,9 @@ func ConfigureRoutes(apiRouter gin.IRoutes) {
 	apiRouter.PATCH("pagerduty-integrations/v3/*selector", pagerdutyIntegrationsV3Edit)
 	apiRouter.DELETE("pagerduty-integrations/v3/*selector", pagerdutyIntegrationsV3Delete)
 	apiRouter.POST("pagerduty-integrations/v3", pagerdutyIntegrationsV3Create)
+	apiRouter.GET("environments/v3/*selector", environmentsV3Get)
+	apiRouter.GET("environments/v3", environmentsV3List)
+
+	apiRouter.GET("chart-releases/v3/*selector", chartReleasesV3Get)
+	apiRouter.GET("chart-releases/v3", chartReleasesV3List)
 }

--- a/sherlock/internal/models/environment.go
+++ b/sherlock/internal/models/environment.go
@@ -9,6 +9,7 @@ import (
 	"github.com/broadinstitute/sherlock/sherlock/internal/config"
 	"github.com/broadinstitute/sherlock/sherlock/internal/errors"
 	"github.com/broadinstitute/sherlock/sherlock/internal/slack"
+	"github.com/google/uuid"
 	"gorm.io/gorm"
 	"strings"
 	"time"
@@ -48,6 +49,7 @@ type Environment struct {
 	OfflineScheduleEndEnabled   *bool
 	OfflineScheduleEndTime      *string
 	OfflineScheduleEndWeekends  *bool
+	PactIdentifier              *uuid.UUID
 }
 
 func (e *Environment) GetCiIdentifier() CiIdentifier {


### PR DESCRIPTION
Environment and ChartRelease GET endpoints, in refactored v3 format.

I noticed that the Pact UUID didn't make it into the new model type for environments, so I added it there too.

## Testing

Lots. I did field-by-field for the data types back and forth, too.

## Risk

Very low, new read-only endpoints.