### PR TITLE
[DDO-3449] v3 environment create

### DIFF
--- a/sherlock/db/migrations/000077_block_duplicate_environments.down.sql
+++ b/sherlock/db/migrations/000077_block_duplicate_environments.down.sql
@@ -1,0 +1,3 @@
+drop index if exists environments_name_unique;
+
+drop index if exists environments_urp_unique;

--- a/sherlock/db/migrations/000077_block_duplicate_environments.up.sql
+++ b/sherlock/db/migrations/000077_block_duplicate_environments.up.sql
@@ -1,0 +1,7 @@
+create unique index environments_name_unique
+    on environments (name)
+    where deleted_at is null;
+
+create unique index environments_urp_unique
+    on environments (unique_resource_prefix)
+    where deleted_at is null;

--- a/sherlock/internal/api/sherlock/environments_v3.go
+++ b/sherlock/internal/api/sherlock/environments_v3.go
@@ -29,7 +29,6 @@ type EnvironmentV3Create struct {
 	TemplateEnvironment       string `json:"templateEnvironment" form:"templateEnvironment"`   // Required for dynamic environments
 	UniqueResourcePrefix      string `json:"uniqueResourcePrefix" form:"uniqueResourcePrefix"` // When creating, will be calculated if left empty
 	DefaultNamespace          string `json:"defaultNamespace" form:"defaultNamespace"`         // When creating, will be calculated if left empty
-	NamePrefix                string `json:"namePrefix" form:"namePrefix"`                     // Used for dynamic environment name generation only, to override using the owner email handle and template name
 	ValuesName                string `json:"valuesName" form:"valuesName"`                     // When creating, defaults to template name or environment name
 	EnvironmentV3Edit
 }
@@ -90,7 +89,7 @@ func (e EnvironmentV3) toModel(db *gorm.DB) (models.Environment, error) {
 		}
 		var templateEnvironment models.Environment
 		if err = db.Where(&templateEnvironmentModel).Select("id").First(&templateEnvironment).Error; err != nil {
-			return models.Environment{}, err
+			return models.Environment{}, fmt.Errorf("template environment '%s' not found: %w", e.TemplateEnvironment, err)
 		} else {
 			ret.TemplateEnvironmentID = &templateEnvironment.ID
 		}
@@ -102,7 +101,7 @@ func (e EnvironmentV3) toModel(db *gorm.DB) (models.Environment, error) {
 		}
 		var defaultCluster models.Cluster
 		if err = db.Where(&defaultClusterModel).Select("id").First(&defaultCluster).Error; err != nil {
-			return models.Environment{}, err
+			return models.Environment{}, fmt.Errorf("default cluster '%s' not found: %w", *e.DefaultCluster, err)
 		} else {
 			ret.DefaultClusterID = &defaultCluster.ID
 		}
@@ -114,7 +113,7 @@ func (e EnvironmentV3) toModel(db *gorm.DB) (models.Environment, error) {
 		}
 		var pagerdutyIntegration models.PagerdutyIntegration
 		if err = db.Where(&pagerdutyIntegrationModel).Select("id").First(&pagerdutyIntegration).Error; err != nil {
-			return models.Environment{}, err
+			return models.Environment{}, fmt.Errorf("pagerduty integration '%s' not found: %w", *e.PagerdutyIntegration, err)
 		} else {
 			ret.PagerdutyIntegrationID = &pagerdutyIntegration.ID
 		}
@@ -126,7 +125,7 @@ func (e EnvironmentV3) toModel(db *gorm.DB) (models.Environment, error) {
 		}
 		var owner models.User
 		if err = db.Where(&ownerModel).Select("id").First(&owner).Error; err != nil {
-			return models.Environment{}, err
+			return models.Environment{}, fmt.Errorf("owner '%s' not found: %w", *e.Owner, err)
 		} else {
 			ret.OwnerID = &owner.ID
 		}

--- a/sherlock/internal/api/sherlock/environments_v3_create.go
+++ b/sherlock/internal/api/sherlock/environments_v3_create.go
@@ -1,0 +1,59 @@
+package sherlock
+
+import (
+	"fmt"
+	"github.com/broadinstitute/sherlock/sherlock/internal/authentication"
+	"github.com/broadinstitute/sherlock/sherlock/internal/errors"
+	"github.com/broadinstitute/sherlock/sherlock/internal/models"
+	"github.com/creasty/defaults"
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm/clause"
+	"net/http"
+)
+
+// environmentsV3Create godoc
+//
+//	@summary		Create a Environment
+//	@description	Create a Environment.
+//	@tags			Environments
+//	@accept			json
+//	@produce		json
+//	@param			environment				body		EnvironmentV3Create	true	"The Environment to create"
+//	@success		201						{object}	EnvironmentV3
+//	@failure		400,403,404,407,409,500	{object}	errors.ErrorResponse
+//	@router			/api/environments/v3 [post]
+func environmentsV3Create(ctx *gin.Context) {
+	db, err := authentication.MustUseDB(ctx)
+	if err != nil {
+		return
+	}
+
+	var body EnvironmentV3Create
+	if err = ctx.ShouldBindJSON(&body); err != nil {
+		errors.AbortRequest(ctx, fmt.Errorf("(%s) request validation error: %w", errors.BadRequest, err))
+		return
+	}
+
+	if err = defaults.Set(&body); err != nil {
+		errors.AbortRequest(ctx, fmt.Errorf("error setting defaults: %w", err))
+		return
+	}
+
+	toCreate, err := body.toModel(db)
+	if err != nil {
+		errors.AbortRequest(ctx, err)
+		return
+	}
+
+	if err = db.Create(&toCreate).Error; err != nil {
+		errors.AbortRequest(ctx, err)
+		return
+	}
+
+	var result models.Environment
+	if err = db.Preload(clause.Associations).First(&result, toCreate.ID).Error; err != nil {
+		errors.AbortRequest(ctx, err)
+		return
+	}
+	ctx.JSON(http.StatusCreated, environmentFromModel(result))
+}

--- a/sherlock/internal/api/sherlock/environments_v3_create_test.go
+++ b/sherlock/internal/api/sherlock/environments_v3_create_test.go
@@ -1,0 +1,169 @@
+package sherlock
+
+import (
+	"github.com/broadinstitute/sherlock/go-shared/pkg/utils"
+	"github.com/broadinstitute/sherlock/sherlock/internal/errors"
+	"github.com/broadinstitute/sherlock/sherlock/internal/models"
+	"github.com/gin-gonic/gin"
+	"net/http"
+)
+
+func (s *handlerSuite) TestEnvironmentsV3Create_badBody() {
+	var got errors.ErrorResponse
+	code := s.HandleRequest(
+		s.NewRequest("POST", "/api/environments/v3", gin.H{
+			"name": 123,
+		}),
+		&got)
+	s.Equal(http.StatusBadRequest, code)
+	s.Equal(errors.BadRequest, got.Type)
+	s.Contains(got.Message, "name")
+}
+
+func (s *handlerSuite) TestEnvironmentsV3Create_failToConvertToModel() {
+	var got errors.ErrorResponse
+	code := s.HandleRequest(
+		s.NewRequest("POST", "/api/environments/v3", EnvironmentV3Create{
+			EnvironmentV3Edit: EnvironmentV3Edit{
+				DefaultCluster: utils.PointerTo("not-found"),
+			},
+		}),
+		&got)
+	s.Equal(http.StatusNotFound, code)
+	s.Equal(errors.NotFound, got.Type)
+	s.Contains(got.Message, "not-found")
+}
+
+func (s *handlerSuite) TestEnvironmentsV3Create_bee() {
+	template := s.TestData.Environment_Swatomation()
+	var got EnvironmentV3
+	code := s.HandleRequest(
+		s.NewRequest("POST", "/api/environments/v3", EnvironmentV3Create{
+			TemplateEnvironment: template.Name,
+		}),
+		&got)
+	s.Equal(http.StatusCreated, code)
+	s.NotZero(got.ID)
+
+	s.Run("copied chart releases", func() {
+		var chartReleasesInTemplate []models.ChartRelease
+		s.NoError(s.DB.Where("environment_id = ?", template.ID).Find(&chartReleasesInTemplate).Error)
+		s.NotZero(len(chartReleasesInTemplate))
+		var chartReleasesInNewEnvironment []models.ChartRelease
+		s.NoError(s.DB.Where("environment_id = ?", got.ID).Find(&chartReleasesInNewEnvironment).Error)
+		s.Equal(len(chartReleasesInTemplate), len(chartReleasesInNewEnvironment))
+	})
+}
+
+func (s *handlerSuite) TestEnvironmentV3Create_template() {
+	s.TestData.Chart_Honeycomb()
+	s.TestData.ChartVersion_Honeycomb_V1()
+	var got EnvironmentV3
+	code := s.HandleRequest(
+		s.NewRequest("POST", "/api/environments/v3", EnvironmentV3Create{
+			Base:      "swatomation",
+			Lifecycle: "template",
+			Name:      "tempy-temp",
+		}),
+		&got)
+	s.Equal(http.StatusCreated, code)
+	s.NotZero(got.ID)
+
+	s.Run("got honeycomb", func() {
+		var chartReleasesInTemplate []models.ChartRelease
+		s.NoError(s.DB.Where("environment_id = ?", got.ID).Find(&chartReleasesInTemplate).Error)
+		s.Len(chartReleasesInTemplate, 1)
+		s.Equal(s.TestData.Chart_Honeycomb().ID, chartReleasesInTemplate[0].ChartID)
+	})
+}
+
+func (s *handlerSuite) TestEnvironmentV3Create_static() {
+	var got EnvironmentV3
+	code := s.HandleRequest(
+		s.NewRequest("POST", "/api/environments/v3", EnvironmentV3Create{
+			Base:      "live",
+			Lifecycle: "static",
+			Name:      "staticy-static",
+			EnvironmentV3Edit: EnvironmentV3Edit{
+				DefaultCluster: utils.PointerTo(s.TestData.Cluster_TerraStaging().Name),
+			},
+		}),
+		&got)
+	s.Equal(http.StatusCreated, code)
+	s.NotZero(got.ID)
+}
+
+func (s *handlerSuite) TestEnvironmentV3Create_staticFail() {
+	var got errors.ErrorResponse
+	code := s.HandleRequest(
+		s.NewRequest("POST", "/api/environments/v3", EnvironmentV3Create{
+			Base:      "live",
+			Lifecycle: "static",
+			Name:      "staticy-static",
+		}),
+		&got)
+	s.Equal(http.StatusBadRequest, code)
+	s.Equal(errors.BadRequest, got.Type)
+	s.Contains(got.Message, "lifecycle_valid")
+}
+
+func (s *handlerSuite) TestEnvironmentsV3Create_blocksDuplicates() {
+	s.TestData.Chart_Honeycomb()
+	s.TestData.ChartVersion_Honeycomb_V1()
+	var got EnvironmentV3
+	code := s.HandleRequest(
+		s.NewRequest("POST", "/api/environments/v3", EnvironmentV3Create{
+			Base:      "swatomation",
+			Lifecycle: "template",
+			Name:      "tempy-temp",
+		}),
+		&got)
+	s.Equal(http.StatusCreated, code)
+	s.NotZero(got.ID)
+	var got2 errors.ErrorResponse
+	code = s.HandleRequest(
+		s.NewRequest("POST", "/api/environments/v3", EnvironmentV3Create{
+			Base:      "swatomation",
+			Lifecycle: "template",
+			Name:      "tempy-temp",
+		}),
+		&got2)
+	s.Equal(http.StatusConflict, code)
+	s.Equal(errors.Conflict, got2.Type)
+}
+
+func (s *handlerSuite) TestEnvironmentsV3Create_suitability() {
+	s.TestData.Chart_Honeycomb()
+	s.TestData.ChartVersion_Honeycomb_V1()
+	var got errors.ErrorResponse
+	code := s.HandleRequest(
+		s.UseNonSuitableUserFor(s.NewRequest("POST", "/api/environments/v3", EnvironmentV3Create{
+			Base:      "swatomation",
+			Lifecycle: "template",
+			Name:      "tempy-temp",
+			EnvironmentV3Edit: EnvironmentV3Edit{
+				RequiresSuitability: utils.PointerTo(true),
+			},
+		})),
+		&got)
+	s.Equal(http.StatusForbidden, code)
+	s.Equal(errors.Forbidden, got.Type)
+}
+
+func (s *handlerSuite) TestEnvironmentsV3Create_suitabilityAllowed() {
+	s.TestData.Chart_Honeycomb()
+	s.TestData.ChartVersion_Honeycomb_V1()
+	var got EnvironmentV3
+	code := s.HandleRequest(
+		s.UseSuitableUserFor(s.NewRequest("POST", "/api/environments/v3", EnvironmentV3Create{
+			Base:      "swatomation",
+			Lifecycle: "template",
+			Name:      "tempy-temp",
+			EnvironmentV3Edit: EnvironmentV3Edit{
+				RequiresSuitability: utils.PointerTo(true),
+			},
+		})),
+		&got)
+	s.Equal(http.StatusCreated, code)
+	s.NotZero(got.ID)
+}

--- a/sherlock/internal/api/sherlock/environments_v3_test.go
+++ b/sherlock/internal/api/sherlock/environments_v3_test.go
@@ -151,7 +151,6 @@ func (s *handlerSuite) TestEnvironmentV3_toModel() {
 					TemplateEnvironment:       templateEnvironment.Name,
 					UniqueResourcePrefix:      "unique-resource-prefix",
 					DefaultNamespace:          "default-namespace",
-					NamePrefix:                "name-prefix",
 					ValuesName:                "values-name",
 					EnvironmentV3Edit: EnvironmentV3Edit{
 						DefaultCluster:              utils.PointerTo(defaultCluster.Name),
@@ -311,7 +310,6 @@ func Test_environmentFromModel(t *testing.T) {
 					TemplateEnvironment:       "name-3",
 					UniqueResourcePrefix:      "unique-resource-prefix",
 					DefaultNamespace:          "default-namespace",
-					NamePrefix:                "",
 					ValuesName:                "values-name",
 					EnvironmentV3Edit: EnvironmentV3Edit{
 						DefaultCluster:              utils.PointerTo("name-4"),

--- a/sherlock/internal/api/sherlock/routes.go
+++ b/sherlock/internal/api/sherlock/routes.go
@@ -106,6 +106,7 @@ func ConfigureRoutes(apiRouter gin.IRoutes) {
 	apiRouter.POST("pagerduty-integrations/v3", pagerdutyIntegrationsV3Create)
 
 	apiRouter.GET("environments/v3/*selector", environmentsV3Get)
+	apiRouter.POST("environments/v3", environmentsV3Create)
 	apiRouter.DELETE("environments/v3/*selector", environmentsV3Delete)
 	apiRouter.GET("environments/v3", environmentsV3List)
 	apiRouter.PATCH("environments/v3/*selector", environmentsV3Edit)

--- a/sherlock/internal/models/environment_test.go
+++ b/sherlock/internal/models/environment_test.go
@@ -372,6 +372,22 @@ func (s *modelSuite) TestEnvironmentValidationSqlOfflineEndPresent() {
 	s.ErrorContains(err, "violates check constraint \"offline_schedule_end_time_present\"")
 }
 
+func (s *modelSuite) TestEnvironmentValidationSqlNameUnique() {
+	s.SetSuitableTestUserForDB()
+	a := s.TestData.Environment_Dev()
+	b := s.TestData.Environment_Staging()
+	err := s.DB.Model(&b).Updates(&Environment{Name: a.Name}).Error
+	s.ErrorContains(err, "violates unique constraint \"environments_name_unique\"")
+}
+
+func (s *modelSuite) TestEnvironmentValidationSqlUrpUnique() {
+	s.SetSuitableTestUserForDB()
+	a := s.TestData.Environment_Dev()
+	b := s.TestData.Environment_Staging()
+	err := s.DB.Model(&b).Updates(&Environment{UniqueResourcePrefix: a.UniqueResourcePrefix}).Error
+	s.ErrorContains(err, "violates unique constraint \"environments_urp_unique\"")
+}
+
 func TestEnvironment_SlackBeehiveLink(t *testing.T) {
 	type fields struct {
 		Name string


### PR DESCRIPTION
Like #461 but for environments.

`namePrefix` is ngmi, that field was never actually used as far as I'm aware and it complicated things so much here (it wasn't persisted to the database!) that I'm just nuking it.

## Testing

Yes

## Risk

Low

There's a breaking change here... for parts of an API no one is using on a field that nothing is using. I still think this qualifies as low, if there's issues it'll come up in adopting the new APIs, not deploying them.