### PR TITLE
[DDO-3470] Add missing PagerdutyIntegration upsert-ish behavior

### DIFF
--- a/sherlock/internal/api/sherlock/pagerduty_integrations_v3_create.go
+++ b/sherlock/internal/api/sherlock/pagerduty_integrations_v3_create.go
@@ -7,14 +7,13 @@ import (
 	"github.com/broadinstitute/sherlock/sherlock/internal/models"
 	"github.com/creasty/defaults"
 	"github.com/gin-gonic/gin"
-	"gorm.io/gorm/clause"
 	"net/http"
 )
 
 // pagerdutyIntegrationsV3Create godoc
 //
 //	@summary		Create a PagerdutyIntegration
-//	@description	Create a PagerdutyIntegration.
+//	@description	Create a PagerdutyIntegration. Duplicate Pagerduty IDs will be gracefully handled by editing the existing entry. This is partially opaque because some fields are writable but not readable.
 //	@tags			PagerdutyIntegrations
 //	@accept			json
 //	@produce		json
@@ -40,13 +39,15 @@ func pagerdutyIntegrationsV3Create(ctx *gin.Context) {
 	}
 
 	toCreate := body.toModel()
-	if err = db.Create(&toCreate).Error; err != nil {
-		errors.AbortRequest(ctx, err)
-		return
-	}
 
 	var result models.PagerdutyIntegration
-	if err = db.Preload(clause.Associations).First(&result, toCreate.ID).Error; err != nil {
+	if err = db.Where(&models.PagerdutyIntegration{
+		PagerdutyID: toCreate.PagerdutyID,
+	}).Assign(&models.PagerdutyIntegration{
+		Name: toCreate.Name,
+		Key:  toCreate.Key,
+		Type: toCreate.Type,
+	}).FirstOrCreate(&result).Error; err != nil {
 		errors.AbortRequest(ctx, err)
 		return
 	}

--- a/sherlock/internal/api/sherlock/pagerduty_integrations_v3_create.go
+++ b/sherlock/internal/api/sherlock/pagerduty_integrations_v3_create.go
@@ -7,6 +7,7 @@ import (
 	"github.com/broadinstitute/sherlock/sherlock/internal/models"
 	"github.com/creasty/defaults"
 	"github.com/gin-gonic/gin"
+	"gorm.io/gorm/clause"
 	"net/http"
 )
 
@@ -47,7 +48,7 @@ func pagerdutyIntegrationsV3Create(ctx *gin.Context) {
 		Name: toCreate.Name,
 		Key:  toCreate.Key,
 		Type: toCreate.Type,
-	}).FirstOrCreate(&result).Error; err != nil {
+	}).Preload(clause.Associations).FirstOrCreate(&result).Error; err != nil {
 		errors.AbortRequest(ctx, err)
 		return
 	}

--- a/sherlock/internal/api/sherlock/pagerduty_integrations_v3_create_test.go
+++ b/sherlock/internal/api/sherlock/pagerduty_integrations_v3_create_test.go
@@ -62,3 +62,24 @@ func (s *handlerSuite) TestPagerdutyIntegrationsV3Create() {
 		s.Equal("pagerduty-integration-name", *got.Name)
 	}
 }
+
+func (s *handlerSuite) TestPagerdutyIntegrationsV3Create_duplicate() {
+	pdi := s.TestData.PagerdutyIntegration_ManuallyTriggeredTerraIncident()
+	var got PagerdutyIntegrationV3
+	code := s.HandleRequest(
+		s.NewSuitableRequest("POST", "/api/pagerduty-integrations/v3", PagerdutyIntegrationV3Create{
+			PagerdutyID: pdi.PagerdutyID,
+			PagerdutyIntegrationV3Edit: PagerdutyIntegrationV3Edit{
+				Name: utils.PointerTo("pagerduty-integration-name"),
+				Key:  utils.PointerTo("pagerduty-integration-key"),
+				Type: utils.PointerTo("pagerduty-integration-type"),
+			},
+		}),
+		&got)
+	s.Equal(http.StatusCreated, code)
+	s.NotZero(got.ID)
+	if s.NotNil(got.Name) {
+		s.Equal("pagerduty-integration-name", *got.Name)
+	}
+	s.Equal(pdi.ID, got.ID)
+}


### PR DESCRIPTION
PagerdutyIntegration is a weird type because there's a field that is writable but not readable. A downstream effect in Beehive is that Beehive relied on upsert behavior that was provided by the generics in v2.

This PR adds similar-enough behavior to the pagerduty create endpoint so that Beehive won't run into edge cases using it.

Note that this isn't full upsert; it's a bit dumber than the slick behavior in #469, but that's not necessary here.

## Testing

Added a test for the new behavior

## Risk