### PR TITLE
[DDO-3449] Chart Release v3 create

### DIFF
--- a/sherlock/db/migrations/000076_block_duplicate_chart_releases.down.sql
+++ b/sherlock/db/migrations/000076_block_duplicate_chart_releases.down.sql
@@ -1,0 +1,5 @@
+drop index if exists chart_releases_name_unique;
+
+drop index if exists chart_releases_environment_chart_unique;
+
+drop index if exists chart_releases_cluster_namespace_chart_unique;

--- a/sherlock/db/migrations/000076_block_duplicate_chart_releases.up.sql
+++ b/sherlock/db/migrations/000076_block_duplicate_chart_releases.up.sql
@@ -1,0 +1,11 @@
+create unique index chart_releases_name_unique
+    on chart_releases (name)
+    where deleted_at is null;
+
+create unique index chart_releases_environment_chart_unique
+    on chart_releases (environment_id, chart_id)
+    where deleted_at is null and environment_id is not null;
+
+create unique index chart_releases_cluster_namespace_chart_unique
+    on chart_releases (cluster_id, namespace, chart_id)
+    where deleted_at is null and cluster_id is not null and namespace is not null;

--- a/sherlock/internal/api/sherlock/chart_releases_v3.go
+++ b/sherlock/internal/api/sherlock/chart_releases_v3.go
@@ -84,7 +84,7 @@ func (c ChartReleaseV3) toModel(db *gorm.DB) (models.ChartRelease, error) {
 		}
 		var chart models.Chart
 		if err = db.Where(&chartModel).Select("id").First(&chart).Error; err != nil {
-			return models.ChartRelease{}, err
+			return models.ChartRelease{}, fmt.Errorf("couldn't load chart '%s': %w", c.Chart, err)
 		} else {
 			ret.ChartID = chart.ID
 		}
@@ -96,7 +96,7 @@ func (c ChartReleaseV3) toModel(db *gorm.DB) (models.ChartRelease, error) {
 		}
 		var cluster models.Cluster
 		if err = db.Where(&clusterModel).Select("id").First(&cluster).Error; err != nil {
-			return models.ChartRelease{}, err
+			return models.ChartRelease{}, fmt.Errorf("couldn't load cluster '%s': %w", c.Cluster, err)
 		} else {
 			ret.ClusterID = &cluster.ID
 		}
@@ -108,7 +108,7 @@ func (c ChartReleaseV3) toModel(db *gorm.DB) (models.ChartRelease, error) {
 		}
 		var environment models.Environment
 		if err = db.Where(&environmentModel).Select("id").First(&environment).Error; err != nil {
-			return models.ChartRelease{}, err
+			return models.ChartRelease{}, fmt.Errorf("couldn't load environment '%s': %w", c.Environment, err)
 		} else {
 			ret.EnvironmentID = &environment.ID
 		}
@@ -120,7 +120,7 @@ func (c ChartReleaseV3) toModel(db *gorm.DB) (models.ChartRelease, error) {
 		}
 		var chartRelease models.ChartRelease
 		if err = db.Where(&chartReleaseModel).Select("id").First(&chartRelease).Error; err != nil {
-			return models.ChartRelease{}, err
+			return models.ChartRelease{}, fmt.Errorf("couldn't load chart release '%s': %w", c.AppVersionFollowChartRelease, err)
 		} else {
 			ret.AppVersionFollowChartReleaseID = &chartRelease.ID
 		}
@@ -132,7 +132,7 @@ func (c ChartReleaseV3) toModel(db *gorm.DB) (models.ChartRelease, error) {
 		}
 		var appVersion models.AppVersion
 		if err = db.Where(&appVersionModel).Select("id").First(&appVersion).Error; err != nil {
-			return models.ChartRelease{}, err
+			return models.ChartRelease{}, fmt.Errorf("couldn't load app version '%s': %w", c.AppVersionReference, err)
 		} else {
 			ret.AppVersionID = &appVersion.ID
 		}
@@ -144,7 +144,7 @@ func (c ChartReleaseV3) toModel(db *gorm.DB) (models.ChartRelease, error) {
 		}
 		var chartRelease models.ChartRelease
 		if err = db.Where(&chartReleaseModel).Select("id").First(&chartRelease).Error; err != nil {
-			return models.ChartRelease{}, err
+			return models.ChartRelease{}, fmt.Errorf("couldn't load chart release '%s': %w", c.ChartVersionFollowChartRelease, err)
 		} else {
 			ret.ChartVersionFollowChartReleaseID = &chartRelease.ID
 		}
@@ -156,7 +156,7 @@ func (c ChartReleaseV3) toModel(db *gorm.DB) (models.ChartRelease, error) {
 		}
 		var chartVersion models.ChartVersion
 		if err = db.Where(&chartVersionModel).Select("id").First(&chartVersion).Error; err != nil {
-			return models.ChartRelease{}, err
+			return models.ChartRelease{}, fmt.Errorf("couldn't load chart version '%s': %w", c.ChartVersionReference, err)
 		} else {
 			ret.ChartVersionID = &chartVersion.ID
 		}
@@ -168,7 +168,7 @@ func (c ChartReleaseV3) toModel(db *gorm.DB) (models.ChartRelease, error) {
 		}
 		var pagerdutyIntegration models.PagerdutyIntegration
 		if err = db.Where(&pagerdutyIntegrationModel).Select("id").First(&pagerdutyIntegration).Error; err != nil {
-			return models.ChartRelease{}, err
+			return models.ChartRelease{}, fmt.Errorf("couldn't load pagerduty integration '%s': %w", *c.PagerdutyIntegration, err)
 		} else {
 			ret.PagerdutyIntegrationID = &pagerdutyIntegration.ID
 		}

--- a/sherlock/internal/api/sherlock/chart_releases_v3_create.go
+++ b/sherlock/internal/api/sherlock/chart_releases_v3_create.go
@@ -7,7 +7,6 @@ import (
 	"github.com/broadinstitute/sherlock/sherlock/internal/models"
 	"github.com/creasty/defaults"
 	"github.com/gin-gonic/gin"
-	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 	"net/http"
 )
@@ -55,11 +54,6 @@ func chartReleasesV3Create(ctx *gin.Context) {
 		return
 	}
 
-	if err = fillChartReleaseDynamicDefaultsForCreation(db, &toCreate); err != nil {
-		errors.AbortRequest(ctx, err)
-		return
-	}
-
 	if err = db.Create(&toCreate).Error; err != nil {
 		errors.AbortRequest(ctx, err)
 		return
@@ -71,109 +65,4 @@ func chartReleasesV3Create(ctx *gin.Context) {
 		return
 	}
 	ctx.JSON(http.StatusCreated, chartReleaseFromModel(result))
-}
-
-// fillChartReleaseDynamicDefaultsForCreation is a helper specifically for chartReleasesV3Create.
-// It is inefficient -- it potentially loads things from the database it doesn't need -- but that's intentional.
-// chartReleasesV3Create will rarely be called (and almost always from the UI) so it's better for this function
-// to be easy to understand than to worry about an errant load of a row or two by primary key.
-func fillChartReleaseDynamicDefaultsForCreation(db *gorm.DB, toCreate *models.ChartRelease) error {
-	var chart models.Chart
-	if err := db.Model(&models.Chart{Model: gorm.Model{ID: toCreate.ChartID}}).Take(&chart).Error; err != nil {
-		return fmt.Errorf("failed to read chart to evaluate defaults: %w", err)
-	}
-
-	// If the chart has a branch and toCreate doesn't, use the chart's branch.
-	// We may end up ignoring this if the branch resolver doesn't end up being chosen.
-	if chart.AppImageGitMainBranch != nil && *chart.AppImageGitMainBranch != "" && toCreate.AppVersionBranch == nil {
-		toCreate.AppVersionBranch = chart.AppImageGitMainBranch
-	}
-
-	// If the chart is marked as exposing an endpoint, copy fields from it.
-	if chart.ChartExposesEndpoint != nil && *chart.ChartExposesEndpoint {
-		if toCreate.Subdomain == nil {
-			toCreate.Subdomain = chart.DefaultSubdomain
-		}
-		if toCreate.Protocol == nil {
-			toCreate.Protocol = chart.DefaultProtocol
-		}
-		if toCreate.Port == nil {
-			toCreate.Port = chart.DefaultPort
-		}
-	}
-
-	// If toCreate doesn't have a set app version resolver, set it based on what's available.
-	// Branch takes last priority because we always try to fill that from the chart.
-	if toCreate.AppVersionResolver == nil {
-		resolver := "none"
-		if toCreate.AppVersionExact != nil {
-			resolver = "exact"
-		} else if toCreate.AppVersionCommit != nil {
-			resolver = "commit"
-		} else if toCreate.AppVersionFollowChartReleaseID != nil {
-			resolver = "follow"
-		} else if toCreate.AppVersionBranch != nil {
-			resolver = "branch"
-		}
-		toCreate.AppVersionResolver = &resolver
-	}
-
-	// If toCreate doesn't have a set chart version resolver, set it based on what's available.
-	if toCreate.ChartVersionResolver == nil {
-		resolver := "latest"
-		if toCreate.ChartVersionExact != nil {
-			resolver = "exact"
-		} else if toCreate.ChartVersionFollowChartReleaseID != nil {
-			resolver = "follow"
-		}
-		toCreate.ChartVersionResolver = &resolver
-	}
-
-	// If we have an environment, use it to fill in defaults.
-	if toCreate.EnvironmentID != nil {
-		var environment models.Environment
-		if err := db.Model(&models.Environment{Model: gorm.Model{ID: *toCreate.EnvironmentID}}).Take(&environment).Error; err != nil {
-			return fmt.Errorf("failed to read environment to evaluate defaults: %w", err)
-		}
-
-		// Name like "leonardo-prod"
-		if toCreate.Name == "" {
-			toCreate.Name = fmt.Sprintf("%s-%s", chart.Name, environment.Name)
-		}
-
-		// If there's no cluster, add it
-		if toCreate.ClusterID == nil && environment.DefaultClusterID != nil {
-			toCreate.ClusterID = environment.DefaultClusterID
-		}
-
-		// If there's no namespace, add it
-		if toCreate.Namespace == "" && environment.DefaultNamespace != "" {
-			toCreate.Namespace = environment.DefaultNamespace
-		}
-
-		// If there's no firecloud develop ref, add it
-		// (We'll remove this shortly because fc-dev is no more, but keeping behavioral parity makes sense for the moment)
-		if toCreate.FirecloudDevelopRef == nil && environment.DefaultFirecloudDevelopRef != nil &&
-			chart.LegacyConfigsEnabled != nil && *chart.LegacyConfigsEnabled {
-			toCreate.FirecloudDevelopRef = environment.DefaultFirecloudDevelopRef
-		}
-	}
-
-	// If we have a cluster, use it to fill in defaults.
-	// The only one we care about is name, so we dodge the whole block if the name is already filled.
-	// This also means that when the cluster got filled from the environment, we won't run this, because the name
-	// would've been filled from the environment too.
-	if toCreate.ClusterID != nil && toCreate.Name == "" {
-		var cluster models.Cluster
-		if err := db.Model(&models.Cluster{Model: gorm.Model{ID: *toCreate.ClusterID}}).Take(&cluster).Error; err != nil {
-			return fmt.Errorf("failed to read cluster to evaluate defaults: %w", err)
-		}
-		if toCreate.Namespace == "" || toCreate.Namespace == cluster.Name {
-			toCreate.Name = fmt.Sprintf("%s-%s", chart.Name, cluster.Name)
-		} else {
-			toCreate.Name = fmt.Sprintf("%s-%s-%s", chart.Name, toCreate.Namespace, cluster.Name)
-		}
-	}
-
-	return nil
 }

--- a/sherlock/internal/api/sherlock/chart_releases_v3_create.go
+++ b/sherlock/internal/api/sherlock/chart_releases_v3_create.go
@@ -1,0 +1,179 @@
+package sherlock
+
+import (
+	"fmt"
+	"github.com/broadinstitute/sherlock/sherlock/internal/authentication"
+	"github.com/broadinstitute/sherlock/sherlock/internal/errors"
+	"github.com/broadinstitute/sherlock/sherlock/internal/models"
+	"github.com/creasty/defaults"
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+	"net/http"
+)
+
+// chartReleasesV3Create godoc
+//
+//	@summary		Create a ChartRelease
+//	@description	Create a ChartRelease.
+//	@tags			ChartReleases
+//	@accept			json
+//	@produce		json
+//	@param			chartRelease			body		ChartReleaseV3Create	true	"The ChartRelease to create"
+//	@success		201						{object}	ChartReleaseV3
+//	@failure		400,403,404,407,409,500	{object}	errors.ErrorResponse
+//	@router			/api/chart-releases/v3 [post]
+func chartReleasesV3Create(ctx *gin.Context) {
+	db, err := authentication.MustUseDB(ctx)
+	if err != nil {
+		return
+	}
+
+	var body ChartReleaseV3Create
+	if err = ctx.ShouldBindJSON(&body); err != nil {
+		errors.AbortRequest(ctx, fmt.Errorf("(%s) request validation error: %w", errors.BadRequest, err))
+		return
+	}
+
+	if err = defaults.Set(&body); err != nil {
+		errors.AbortRequest(ctx, fmt.Errorf("error setting defaults: %w", err))
+		return
+	}
+
+	toCreate, err := body.toModel(db)
+	if err != nil {
+		errors.AbortRequest(ctx, err)
+		return
+	}
+
+	if toCreate.ChartID == 0 {
+		errors.AbortRequest(ctx, fmt.Errorf("(%s) chart is required", errors.BadRequest))
+		return
+	}
+	if (toCreate.EnvironmentID == nil || *toCreate.EnvironmentID == 0) && (toCreate.ClusterID == nil || *toCreate.ClusterID == 0) {
+		errors.AbortRequest(ctx, fmt.Errorf("(%s) either environment or cluster is required", errors.BadRequest))
+		return
+	}
+
+	if err = fillChartReleaseDynamicDefaultsForCreation(db, &toCreate); err != nil {
+		errors.AbortRequest(ctx, err)
+		return
+	}
+
+	if err = db.Create(&toCreate).Error; err != nil {
+		errors.AbortRequest(ctx, err)
+		return
+	}
+
+	var result models.ChartRelease
+	if err = db.Preload(clause.Associations).First(&result, toCreate.ID).Error; err != nil {
+		errors.AbortRequest(ctx, err)
+		return
+	}
+	ctx.JSON(http.StatusCreated, chartReleaseFromModel(result))
+}
+
+// fillChartReleaseDynamicDefaultsForCreation is a helper specifically for chartReleasesV3Create.
+// It is inefficient -- it potentially loads things from the database it doesn't need -- but that's intentional.
+// chartReleasesV3Create will rarely be called (and almost always from the UI) so it's better for this function
+// to be easy to understand than to worry about an errant load of a row or two by primary key.
+func fillChartReleaseDynamicDefaultsForCreation(db *gorm.DB, toCreate *models.ChartRelease) error {
+	var chart models.Chart
+	if err := db.Model(&models.Chart{Model: gorm.Model{ID: toCreate.ChartID}}).Take(&chart).Error; err != nil {
+		return fmt.Errorf("failed to read chart to evaluate defaults: %w", err)
+	}
+
+	// If the chart has a branch and toCreate doesn't, use the chart's branch.
+	// We may end up ignoring this if the branch resolver doesn't end up being chosen.
+	if chart.AppImageGitMainBranch != nil && *chart.AppImageGitMainBranch != "" && toCreate.AppVersionBranch == nil {
+		toCreate.AppVersionBranch = chart.AppImageGitMainBranch
+	}
+
+	// If the chart is marked as exposing an endpoint, copy fields from it.
+	if chart.ChartExposesEndpoint != nil && *chart.ChartExposesEndpoint {
+		if toCreate.Subdomain == nil {
+			toCreate.Subdomain = chart.DefaultSubdomain
+		}
+		if toCreate.Protocol == nil {
+			toCreate.Protocol = chart.DefaultProtocol
+		}
+		if toCreate.Port == nil {
+			toCreate.Port = chart.DefaultPort
+		}
+	}
+
+	// If toCreate doesn't have a set app version resolver, set it based on what's available.
+	// Branch takes last priority because we always try to fill that from the chart.
+	if toCreate.AppVersionResolver == nil {
+		resolver := "none"
+		if toCreate.AppVersionExact != nil {
+			resolver = "exact"
+		} else if toCreate.AppVersionCommit != nil {
+			resolver = "commit"
+		} else if toCreate.AppVersionFollowChartReleaseID != nil {
+			resolver = "follow"
+		} else if toCreate.AppVersionBranch != nil {
+			resolver = "branch"
+		}
+		toCreate.AppVersionResolver = &resolver
+	}
+
+	// If toCreate doesn't have a set chart version resolver, set it based on what's available.
+	if toCreate.ChartVersionResolver == nil {
+		resolver := "latest"
+		if toCreate.ChartVersionExact != nil {
+			resolver = "exact"
+		} else if toCreate.ChartVersionFollowChartReleaseID != nil {
+			resolver = "follow"
+		}
+		toCreate.ChartVersionResolver = &resolver
+	}
+
+	// If we have an environment, use it to fill in defaults.
+	if toCreate.EnvironmentID != nil {
+		var environment models.Environment
+		if err := db.Model(&models.Environment{Model: gorm.Model{ID: *toCreate.EnvironmentID}}).Take(&environment).Error; err != nil {
+			return fmt.Errorf("failed to read environment to evaluate defaults: %w", err)
+		}
+
+		// Name like "leonardo-prod"
+		if toCreate.Name == "" {
+			toCreate.Name = fmt.Sprintf("%s-%s", chart.Name, environment.Name)
+		}
+
+		// If there's no cluster, add it
+		if toCreate.ClusterID == nil && environment.DefaultClusterID != nil {
+			toCreate.ClusterID = environment.DefaultClusterID
+		}
+
+		// If there's no namespace, add it
+		if toCreate.Namespace == "" && environment.DefaultNamespace != "" {
+			toCreate.Namespace = environment.DefaultNamespace
+		}
+
+		// If there's no firecloud develop ref, add it
+		// (We'll remove this shortly because fc-dev is no more, but keeping behavioral parity makes sense for the moment)
+		if toCreate.FirecloudDevelopRef == nil && environment.DefaultFirecloudDevelopRef != nil &&
+			chart.LegacyConfigsEnabled != nil && *chart.LegacyConfigsEnabled {
+			toCreate.FirecloudDevelopRef = environment.DefaultFirecloudDevelopRef
+		}
+	}
+
+	// If we have a cluster, use it to fill in defaults.
+	// The only one we care about is name, so we dodge the whole block if the name is already filled.
+	// This also means that when the cluster got filled from the environment, we won't run this, because the name
+	// would've been filled from the environment too.
+	if toCreate.ClusterID != nil && toCreate.Name == "" {
+		var cluster models.Cluster
+		if err := db.Model(&models.Cluster{Model: gorm.Model{ID: *toCreate.ClusterID}}).Take(&cluster).Error; err != nil {
+			return fmt.Errorf("failed to read cluster to evaluate defaults: %w", err)
+		}
+		if toCreate.Namespace == "" || toCreate.Namespace == cluster.Name {
+			toCreate.Name = fmt.Sprintf("%s-%s", chart.Name, cluster.Name)
+		} else {
+			toCreate.Name = fmt.Sprintf("%s-%s-%s", chart.Name, toCreate.Namespace, cluster.Name)
+		}
+	}
+
+	return nil
+}

--- a/sherlock/internal/api/sherlock/chart_releases_v3_create_test.go
+++ b/sherlock/internal/api/sherlock/chart_releases_v3_create_test.go
@@ -211,3 +211,35 @@ func (s *handlerSuite) TestChartReleasesV3Create_blocksDuplicates() {
 	s.Equal(http.StatusConflict, code)
 	s.Equal(errors.Conflict, got2.Type)
 }
+
+func (s *handlerSuite) TestChartReleasesV3Create_suitability() {
+	s.TestData.Chart_Leonardo()
+	s.TestData.AppVersion_Leonardo_V1()
+	s.TestData.ChartVersion_Leonardo_V1()
+	s.TestData.Environment_Prod()
+	var got errors.ErrorResponse
+	code := s.HandleRequest(
+		s.UseNonSuitableUserFor(s.NewRequest("POST", "/api/chart-releases/v3", ChartReleaseV3Create{
+			Chart:       "leonardo",
+			Environment: "prod",
+		})),
+		&got)
+	s.Equal(http.StatusForbidden, code)
+	s.Equal(errors.Forbidden, got.Type)
+}
+
+func (s *handlerSuite) TestChartReleasesV3Create_suitabilityAllowed() {
+	s.TestData.Chart_Leonardo()
+	s.TestData.AppVersion_Leonardo_V1()
+	s.TestData.ChartVersion_Leonardo_V1()
+	s.TestData.Environment_Prod()
+	var got ChartReleaseV3
+	code := s.HandleRequest(
+		s.UseSuitableUserFor(s.NewRequest("POST", "/api/chart-releases/v3", ChartReleaseV3Create{
+			Chart:       "leonardo",
+			Environment: "prod",
+		})),
+		&got)
+	s.Equal(http.StatusCreated, code)
+	s.NotEmpty(got.ID)
+}

--- a/sherlock/internal/api/sherlock/chart_releases_v3_create_test.go
+++ b/sherlock/internal/api/sherlock/chart_releases_v3_create_test.go
@@ -1,0 +1,213 @@
+package sherlock
+
+import (
+	"github.com/broadinstitute/sherlock/go-shared/pkg/utils"
+	"github.com/broadinstitute/sherlock/sherlock/internal/errors"
+	"github.com/gin-gonic/gin"
+	"net/http"
+)
+
+func (s *handlerSuite) TestChartReleasesV3Create_badBody() {
+	var got errors.ErrorResponse
+	code := s.HandleRequest(
+		s.NewRequest("POST", "/api/chart-releases/v3", gin.H{
+			"chart": 123,
+		}),
+		&got)
+	s.Equal(http.StatusBadRequest, code)
+	s.Equal(errors.BadRequest, got.Type)
+	s.Contains(got.Message, "chart")
+}
+
+func (s *handlerSuite) TestChartReleasesV3Create_failToConvertToModel() {
+	var got errors.ErrorResponse
+	code := s.HandleRequest(
+		s.NewRequest("POST", "/api/chart-releases/v3", ChartReleaseV3Create{
+			Chart: "not-found",
+		}),
+		&got)
+	s.Equal(http.StatusNotFound, code)
+	s.Equal(errors.NotFound, got.Type)
+	s.Contains(got.Message, "not-found")
+}
+
+func (s *handlerSuite) TestChartReleasesV3Create_missingChart() {
+	var got errors.ErrorResponse
+	code := s.HandleRequest(
+		s.NewRequest("POST", "/api/chart-releases/v3", ChartReleaseV3Create{}),
+		&got)
+	s.Equal(http.StatusBadRequest, code)
+	s.Equal(errors.BadRequest, got.Type)
+	s.Contains(got.Message, "chart is required")
+}
+
+func (s *handlerSuite) TestChartReleasesV3Create_missingDestination() {
+	s.TestData.Chart_Leonardo()
+	var got errors.ErrorResponse
+	code := s.HandleRequest(
+		s.NewRequest("POST", "/api/chart-releases/v3", ChartReleaseV3Create{
+			Chart: "leonardo",
+		}),
+		&got)
+	s.Equal(http.StatusBadRequest, code)
+	s.Equal(errors.BadRequest, got.Type)
+	s.Contains(got.Message, "environment or cluster is required")
+}
+
+func (s *handlerSuite) TestChartReleasesV3Create_cannotFindBranchAppVersion() {
+	s.TestData.Chart_Leonardo()
+	s.TestData.Environment_Dev()
+	var got errors.ErrorResponse
+	code := s.HandleRequest(
+		s.NewRequest("POST", "/api/chart-releases/v3", ChartReleaseV3Create{
+			Chart:       "leonardo",
+			Environment: "dev",
+		}),
+		&got)
+	s.Equal(http.StatusNotFound, code)
+	s.Equal(errors.NotFound, got.Type)
+	s.Contains(got.Message, "no recorded app versions for leonardo come from a '"+*s.TestData.Chart_Leonardo().AppImageGitMainBranch+"' branch")
+}
+
+func (s *handlerSuite) TestChartReleasesV3Create_cannotFindLatestChartVersion() {
+	s.TestData.Chart_Leonardo()
+	s.TestData.AppVersion_Leonardo_V1()
+	s.TestData.Environment_Dev()
+	var got errors.ErrorResponse
+	code := s.HandleRequest(
+		s.NewRequest("POST", "/api/chart-releases/v3", ChartReleaseV3Create{
+			Chart:       "leonardo",
+			Environment: "dev",
+		}),
+		&got)
+	s.Equal(http.StatusNotFound, code)
+	s.Equal(errors.NotFound, got.Type)
+	s.Contains(got.Message, "unable to query latest chart version for leonardo")
+}
+
+func (s *handlerSuite) TestChartReleasesV3Create_normalCase() {
+	s.TestData.Chart_Leonardo()
+	s.TestData.AppVersion_Leonardo_V1()
+	s.TestData.ChartVersion_Leonardo_V1()
+	s.TestData.Environment_Dev()
+	var got ChartReleaseV3
+	code := s.HandleRequest(
+		s.NewRequest("POST", "/api/chart-releases/v3", ChartReleaseV3Create{
+			Chart:       "leonardo",
+			Environment: "dev",
+		}),
+		&got)
+	s.Equal(http.StatusCreated, code)
+	s.NotEmpty(got.ID)
+	s.Equal("leonardo-dev", got.Name)
+}
+
+func (s *handlerSuite) TestChartReleasesV3Create_normalCaseCluster() {
+	s.TestData.Chart_Leonardo()
+	s.TestData.AppVersion_Leonardo_V1()
+	s.TestData.ChartVersion_Leonardo_V1()
+	s.TestData.Environment_Dev()
+	var got ChartReleaseV3
+	code := s.HandleRequest(
+		s.NewRequest("POST", "/api/chart-releases/v3", ChartReleaseV3Create{
+			Chart:     "leonardo",
+			Cluster:   "terra-dev",
+			Namespace: "terra-dev",
+		}),
+		&got)
+	s.Equal(http.StatusCreated, code)
+	s.NotEmpty(got.ID)
+	s.Equal("leonardo-terra-dev", got.Name)
+}
+
+func (s *handlerSuite) TestChartReleasesV3Create_normalCaseClusterWeirdNamespace() {
+	s.TestData.Chart_Leonardo()
+	s.TestData.AppVersion_Leonardo_V1()
+	s.TestData.ChartVersion_Leonardo_V1()
+	s.TestData.Environment_Dev()
+	var got ChartReleaseV3
+	code := s.HandleRequest(
+		s.NewRequest("POST", "/api/chart-releases/v3", ChartReleaseV3Create{
+			Chart:     "leonardo",
+			Cluster:   "terra-dev",
+			Namespace: "some-namespace",
+		}),
+		&got)
+	s.Equal(http.StatusCreated, code)
+	s.NotEmpty(got.ID)
+	s.Equal("leonardo-some-namespace-terra-dev", got.Name)
+}
+
+func (s *handlerSuite) TestChartReleasesV3Create_noDefaults() {
+	s.TestData.Chart_Leonardo()
+	s.TestData.AppVersion_Leonardo_V1()
+	s.TestData.ChartVersion_Leonardo_V1()
+	s.TestData.Environment_Dev()
+	var got ChartReleaseV3
+	code := s.HandleRequest(
+		s.NewRequest("POST", "/api/chart-releases/v3", ChartReleaseV3Create{
+			Chart:                "leonardo",
+			Cluster:              "terra-dev",
+			Environment:          "dev",
+			Name:                 "name",
+			Namespace:            "namespace",
+			AppVersionResolver:   utils.PointerTo("exact"),
+			AppVersionExact:      utils.PointerTo(s.TestData.AppVersion_Leonardo_V1().AppVersion),
+			ChartVersionResolver: utils.PointerTo("exact"),
+			ChartVersionExact:    utils.PointerTo(s.TestData.ChartVersion_Leonardo_V1().ChartVersion),
+			HelmfileRef:          utils.PointerTo("HEAD"),
+			HelmfileRefEnabled:   utils.PointerTo(true),
+			FirecloudDevelopRef:  utils.PointerTo("develop"),
+			ChartReleaseV3Edit: ChartReleaseV3Edit{
+				Subdomain:               utils.PointerTo("subdomain"),
+				Protocol:                utils.PointerTo("protocol"),
+				Port:                    utils.PointerTo[uint](123),
+				IncludeInBulkChangesets: utils.PointerTo(false),
+			},
+		}),
+		&got)
+	s.Equal(http.StatusCreated, code)
+	s.NotEmpty(got.ID)
+	s.Equal("leonardo", got.Chart)
+	s.Equal("terra-dev", got.Cluster)
+	s.Equal("dev", got.Environment)
+	s.Equal("name", got.Name)
+	s.Equal("namespace", got.Namespace)
+	s.Equal("exact", *got.AppVersionResolver)
+	s.Equal(s.TestData.AppVersion_Leonardo_V1().AppVersion, *got.AppVersionExact)
+	s.Equal("exact", *got.ChartVersionResolver)
+	s.Equal(s.TestData.ChartVersion_Leonardo_V1().ChartVersion, *got.ChartVersionExact)
+	s.Equal("HEAD", *got.HelmfileRef)
+	s.Equal(true, *got.HelmfileRefEnabled)
+	s.Equal("develop", *got.FirecloudDevelopRef)
+	s.Equal("subdomain", *got.Subdomain)
+	s.Equal("protocol", *got.Protocol)
+	s.Equal(uint(123), *got.Port)
+	s.Equal(false, *got.IncludeInBulkChangesets)
+}
+
+func (s *handlerSuite) TestChartReleasesV3Create_blocksDuplicates() {
+	s.TestData.Chart_Leonardo()
+	s.TestData.AppVersion_Leonardo_V1()
+	s.TestData.ChartVersion_Leonardo_V1()
+	s.TestData.Environment_Dev()
+	var got ChartReleaseV3
+	code := s.HandleRequest(
+		s.NewRequest("POST", "/api/chart-releases/v3", ChartReleaseV3Create{
+			Chart:       "leonardo",
+			Environment: "dev",
+		}),
+		&got)
+	s.Equal(http.StatusCreated, code)
+	s.NotEmpty(got.ID)
+	s.Equal("leonardo-dev", got.Name)
+	var got2 errors.ErrorResponse
+	code = s.HandleRequest(
+		s.NewRequest("POST", "/api/chart-releases/v3", ChartReleaseV3Create{
+			Chart:       "leonardo",
+			Environment: "dev",
+		}),
+		&got2)
+	s.Equal(http.StatusConflict, code)
+	s.Equal(errors.Conflict, got2.Type)
+}

--- a/sherlock/internal/api/sherlock/routes.go
+++ b/sherlock/internal/api/sherlock/routes.go
@@ -111,6 +111,7 @@ func ConfigureRoutes(apiRouter gin.IRoutes) {
 	apiRouter.PATCH("environments/v3/*selector", environmentsV3Edit)
 
 	apiRouter.GET("chart-releases/v3/*selector", chartReleasesV3Get)
+	apiRouter.POST("chart-releases/v3", chartReleasesV3Create)
 	apiRouter.DELETE("chart-releases/v3/*selector", chartReleasesV3Delete)
 	apiRouter.GET("chart-releases/v3", chartReleasesV3List)
 	apiRouter.PATCH("chart-releases/v3/*selector", chartReleasesV3Edit)

--- a/sherlock/internal/deprecated_controllers/v2controllers/changeset.go
+++ b/sherlock/internal/deprecated_controllers/v2controllers/changeset.go
@@ -385,7 +385,7 @@ func modelChangesetToChangeset(model *v2models.Changeset) *Changeset {
 		if newChartVersion != nil {
 			newChartVersions = append(newChartVersions, *newChartVersion)
 		}
-		sort.SliceIsSorted(newChartVersions, func(i, j int) bool {
+		sort.Slice(newChartVersions, func(i, j int) bool {
 			return newChartVersions[i].CreatedAt.Before(newChartVersions[j].CreatedAt)
 		})
 	}

--- a/sherlock/internal/models/chart_release.go
+++ b/sherlock/internal/models/chart_release.go
@@ -132,8 +132,9 @@ func (c *ChartRelease) setCreationDefaults(tx *gorm.DB) error {
 			c.ClusterID = environment.DefaultClusterID
 		}
 
-		// If there's no namespace, add it
-		if c.Namespace == "" && environment.DefaultNamespace != "" {
+		// If there's no namespace and we have a cluster, add it
+		// (If there's no cluster, validation says we shouldn't have a namespace either)
+		if c.Namespace == "" && environment.DefaultNamespace != "" && c.ClusterID != nil {
 			c.Namespace = environment.DefaultNamespace
 		}
 

--- a/sherlock/internal/models/chart_release.go
+++ b/sherlock/internal/models/chart_release.go
@@ -250,7 +250,7 @@ func (c *ChartRelease) resolve(tx *gorm.DB) error {
 	return c.ChartReleaseVersion.resolve(tx, c.ChartID)
 }
 
-// BeforeCreate checks permissions
+// BeforeCreate checks permissions, sets defaults, and resolves the versions
 func (c *ChartRelease) BeforeCreate(tx *gorm.DB) error {
 	if err := c.errorIfForbidden(tx); err != nil {
 		return err

--- a/sherlock/internal/models/chart_release_test.go
+++ b/sherlock/internal/models/chart_release_test.go
@@ -159,6 +159,27 @@ func (s *modelSuite) TestChartReleaseValidationSqlDestinationTypeInvalidDestinat
 	s.ErrorContains(err, "violates check constraint \"destination_type_valid\"")
 }
 
+func (s *modelSuite) TestChartReleaseValidationSqlNameUnique() {
+	a := s.TestData.ChartRelease_LeonardoProd()
+	b := s.TestData.ChartRelease_LeonardoStaging()
+	err := s.DB.Model(&b).Updates(&ChartRelease{Name: a.Name}).Error
+	s.ErrorContains(err, "violates unique constraint \"chart_releases_name_unique\"")
+}
+
+func (s *modelSuite) TestChartReleaseValidationSqlEnvironmentChartUnique() {
+	a := s.TestData.ChartRelease_LeonardoProd()
+	b := s.TestData.ChartRelease_LeonardoStaging()
+	err := s.DB.Model(&b).Updates(&ChartRelease{EnvironmentID: a.EnvironmentID}).Error
+	s.ErrorContains(err, "violates unique constraint \"chart_releases_environment_chart_unique\"")
+}
+
+func (s *modelSuite) TestChartReleaseValidationSqlClusterNamespaceChartUnique() {
+	a := s.TestData.ChartRelease_LeonardoProd()
+	b := s.TestData.ChartRelease_LeonardoStaging()
+	err := s.DB.Model(&b).Updates(&ChartRelease{ClusterID: a.ClusterID, Namespace: a.Namespace}).Error
+	s.ErrorContains(err, "violates unique constraint \"chart_releases_cluster_namespace_chart_unique\"")
+}
+
 func TestChartRelease_SlackBeehiveLink(t *testing.T) {
 	type fields struct {
 		Name string

--- a/sherlock/internal/models/chart_release_version.go
+++ b/sherlock/internal/models/chart_release_version.go
@@ -78,11 +78,11 @@ func (crv *ChartReleaseVersion) resolveAppVersion(tx *gorm.DB, chart Chart) erro
 			First(&appVersion).Error; err != nil {
 			if goerrors.Is(err, gorm.ErrRecordNotFound) {
 				if chart.AppImageGitRepo != nil {
-					return fmt.Errorf("(%s) no recorded app versions for %s come from a '%s' branch: check that GitHub Actions are building, publishing, and reporting the app versions on the branch: https://github.com/%s/commits/%s", errors.NotFound, chart.Name, *crv.AppVersionCommit, *chart.AppImageGitRepo, *crv.AppVersionBranch)
+					return fmt.Errorf("(%s) no recorded app versions for %s come from a '%s' branch: check that GitHub Actions are building, publishing, and reporting the app versions on the branch: https://github.com/%s/commits/%s", errors.NotFound, chart.Name, *crv.AppVersionBranch, *chart.AppImageGitRepo, *crv.AppVersionBranch)
 				}
-				return fmt.Errorf("(%s) no recorded app versions for %s come from a '%s' branch: check that GitHub Actions are building, publishing, and reporting the app versions on the branch", errors.NotFound, chart.Name, *crv.AppVersionCommit)
+				return fmt.Errorf("(%s) no recorded app versions for %s come from a '%s' branch: check that GitHub Actions are building, publishing, and reporting the app versions on the branch", errors.NotFound, chart.Name, *crv.AppVersionBranch)
 			}
-			return fmt.Errorf("failed to find an app version for %s built on a commit starting with '%s': %w", chart.Name, *crv.AppVersionCommit, err)
+			return fmt.Errorf("failed to find an app version for %s built on a branch of '%s': %w", chart.Name, *crv.AppVersionBranch, err)
 		}
 		crv.AppVersionExact = &appVersion.AppVersion
 		crv.AppVersionID = &appVersion.ID

--- a/sherlock/internal/models/environment.go
+++ b/sherlock/internal/models/environment.go
@@ -159,9 +159,7 @@ func (e *Environment) autoPopulateChartReleases(tx *gorm.DB) error {
 			chartRelease := ChartRelease{
 				ChartID:                 templateChartRelease.ChartID,
 				ClusterID:               e.DefaultClusterID,
-				DestinationType:         "environment",
 				EnvironmentID:           &e.ID,
-				Name:                    fmt.Sprintf("%s-%s", templateChartRelease.Chart.Name, e.Name),
 				Namespace:               e.DefaultNamespace,
 				ChartReleaseVersion:     templateChartRelease.ChartReleaseVersion,
 				Subdomain:               templateChartRelease.Subdomain,
@@ -186,23 +184,10 @@ func (e *Environment) autoPopulateChartReleases(tx *gorm.DB) error {
 			if err := tx.Where(&Chart{Name: chartToAutoPopulateInTemplate.String("name")}).Take(&chart).Error; err != nil {
 				return fmt.Errorf("(%s) wasn't able to insert model.environments.templates.autoPopulateCharts entry %d, '%s': %w", errors.InternalServerError, index+1, chartToAutoPopulateInTemplate.String("name"), err)
 			}
-			if err := tx.Model(&ChartRelease{}).Create(&ChartRelease{
-				ChartID:         chart.ID,
-				ClusterID:       e.DefaultClusterID,
-				DestinationType: "environment",
-				EnvironmentID:   &e.ID,
-				Name:            fmt.Sprintf("%s-%s", chart.Name, e.Name),
-				Namespace:       e.DefaultNamespace,
-				ChartReleaseVersion: ChartReleaseVersion{
-					AppVersionResolver:   utils.PointerTo("none"),
-					ChartVersionResolver: utils.PointerTo("latest"),
-					HelmfileRef:          utils.PointerTo("HEAD"),
-					HelmfileRefEnabled:   utils.PointerTo(false),
-				},
-				Subdomain:               chart.DefaultSubdomain,
-				Protocol:                chart.DefaultProtocol,
-				Port:                    chart.DefaultPort,
-				IncludeInBulkChangesets: utils.PointerTo(true),
+			if err := tx.Create(&ChartRelease{
+				ChartID:       chart.ID,
+				ClusterID:     e.DefaultClusterID,
+				EnvironmentID: &e.ID,
 			}).Error; err != nil {
 				return fmt.Errorf("wasn't able to create instance of %s: %w", chart.Name, err)
 			}

--- a/sherlock/internal/models/environment.go
+++ b/sherlock/internal/models/environment.go
@@ -169,12 +169,10 @@ func (e *Environment) autoPopulateChartReleases(tx *gorm.DB) error {
 				Port:                    templateChartRelease.Port,
 				IncludeInBulkChangesets: templateChartRelease.IncludeInBulkChangesets,
 			}
-			if err := chartRelease.resolve(tx); err != nil {
-				return fmt.Errorf("error resolving versions for %s: %w", chartRelease.Name, err)
-			}
 			// We don't worry about database instance, because the chart release's hooks will handle that.
 			// It's slightly inefficient, because it has to load back the template info, but it's clearly correct.
-			if err := tx.Model(&ChartRelease{}).Create(&chartRelease).Error; err != nil {
+			// Similarly, we don't worry about resolving the versions, because the hooks do that too.
+			if err := tx.Create(&chartRelease).Error; err != nil {
 				return fmt.Errorf("wasn't able to copy template's %s release: %w", templateChartRelease.Name, err)
 			}
 		}

--- a/sherlock/internal/models/test_data.go
+++ b/sherlock/internal/models/test_data.go
@@ -383,7 +383,7 @@ func (td *testDataImpl) AppVersion_Leonardo_V1() AppVersion {
 		td.appVersion_leonardo_v1 = AppVersion{
 			ChartID:    td.Chart_Leonardo().ID,
 			AppVersion: "v0.0.1",
-			GitBranch:  "develop",
+			GitBranch:  *td.Chart_Leonardo().AppImageGitMainBranch,
 			GitCommit:  "a1b2c3d4",
 		}
 		td.h.SetSuitableTestUserForDB()
@@ -397,7 +397,7 @@ func (td *testDataImpl) AppVersion_Leonardo_V2() AppVersion {
 		td.appVersion_leonardo_v2 = AppVersion{
 			ChartID:            td.Chart_Leonardo().ID,
 			AppVersion:         "v0.0.2",
-			GitBranch:          "develop",
+			GitBranch:          *td.Chart_Leonardo().AppImageGitMainBranch,
 			GitCommit:          "e5f6g7h8",
 			ParentAppVersionID: utils.PointerTo(td.AppVersion_Leonardo_V1().ID),
 		}
@@ -412,7 +412,7 @@ func (td *testDataImpl) AppVersion_Leonardo_V3() AppVersion {
 		td.appVersion_leonardo_v3 = AppVersion{
 			ChartID:            td.Chart_Leonardo().ID,
 			AppVersion:         "v0.0.3",
-			GitBranch:          "develop",
+			GitBranch:          *td.Chart_Leonardo().AppImageGitMainBranch,
 			GitCommit:          "i1j2k3l4",
 			ParentAppVersionID: utils.PointerTo(td.AppVersion_Leonardo_V2().ID),
 		}


### PR DESCRIPTION
A variety of bug fixes and tests to stabilize the v3 chart release creation endpoint.

The largest fix is to properly block duplicate chart releases in the v3 world. This code here is used only when manually creating a specific chart release in al already-existing destination from Beehive.

There's also a minor fix stabilizing the sort order for v2 changesets. The increased load on the database from the added tests actually revealed that the return order for the embedded changelogs inside v2 changesets was unpredictable. Rather than make the tests for v2 changesets not care about the ordering -- the ordering does help readability in Beehive -- I added code to v2 changesets to stabilize the return order. We're about to remove the v2 code entirely (and the failure was _quite_ frequent, I spent most of the week tracking this down) so I'm calling it good enough.

## Testing

Tests for both the endpoint and the improved validation under the hood

## Risk

Low