### PR TITLE
[DDO-3449] Resolve issues with the v3 changeset API in the Go client

### DIFF
--- a/sherlock/internal/api/sherlock/changesets_procedures_v3_chart_release_history.go
+++ b/sherlock/internal/api/sherlock/changesets_procedures_v3_chart_release_history.go
@@ -16,7 +16,7 @@ import (
 //	@description	List existing applied Changesets for a particular Chart Release, ordered by most recently applied.
 //	@tags			Changesets
 //	@produce		json
-//	@param			selector				path		string	true	"Selector of the Chart Release to find applied Changesets for"
+//	@param			chart-release			path		string	true	"Selector of the Chart Release to find applied Changesets for"
 //	@param			offset					query		int		false	"An optional offset to skip a number of latest Changesets"
 //	@param			limit					query		int		false	"An optional limit to the number of entries returned"
 //	@success		200						{array}		ChangesetV3

--- a/sherlock/internal/api/sherlock/changesets_procedures_v3_plan.go
+++ b/sherlock/internal/api/sherlock/changesets_procedures_v3_plan.go
@@ -41,7 +41,7 @@ type ChangesetV3PlanRequestEnvironmentEntry struct {
 //	@accept			json
 //	@produce		json
 //	@param			changeset-plan-request	body		ChangesetV3PlanRequest	true	"Info on what version changes or refreshes to plan"
-//	@param			verbose-output			query		bool		false	"If full information about the changesets should be returned, defaults to true. If false, only the IDs will be returned."
+//	@param			verbose-output			query		bool					false	"If full information about the changesets should be returned, defaults to true. If false, only the IDs will be returned."
 //	@success		200,201					{array}		ChangesetV3
 //	@failure		400,403,404,407,409,500	{object}	errors.ErrorResponse
 //	@router			/api/changesets/procedures/v3/plan [post]

--- a/sherlock/internal/api/sherlock/changesets_procedures_v3_plan_and_apply.go
+++ b/sherlock/internal/api/sherlock/changesets_procedures_v3_plan_and_apply.go
@@ -20,7 +20,7 @@ import (
 //	@accept			json
 //	@produce		json
 //	@param			changeset-plan-request	body		ChangesetV3PlanRequest	true	"Info on what version changes or refreshes to apply."
-//	@param			verbose-output			query		bool		false	"If full information about the changesets should be returned, defaults to true. If false, only the IDs will be returned."
+//	@param			verbose-output			query		bool					false	"If full information about the changesets should be returned, defaults to true. If false, only the IDs will be returned."
 //	@success		200,201					{array}		ChangesetV3
 //	@failure		400,403,404,407,409,500	{object}	errors.ErrorResponse
 //	@router			/api/changesets/procedures/v3/plan-and-apply [post]

--- a/sherlock/internal/api/sherlock/changesets_v3.go
+++ b/sherlock/internal/api/sherlock/changesets_v3.go
@@ -10,7 +10,10 @@ import (
 
 type ChangesetV3 struct {
 	CommonFields
+	ChangesetV3Query
+}
 
+type ChangesetV3Query struct {
 	CiIdentifier     *CiIdentifierV3 `json:"ciIdentifier,omitempty" form:"-"`
 	ChartReleaseInfo *ChartReleaseV3 `json:"chartReleaseInfo,omitempty" form:"-"`
 
@@ -228,40 +231,46 @@ func (c ChangesetV3) toModel(db *gorm.DB) (models.Changeset, error) {
 	return ret, nil
 }
 
+func (c ChangesetV3Query) toModel(db *gorm.DB) (models.Changeset, error) {
+	return ChangesetV3{ChangesetV3Query: c}.toModel(db)
+}
+
 func (c ChangesetV3Create) toModel(db *gorm.DB) (models.Changeset, error) {
-	return ChangesetV3{ChangesetV3Create: c}.toModel(db)
+	return ChangesetV3Query{ChangesetV3Create: c}.toModel(db)
 }
 
 func changesetFromModel(model models.Changeset) ChangesetV3 {
 	ret := ChangesetV3{
-		CommonFields:             commonFieldsFromGormModel(model.Model),
-		CiIdentifier:             utils.NilOrCall(ciIdentifierFromModel, model.CiIdentifier),
-		ChartReleaseInfo:         utils.NilOrCall(chartReleaseFromModel, model.ChartRelease),
-		AppliedAt:                model.AppliedAt,
-		SupersededAt:             model.SupersededAt,
-		PlannedByInfo:            utils.NilOrCall(userFromModel, model.PlannedBy),
-		AppliedByInfo:            utils.NilOrCall(userFromModel, model.AppliedBy),
-		FromResolvedAt:           model.From.ResolvedAt,
-		FromAppVersionResolver:   model.From.AppVersionResolver,
-		FromAppVersionExact:      model.From.AppVersionExact,
-		FromAppVersionBranch:     model.From.AppVersionBranch,
-		FromAppVersionCommit:     model.From.AppVersionCommit,
-		FromChartVersionResolver: model.From.ChartVersionResolver,
-		FromChartVersionExact:    model.From.ChartVersionExact,
-		FromHelmfileRef:          model.From.HelmfileRef,
-		FromHelmfileRefEnabled:   model.From.HelmfileRefEnabled,
-		FromFirecloudDevelopRef:  model.From.FirecloudDevelopRef,
-		ToResolvedAt:             model.To.ResolvedAt,
-		ChangesetV3Create: ChangesetV3Create{
-			ToAppVersionResolver:   model.To.AppVersionResolver,
-			ToAppVersionExact:      model.To.AppVersionExact,
-			ToAppVersionBranch:     model.To.AppVersionBranch,
-			ToAppVersionCommit:     model.To.AppVersionCommit,
-			ToChartVersionResolver: model.To.ChartVersionResolver,
-			ToChartVersionExact:    model.To.ChartVersionExact,
-			ToHelmfileRef:          model.To.HelmfileRef,
-			ToHelmfileRefEnabled:   model.To.HelmfileRefEnabled,
-			ToFirecloudDevelopRef:  model.To.FirecloudDevelopRef,
+		CommonFields: commonFieldsFromGormModel(model.Model),
+		ChangesetV3Query: ChangesetV3Query{
+			CiIdentifier:             utils.NilOrCall(ciIdentifierFromModel, model.CiIdentifier),
+			ChartReleaseInfo:         utils.NilOrCall(chartReleaseFromModel, model.ChartRelease),
+			AppliedAt:                model.AppliedAt,
+			SupersededAt:             model.SupersededAt,
+			PlannedByInfo:            utils.NilOrCall(userFromModel, model.PlannedBy),
+			AppliedByInfo:            utils.NilOrCall(userFromModel, model.AppliedBy),
+			FromResolvedAt:           model.From.ResolvedAt,
+			FromAppVersionResolver:   model.From.AppVersionResolver,
+			FromAppVersionExact:      model.From.AppVersionExact,
+			FromAppVersionBranch:     model.From.AppVersionBranch,
+			FromAppVersionCommit:     model.From.AppVersionCommit,
+			FromChartVersionResolver: model.From.ChartVersionResolver,
+			FromChartVersionExact:    model.From.ChartVersionExact,
+			FromHelmfileRef:          model.From.HelmfileRef,
+			FromHelmfileRefEnabled:   model.From.HelmfileRefEnabled,
+			FromFirecloudDevelopRef:  model.From.FirecloudDevelopRef,
+			ToResolvedAt:             model.To.ResolvedAt,
+			ChangesetV3Create: ChangesetV3Create{
+				ToAppVersionResolver:   model.To.AppVersionResolver,
+				ToAppVersionExact:      model.To.AppVersionExact,
+				ToAppVersionBranch:     model.To.AppVersionBranch,
+				ToAppVersionCommit:     model.To.AppVersionCommit,
+				ToChartVersionResolver: model.To.ChartVersionResolver,
+				ToChartVersionExact:    model.To.ChartVersionExact,
+				ToHelmfileRef:          model.To.HelmfileRef,
+				ToHelmfileRefEnabled:   model.To.HelmfileRefEnabled,
+				ToFirecloudDevelopRef:  model.To.FirecloudDevelopRef,
+			},
 		},
 	}
 	if len(model.NewAppVersions) > 0 {

--- a/sherlock/internal/api/sherlock/changesets_v3_list.go
+++ b/sherlock/internal/api/sherlock/changesets_v3_list.go
@@ -16,8 +16,8 @@ import (
 //	@description	List Changesets matching a filter.
 //	@tags			Changesets
 //	@produce		json
-//	@param			filter					query		ChangesetV3	false	"Filter the returned Changesets"
-//	@param			id						query		[]int		false	"Get specific changesets by their IDs, can be passed multiple times"
+//	@param			filter					query		ChangesetV3Query	false	"Filter the returned Changesets"
+//	@param			id 						query		[]int		false	"Get specific changesets by their IDs, can be passed multiple times"
 //	@param			limit					query		int			false	"Control how many Changesets are returned (default 100), ignored if specific IDs are passed"
 //	@param			offset					query		int			false	"Control the offset for the returned Changesets (default 0), ignored if specific IDs are passed"
 //	@success		200						{array}		ChangesetV3
@@ -28,7 +28,7 @@ func changesetsV3List(ctx *gin.Context) {
 	if err != nil {
 		return
 	}
-	var filter ChangesetV3
+	var filter ChangesetV3Query
 	if err = ctx.ShouldBindQuery(&filter); err != nil {
 		errors.AbortRequest(ctx, err)
 		return
@@ -52,8 +52,8 @@ func changesetsV3List(ctx *gin.Context) {
 			}
 		}
 
-		// We wipe out the ID field of the modelFilter. Either we have one ID and it being in the filter is superfluous,
-		// or we have multiple and it being in the filter is actually a problem (because the filter would have just one ID)
+		// The ID of the model filter should always be 0 because ChangesetV3Query lacks that field, but we set it to 0
+		// explicitly here to make extra sure and to have a good excuse to explain why we're doing it.
 		modelFilter.ID = 0
 
 		if err = db.

--- a/sherlock/internal/api/sherlock/changesets_v3_test.go
+++ b/sherlock/internal/api/sherlock/changesets_v3_test.go
@@ -312,35 +312,37 @@ func (s *handlerSuite) TestChangesetV3_toModel() {
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
 			c := ChangesetV3{
-				CommonFields:                       tt.fields.CommonFields,
-				CiIdentifier:                       tt.fields.CiIdentifier,
-				ChartReleaseInfo:                   tt.fields.ChartReleaseInfo,
-				AppliedAt:                          tt.fields.AppliedAt,
-				SupersededAt:                       tt.fields.SupersededAt,
-				NewAppVersions:                     tt.fields.NewAppVersions,
-				NewChartVersions:                   tt.fields.NewChartVersions,
-				FromResolvedAt:                     tt.fields.FromResolvedAt,
-				FromAppVersionResolver:             tt.fields.FromAppVersionResolver,
-				FromAppVersionExact:                tt.fields.FromAppVersionExact,
-				FromAppVersionBranch:               tt.fields.FromAppVersionBranch,
-				FromAppVersionCommit:               tt.fields.FromAppVersionCommit,
-				FromAppVersionFollowChartRelease:   tt.fields.FromAppVersionFollowChartRelease,
-				FromAppVersionReference:            tt.fields.FromAppVersionReference,
-				FromChartVersionResolver:           tt.fields.FromChartVersionResolver,
-				FromChartVersionExact:              tt.fields.FromChartVersionExact,
-				FromChartVersionFollowChartRelease: tt.fields.FromChartVersionFollowChartRelease,
-				FromChartVersionReference:          tt.fields.FromChartVersionReference,
-				FromHelmfileRef:                    tt.fields.FromHelmfileRef,
-				FromHelmfileRefEnabled:             tt.fields.FromHelmfileRefEnabled,
-				FromFirecloudDevelopRef:            tt.fields.FromFirecloudDevelopRef,
-				ToResolvedAt:                       tt.fields.ToResolvedAt,
-				ToAppVersionReference:              tt.fields.ToAppVersionReference,
-				ToChartVersionReference:            tt.fields.ToChartVersionReference,
-				PlannedBy:                          tt.fields.PlannedBy,
-				PlannedByInfo:                      tt.fields.PlannedByInfo,
-				AppliedBy:                          tt.fields.AppliedBy,
-				AppliedByInfo:                      tt.fields.AppliedByInfo,
-				ChangesetV3Create:                  tt.fields.ChangesetV3Create,
+				CommonFields: tt.fields.CommonFields,
+				ChangesetV3Query: ChangesetV3Query{
+					CiIdentifier:                       tt.fields.CiIdentifier,
+					ChartReleaseInfo:                   tt.fields.ChartReleaseInfo,
+					AppliedAt:                          tt.fields.AppliedAt,
+					SupersededAt:                       tt.fields.SupersededAt,
+					NewAppVersions:                     tt.fields.NewAppVersions,
+					NewChartVersions:                   tt.fields.NewChartVersions,
+					FromResolvedAt:                     tt.fields.FromResolvedAt,
+					FromAppVersionResolver:             tt.fields.FromAppVersionResolver,
+					FromAppVersionExact:                tt.fields.FromAppVersionExact,
+					FromAppVersionBranch:               tt.fields.FromAppVersionBranch,
+					FromAppVersionCommit:               tt.fields.FromAppVersionCommit,
+					FromAppVersionFollowChartRelease:   tt.fields.FromAppVersionFollowChartRelease,
+					FromAppVersionReference:            tt.fields.FromAppVersionReference,
+					FromChartVersionResolver:           tt.fields.FromChartVersionResolver,
+					FromChartVersionExact:              tt.fields.FromChartVersionExact,
+					FromChartVersionFollowChartRelease: tt.fields.FromChartVersionFollowChartRelease,
+					FromChartVersionReference:          tt.fields.FromChartVersionReference,
+					FromHelmfileRef:                    tt.fields.FromHelmfileRef,
+					FromHelmfileRefEnabled:             tt.fields.FromHelmfileRefEnabled,
+					FromFirecloudDevelopRef:            tt.fields.FromFirecloudDevelopRef,
+					ToResolvedAt:                       tt.fields.ToResolvedAt,
+					ToAppVersionReference:              tt.fields.ToAppVersionReference,
+					ToChartVersionReference:            tt.fields.ToChartVersionReference,
+					PlannedBy:                          tt.fields.PlannedBy,
+					PlannedByInfo:                      tt.fields.PlannedByInfo,
+					AppliedBy:                          tt.fields.AppliedBy,
+					AppliedByInfo:                      tt.fields.AppliedByInfo,
+					ChangesetV3Create:                  tt.fields.ChangesetV3Create,
+				},
 			}
 			got, err := c.toModel(s.DB)
 			if !tt.wantErr(s.T(), err, "toModel()") {
@@ -382,8 +384,10 @@ func Test_changesetFromModel(t *testing.T) {
 				},
 			},
 			want: ChangesetV3{
-				NewAppVersions: []AppVersionV3{
-					{CommonFields: CommonFields{ID: 1}},
+				ChangesetV3Query: ChangesetV3Query{
+					NewAppVersions: []AppVersionV3{
+						{CommonFields: CommonFields{ID: 1}},
+					},
 				},
 			},
 		},
@@ -403,8 +407,10 @@ func Test_changesetFromModel(t *testing.T) {
 				},
 			},
 			want: ChangesetV3{
-				NewChartVersions: []ChartVersionV3{
-					{CommonFields: CommonFields{ID: 1}},
+				ChangesetV3Query: ChangesetV3Query{
+					NewChartVersions: []ChartVersionV3{
+						{CommonFields: CommonFields{ID: 1}},
+					},
 				},
 			},
 		},
@@ -420,7 +426,9 @@ func Test_changesetFromModel(t *testing.T) {
 				},
 			},
 			want: ChangesetV3{
-				FromAppVersionFollowChartRelease: "name",
+				ChangesetV3Query: ChangesetV3Query{
+					FromAppVersionFollowChartRelease: "name",
+				},
 			},
 		},
 		{
@@ -433,7 +441,9 @@ func Test_changesetFromModel(t *testing.T) {
 				},
 			},
 			want: ChangesetV3{
-				FromAppVersionFollowChartRelease: "1",
+				ChangesetV3Query: ChangesetV3Query{
+					FromAppVersionFollowChartRelease: "1",
+				},
 			},
 		},
 		{
@@ -451,7 +461,9 @@ func Test_changesetFromModel(t *testing.T) {
 				},
 			},
 			want: ChangesetV3{
-				FromAppVersionReference: "name/version",
+				ChangesetV3Query: ChangesetV3Query{
+					FromAppVersionReference: "name/version",
+				},
 			},
 		},
 		{
@@ -467,7 +479,9 @@ func Test_changesetFromModel(t *testing.T) {
 				},
 			},
 			want: ChangesetV3{
-				FromAppVersionReference: "1/version",
+				ChangesetV3Query: ChangesetV3Query{
+					FromAppVersionReference: "1/version",
+				},
 			},
 		},
 		{
@@ -480,7 +494,9 @@ func Test_changesetFromModel(t *testing.T) {
 				},
 			},
 			want: ChangesetV3{
-				FromAppVersionReference: "1",
+				ChangesetV3Query: ChangesetV3Query{
+					FromAppVersionReference: "1",
+				},
 			},
 		},
 		{
@@ -495,7 +511,9 @@ func Test_changesetFromModel(t *testing.T) {
 				},
 			},
 			want: ChangesetV3{
-				FromChartVersionFollowChartRelease: "name",
+				ChangesetV3Query: ChangesetV3Query{
+					FromChartVersionFollowChartRelease: "name",
+				},
 			},
 		},
 		{
@@ -508,7 +526,9 @@ func Test_changesetFromModel(t *testing.T) {
 				},
 			},
 			want: ChangesetV3{
-				FromChartVersionFollowChartRelease: "1",
+				ChangesetV3Query: ChangesetV3Query{
+					FromChartVersionFollowChartRelease: "1",
+				},
 			},
 		},
 		{
@@ -526,7 +546,9 @@ func Test_changesetFromModel(t *testing.T) {
 				},
 			},
 			want: ChangesetV3{
-				FromChartVersionReference: "name/version",
+				ChangesetV3Query: ChangesetV3Query{
+					FromChartVersionReference: "name/version",
+				},
 			},
 		},
 		{
@@ -542,7 +564,9 @@ func Test_changesetFromModel(t *testing.T) {
 				},
 			},
 			want: ChangesetV3{
-				FromChartVersionReference: "1/version",
+				ChangesetV3Query: ChangesetV3Query{
+					FromChartVersionReference: "1/version",
+				},
 			},
 		},
 		{
@@ -555,7 +579,9 @@ func Test_changesetFromModel(t *testing.T) {
 				},
 			},
 			want: ChangesetV3{
-				FromChartVersionReference: "1",
+				ChangesetV3Query: ChangesetV3Query{
+					FromChartVersionReference: "1",
+				},
 			},
 		},
 
@@ -571,8 +597,10 @@ func Test_changesetFromModel(t *testing.T) {
 				},
 			},
 			want: ChangesetV3{
-				ChangesetV3Create: ChangesetV3Create{
-					ToAppVersionFollowChartRelease: "name",
+				ChangesetV3Query: ChangesetV3Query{
+					ChangesetV3Create: ChangesetV3Create{
+						ToAppVersionFollowChartRelease: "name",
+					},
 				},
 			},
 		},
@@ -586,8 +614,10 @@ func Test_changesetFromModel(t *testing.T) {
 				},
 			},
 			want: ChangesetV3{
-				ChangesetV3Create: ChangesetV3Create{
-					ToAppVersionFollowChartRelease: "1",
+				ChangesetV3Query: ChangesetV3Query{
+					ChangesetV3Create: ChangesetV3Create{
+						ToAppVersionFollowChartRelease: "1",
+					},
 				},
 			},
 		},
@@ -606,7 +636,9 @@ func Test_changesetFromModel(t *testing.T) {
 				},
 			},
 			want: ChangesetV3{
-				ToAppVersionReference: "name/version",
+				ChangesetV3Query: ChangesetV3Query{
+					ToAppVersionReference: "name/version",
+				},
 			},
 		},
 		{
@@ -622,7 +654,9 @@ func Test_changesetFromModel(t *testing.T) {
 				},
 			},
 			want: ChangesetV3{
-				ToAppVersionReference: "1/version",
+				ChangesetV3Query: ChangesetV3Query{
+					ToAppVersionReference: "1/version",
+				},
 			},
 		},
 		{
@@ -635,7 +669,9 @@ func Test_changesetFromModel(t *testing.T) {
 				},
 			},
 			want: ChangesetV3{
-				ToAppVersionReference: "1",
+				ChangesetV3Query: ChangesetV3Query{
+					ToAppVersionReference: "1",
+				},
 			},
 		},
 		{
@@ -650,8 +686,10 @@ func Test_changesetFromModel(t *testing.T) {
 				},
 			},
 			want: ChangesetV3{
-				ChangesetV3Create: ChangesetV3Create{
-					ToChartVersionFollowChartRelease: "name",
+				ChangesetV3Query: ChangesetV3Query{
+					ChangesetV3Create: ChangesetV3Create{
+						ToChartVersionFollowChartRelease: "name",
+					},
 				},
 			},
 		},
@@ -665,8 +703,10 @@ func Test_changesetFromModel(t *testing.T) {
 				},
 			},
 			want: ChangesetV3{
-				ChangesetV3Create: ChangesetV3Create{
-					ToChartVersionFollowChartRelease: "1",
+				ChangesetV3Query: ChangesetV3Query{
+					ChangesetV3Create: ChangesetV3Create{
+						ToChartVersionFollowChartRelease: "1",
+					},
 				},
 			},
 		},
@@ -685,7 +725,9 @@ func Test_changesetFromModel(t *testing.T) {
 				},
 			},
 			want: ChangesetV3{
-				ToChartVersionReference: "name/version",
+				ChangesetV3Query: ChangesetV3Query{
+					ToChartVersionReference: "name/version",
+				},
 			},
 		},
 		{
@@ -701,7 +743,9 @@ func Test_changesetFromModel(t *testing.T) {
 				},
 			},
 			want: ChangesetV3{
-				ToChartVersionReference: "1/version",
+				ChangesetV3Query: ChangesetV3Query{
+					ToChartVersionReference: "1/version",
+				},
 			},
 		},
 		{
@@ -714,7 +758,9 @@ func Test_changesetFromModel(t *testing.T) {
 				},
 			},
 			want: ChangesetV3{
-				ToChartVersionReference: "1",
+				ChangesetV3Query: ChangesetV3Query{
+					ToChartVersionReference: "1",
+				},
 			},
 		},
 		{
@@ -727,11 +773,13 @@ func Test_changesetFromModel(t *testing.T) {
 				},
 			},
 			want: ChangesetV3{
-				PlannedBy: utils.PointerTo("email"),
-				PlannedByInfo: &UserV3{
-					Email:                  "email",
-					SuitabilityDescription: utils.PointerTo("user email lacks production suitability"),
-					Suitable:               utils.PointerTo(false),
+				ChangesetV3Query: ChangesetV3Query{
+					PlannedBy: utils.PointerTo("email"),
+					PlannedByInfo: &UserV3{
+						Email:                  "email",
+						SuitabilityDescription: utils.PointerTo("user email lacks production suitability"),
+						Suitable:               utils.PointerTo(false),
+					},
 				},
 			},
 		},
@@ -743,7 +791,9 @@ func Test_changesetFromModel(t *testing.T) {
 				},
 			},
 			want: ChangesetV3{
-				PlannedBy: utils.PointerTo("1"),
+				ChangesetV3Query: ChangesetV3Query{
+					PlannedBy: utils.PointerTo("1"),
+				},
 			},
 		},
 		{
@@ -756,11 +806,13 @@ func Test_changesetFromModel(t *testing.T) {
 				},
 			},
 			want: ChangesetV3{
-				AppliedBy: utils.PointerTo("email"),
-				AppliedByInfo: &UserV3{
-					Email:                  "email",
-					SuitabilityDescription: utils.PointerTo("user email lacks production suitability"),
-					Suitable:               utils.PointerTo(false),
+				ChangesetV3Query: ChangesetV3Query{
+					AppliedBy: utils.PointerTo("email"),
+					AppliedByInfo: &UserV3{
+						Email:                  "email",
+						SuitabilityDescription: utils.PointerTo("user email lacks production suitability"),
+						Suitable:               utils.PointerTo(false),
+					},
 				},
 			},
 		},
@@ -772,7 +824,9 @@ func Test_changesetFromModel(t *testing.T) {
 				},
 			},
 			want: ChangesetV3{
-				AppliedBy: utils.PointerTo("1"),
+				ChangesetV3Query: ChangesetV3Query{
+					AppliedBy: utils.PointerTo("1"),
+				},
 			},
 		},
 		{
@@ -785,12 +839,14 @@ func Test_changesetFromModel(t *testing.T) {
 				},
 			},
 			want: ChangesetV3{
-				ChangesetV3Create: ChangesetV3Create{
-					ChartRelease: "name",
-				},
-				ChartReleaseInfo: &ChartReleaseV3{
-					ChartReleaseV3Create: ChartReleaseV3Create{
-						Name: "name",
+				ChangesetV3Query: ChangesetV3Query{
+					ChangesetV3Create: ChangesetV3Create{
+						ChartRelease: "name",
+					},
+					ChartReleaseInfo: &ChartReleaseV3{
+						ChartReleaseV3Create: ChartReleaseV3Create{
+							Name: "name",
+						},
 					},
 				},
 			},
@@ -803,8 +859,10 @@ func Test_changesetFromModel(t *testing.T) {
 				},
 			},
 			want: ChangesetV3{
-				ChangesetV3Create: ChangesetV3Create{
-					ChartRelease: "1",
+				ChangesetV3Query: ChangesetV3Query{
+					ChangesetV3Create: ChangesetV3Create{
+						ChartRelease: "1",
+					},
 				},
 			},
 		},
@@ -847,31 +905,33 @@ func Test_changesetFromModel(t *testing.T) {
 				},
 			},
 			want: ChangesetV3{
-				CommonFields:             CommonFields{ID: 1},
-				CiIdentifier:             &CiIdentifierV3{CommonFields: CommonFields{ID: 2}},
-				AppliedAt:                utils.PointerTo(now.Add(time.Hour)),
-				SupersededAt:             utils.PointerTo(now.Add(time.Minute)),
-				FromResolvedAt:           utils.PointerTo(now.Add(-time.Hour)),
-				FromAppVersionResolver:   utils.PointerTo("resolver"),
-				FromAppVersionExact:      utils.PointerTo("exact"),
-				FromAppVersionBranch:     utils.PointerTo("branch"),
-				FromAppVersionCommit:     utils.PointerTo("commit"),
-				FromChartVersionResolver: utils.PointerTo("resolver"),
-				FromChartVersionExact:    utils.PointerTo("exact"),
-				FromHelmfileRef:          utils.PointerTo("helmfile-ref"),
-				FromHelmfileRefEnabled:   utils.PointerTo(true),
-				FromFirecloudDevelopRef:  utils.PointerTo("firecloud-develop-ref"),
-				ToResolvedAt:             utils.PointerTo(now.Add(time.Hour)),
-				ChangesetV3Create: ChangesetV3Create{
-					ToAppVersionResolver:   utils.PointerTo("resolver"),
-					ToAppVersionExact:      utils.PointerTo("exact"),
-					ToAppVersionBranch:     utils.PointerTo("branch"),
-					ToAppVersionCommit:     utils.PointerTo("commit"),
-					ToChartVersionResolver: utils.PointerTo("resolver"),
-					ToChartVersionExact:    utils.PointerTo("exact"),
-					ToHelmfileRef:          utils.PointerTo("helmfile-ref"),
-					ToHelmfileRefEnabled:   utils.PointerTo(true),
-					ToFirecloudDevelopRef:  utils.PointerTo("firecloud-develop-ref"),
+				CommonFields: CommonFields{ID: 1},
+				ChangesetV3Query: ChangesetV3Query{
+					CiIdentifier:             &CiIdentifierV3{CommonFields: CommonFields{ID: 2}},
+					AppliedAt:                utils.PointerTo(now.Add(time.Hour)),
+					SupersededAt:             utils.PointerTo(now.Add(time.Minute)),
+					FromResolvedAt:           utils.PointerTo(now.Add(-time.Hour)),
+					FromAppVersionResolver:   utils.PointerTo("resolver"),
+					FromAppVersionExact:      utils.PointerTo("exact"),
+					FromAppVersionBranch:     utils.PointerTo("branch"),
+					FromAppVersionCommit:     utils.PointerTo("commit"),
+					FromChartVersionResolver: utils.PointerTo("resolver"),
+					FromChartVersionExact:    utils.PointerTo("exact"),
+					FromHelmfileRef:          utils.PointerTo("helmfile-ref"),
+					FromHelmfileRefEnabled:   utils.PointerTo(true),
+					FromFirecloudDevelopRef:  utils.PointerTo("firecloud-develop-ref"),
+					ToResolvedAt:             utils.PointerTo(now.Add(time.Hour)),
+					ChangesetV3Create: ChangesetV3Create{
+						ToAppVersionResolver:   utils.PointerTo("resolver"),
+						ToAppVersionExact:      utils.PointerTo("exact"),
+						ToAppVersionBranch:     utils.PointerTo("branch"),
+						ToAppVersionCommit:     utils.PointerTo("commit"),
+						ToChartVersionResolver: utils.PointerTo("resolver"),
+						ToChartVersionExact:    utils.PointerTo("exact"),
+						ToHelmfileRef:          utils.PointerTo("helmfile-ref"),
+						ToHelmfileRefEnabled:   utils.PointerTo(true),
+						ToFirecloudDevelopRef:  utils.PointerTo("firecloud-develop-ref"),
+					},
 				},
 			},
 		},

--- a/sherlock/internal/api/sherlock/environments_v3.go
+++ b/sherlock/internal/api/sherlock/environments_v3.go
@@ -41,8 +41,8 @@ type EnvironmentV3Edit struct {
 	BaseDomain                  *string    `json:"baseDomain" form:"baseDomain" default:"bee.envs-terra.bio"`
 	NamePrefixesDomain          *bool      `json:"namePrefixesDomain" form:"namePrefixesDomain" default:"true"`
 	HelmfileRef                 *string    `json:"helmfileRef" form:"helmfileRef" default:"HEAD"`
-	PreventDeletion             *bool      `json:"preventDeletion" form:"preventDeletion" default:"false"` // Used to protect specific BEEs from deletion (thelma checks this field)
-	DeleteAfter                 *time.Time `json:"deleteAfter,omitempty" form:"deleteAfter"`               // If set, the BEE will be automatically deleted after this time (thelma checks this field)
+	PreventDeletion             *bool      `json:"preventDeletion" form:"preventDeletion" default:"false"`      // Used to protect specific BEEs from deletion (thelma checks this field)
+	DeleteAfter                 *time.Time `json:"deleteAfter,omitempty" form:"deleteAfter" format:"date-time"` // If set, the BEE will be automatically deleted after this time (thelma checks this field)
 	Description                 *string    `json:"description" form:"description"`
 	PactIdentifier              *uuid.UUID `json:"pactIdentifier" form:"PactIdentifier"`
 	PagerdutyIntegration        *string    `json:"pagerdutyIntegration,omitempty" form:"pagerdutyIntegration"`


### PR DESCRIPTION
Fix one typo and one decidedly-not-typo in #467 that reared their head when generating the typed Go client in https://github.com/broadinstitute/sherlock/actions/runs/7830793055/job/21365702606.

The typo was me renaming a path parameter in the code but not fully in one of the Swagger comments. The other one was a type-system issue with query parameter parsing. In both cases, I think the Swagger page would've worked fine, but the Go client was getting type system issues, so here's a fix.

I also tweaked the string type for one of the fields to document it specifically a time field, rather than a plain string.