### PR TITLE
[DDO-3470] Add missing database instance method (upsert)

### DIFF
--- a/sherlock/internal/api/sherlock/database_instances_v3_create.go
+++ b/sherlock/internal/api/sherlock/database_instances_v3_create.go
@@ -7,6 +7,7 @@ import (
 	"github.com/broadinstitute/sherlock/sherlock/internal/models"
 	"github.com/creasty/defaults"
 	"github.com/gin-gonic/gin"
+	"github.com/gin-gonic/gin/binding"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 	"net/http"
@@ -30,7 +31,8 @@ func databaseInstancesV3Create(ctx *gin.Context) {
 	}
 
 	var body DatabaseInstanceV3Create
-	if err = ctx.ShouldBindJSON(&body); err != nil {
+	// ShouldBindBodyWith used to handle double-reading body when redirected from databaseInstancesV3Upsert
+	if err = ctx.ShouldBindBodyWith(&body, binding.JSON); err != nil {
 		errors.AbortRequest(ctx, fmt.Errorf("(%s) request validation error: %w", errors.BadRequest, err))
 		return
 	}

--- a/sherlock/internal/api/sherlock/database_instances_v3_edit.go
+++ b/sherlock/internal/api/sherlock/database_instances_v3_edit.go
@@ -6,6 +6,7 @@ import (
 	"github.com/broadinstitute/sherlock/sherlock/internal/errors"
 	"github.com/broadinstitute/sherlock/sherlock/internal/models"
 	"github.com/gin-gonic/gin"
+	"github.com/gin-gonic/gin/binding"
 	"gorm.io/gorm/clause"
 	"net/http"
 )
@@ -33,7 +34,8 @@ func databaseInstancesV3Edit(ctx *gin.Context) {
 	}
 
 	var body DatabaseInstanceV3Edit
-	if err = ctx.ShouldBindJSON(&body); err != nil {
+	// ShouldBindBodyWith used to handle double-reading body when redirected from databaseInstancesV3Upsert
+	if err = ctx.ShouldBindBodyWith(&body, binding.JSON); err != nil {
 		errors.AbortRequest(ctx, fmt.Errorf("(%s) request validation error: %w", errors.BadRequest, err))
 		return
 	}

--- a/sherlock/internal/api/sherlock/database_instances_v3_upsert.go
+++ b/sherlock/internal/api/sherlock/database_instances_v3_upsert.go
@@ -1,0 +1,60 @@
+package sherlock
+
+import (
+	"fmt"
+	"github.com/broadinstitute/sherlock/go-shared/pkg/utils"
+	"github.com/broadinstitute/sherlock/sherlock/internal/authentication"
+	"github.com/broadinstitute/sherlock/sherlock/internal/errors"
+	"github.com/broadinstitute/sherlock/sherlock/internal/models"
+	"github.com/gin-gonic/gin"
+	"github.com/gin-gonic/gin/binding"
+)
+
+// databaseInstancesV3Upsert godoc
+//
+//	@summary		Create or edit a DatabaseInstance
+//	@description	Create or edit a DatabaseInstance, depending on whether one already exists for the chart release
+//	@tags			DatabaseInstances
+//	@accept			json
+//	@produce		json
+//	@param			databaseInstance		body		DatabaseInstanceV3Create	true	"The DatabaseInstance to create or edit. Defaults will only be set if creating."
+//	@success		200,201					{object}	DatabaseInstanceV3
+//	@failure		400,403,404,407,409,500	{object}	errors.ErrorResponse
+//	@router			/api/database-instances/v3 [put]
+func databaseInstancesV3Upsert(ctx *gin.Context) {
+	db, err := authentication.MustUseDB(ctx)
+	if err != nil {
+		return
+	}
+
+	var body DatabaseInstanceV3Create
+	// ShouldBindBodyWith used to handle double-reading body when redirected from databaseInstancesV3Upsert
+	if err = ctx.ShouldBindBodyWith(&body, binding.JSON); err != nil {
+		errors.AbortRequest(ctx, fmt.Errorf("(%s) request validation error: %w", errors.BadRequest, err))
+		return
+	}
+
+	toUpsert, err := body.toModel(db)
+	if err != nil {
+		errors.AbortRequest(ctx, err)
+		return
+	}
+
+	if toUpsert.ChartReleaseID == 0 {
+		errors.AbortRequest(ctx, fmt.Errorf("(%s) chartRelease is required", errors.BadRequest))
+		return
+	}
+
+	var existing []models.DatabaseInstance
+	if err = db.Where(&models.DatabaseInstance{ChartReleaseID: toUpsert.ChartReleaseID}).Select("id").Find(&existing).Error; err != nil {
+		errors.AbortRequest(ctx, err)
+		return
+	} else if len(existing) >= 1 {
+		// If it exists, redirect to the edit method and set the selector param as if it had been passed
+		ctx.AddParam("selector", utils.UintToString(existing[0].ID))
+		databaseInstancesV3Edit(ctx)
+	} else {
+		// Otherwise, redirect to the create method
+		databaseInstancesV3Create(ctx)
+	}
+}

--- a/sherlock/internal/api/sherlock/database_instances_v3_upsert_test.go
+++ b/sherlock/internal/api/sherlock/database_instances_v3_upsert_test.go
@@ -1,0 +1,75 @@
+package sherlock
+
+import (
+	"github.com/broadinstitute/sherlock/go-shared/pkg/utils"
+	"github.com/broadinstitute/sherlock/sherlock/internal/errors"
+	"github.com/gin-gonic/gin"
+	"net/http"
+)
+
+func (s *handlerSuite) TestDatabaseInstancesV3Upsert_badBody() {
+	var got errors.ErrorResponse
+	code := s.HandleRequest(
+		s.NewRequest("PUT", "/api/database-instances/v3", gin.H{
+			"platform": 123,
+		}),
+		&got)
+	s.Equal(http.StatusBadRequest, code)
+	s.Equal(errors.BadRequest, got.Type)
+	s.Contains(got.Message, "platform")
+}
+
+func (s *handlerSuite) TestDatabaseInstancesV3Upsert_requiresChartRelease() {
+	var got errors.ErrorResponse
+	code := s.HandleRequest(
+		s.NewRequest("PUT", "/api/database-instances/v3", DatabaseInstanceV3Create{
+			DatabaseInstanceV3Edit: DatabaseInstanceV3Edit{
+				Platform:        utils.PointerTo("google"),
+				GoogleProject:   utils.PointerTo("some-project"),
+				InstanceName:    utils.PointerTo("some-instance"),
+				DefaultDatabase: utils.PointerTo("stairway or something idk"),
+			},
+		}),
+		&got)
+	s.Equal(http.StatusBadRequest, code)
+	s.Contains(got.Message, "chartRelease")
+}
+
+func (s *handlerSuite) TestDatabaseInstancesV3Upsert_chartReleaseNotFound() {
+	var got errors.ErrorResponse
+	code := s.HandleRequest(
+		s.NewRequest("PUT", "/api/database-instances/v3", DatabaseInstanceV3Create{
+			ChartRelease: "not-found",
+		}),
+		&got)
+	s.Equal(http.StatusNotFound, code)
+	s.Contains(got.Message, "not-found")
+}
+
+func (s *handlerSuite) TestDatabaseInstancesV3Upsert_edits() {
+	di := s.TestData.DatabaseInstance_LeonardoDev()
+	var got DatabaseInstanceV3
+	code := s.HandleRequest(
+		s.NewRequest("PUT", "/api/database-instances/v3", DatabaseInstanceV3Create{
+			ChartRelease: s.TestData.ChartRelease_LeonardoDev().Name,
+			DatabaseInstanceV3Edit: DatabaseInstanceV3Edit{
+				DefaultDatabase: utils.PointerTo("foo"),
+			}}),
+		&got)
+	s.Equal(http.StatusOK, code)
+	s.Equal("foo", *got.DefaultDatabase)
+	s.Equal(di.ID, got.ID)
+}
+
+func (s *handlerSuite) TestDatabaseInstancesV3Upsert_creates() {
+	var got DatabaseInstanceV3
+	code := s.HandleRequest(
+		s.NewRequest("PUT", "/api/database-instances/v3", DatabaseInstanceV3Create{
+			ChartRelease: s.TestData.ChartRelease_LeonardoDev().Name,
+		}),
+		&got)
+	s.Equal(http.StatusCreated, code)
+	if s.NotNil(got.DefaultDatabase) {
+		s.Equal("leonardo", *got.DefaultDatabase)
+	}
+}

--- a/sherlock/internal/api/sherlock/routes.go
+++ b/sherlock/internal/api/sherlock/routes.go
@@ -122,6 +122,7 @@ func ConfigureRoutes(apiRouter gin.IRoutes) {
 	apiRouter.DELETE("database-instances/v3/*selector", databaseInstancesV3Delete)
 	apiRouter.GET("database-instances/v3", databaseInstancesV3List)
 	apiRouter.PATCH("database-instances/v3/*selector", databaseInstancesV3Edit)
+	apiRouter.PUT("database-instances/v3", databaseInstancesV3Upsert)
 
 	apiRouter.GET("changesets/procedures/v3/version-history/:version-type/:chart/:version", changesetsProceduresV3VersionHistory)
 	apiRouter.GET("changesets/procedures/v3/chart-release-history/*chart-release", changesetsProceduresV3ChartReleaseHistory)


### PR DESCRIPTION
I thought that this wasn't used at all but it turns out I took a shortcut from Beehive that actually requires this. The easiest thing to do is basically make it just redirect to either the create handler or the edit handler. That requires a tiny bit of trickery to read the body twice but I think that's worth it to avoid adding indirection to the create and edit functions or duplicating code.

## Testing

Added a test file, creates and edits are already tested

## Risk

Very low