### PR TITLE
[DDO-3470] Add missing association details in v3 list endpoints

### DIFF
--- a/sherlock/internal/api/sherlock/app_version_v3_list.go
+++ b/sherlock/internal/api/sherlock/app_version_v3_list.go
@@ -7,6 +7,7 @@ import (
 	"github.com/broadinstitute/sherlock/sherlock/internal/errors"
 	"github.com/broadinstitute/sherlock/sherlock/internal/models"
 	"github.com/gin-gonic/gin"
+	"gorm.io/gorm/clause"
 	"net/http"
 )
 
@@ -54,6 +55,7 @@ func appVersionsV3List(ctx *gin.Context) {
 		Limit(limit).
 		Offset(offset).
 		Order("created_at desc").
+		Preload(clause.Associations).
 		Find(&results).Error; err != nil {
 		errors.AbortRequest(ctx, err)
 		return

--- a/sherlock/internal/api/sherlock/app_version_v3_list_test.go
+++ b/sherlock/internal/api/sherlock/app_version_v3_list_test.go
@@ -82,6 +82,11 @@ func (s *handlerSuite) TestAppVersionsV3List() {
 			&got)
 		s.Equal(http.StatusOK, code)
 		s.Len(got, 3)
+		s.Run("associations", func() {
+			for _, chartVersion := range got {
+				s.NotNil(chartVersion.ChartInfo)
+			}
+		})
 	})
 	s.Run("all via user filter", func() {
 		var got []AppVersionV3

--- a/sherlock/internal/api/sherlock/chart_releases_v3_delete.go
+++ b/sherlock/internal/api/sherlock/chart_releases_v3_delete.go
@@ -34,7 +34,7 @@ func chartReleasesV3Delete(ctx *gin.Context) {
 		errors.AbortRequest(ctx, err)
 		return
 	}
-	if err = db.Delete(&result).Error; err != nil {
+	if err = db.Omit(clause.Associations).Delete(&result).Error; err != nil {
 		errors.AbortRequest(ctx, err)
 		return
 	}

--- a/sherlock/internal/api/sherlock/chart_releases_v3_list.go
+++ b/sherlock/internal/api/sherlock/chart_releases_v3_list.go
@@ -7,6 +7,7 @@ import (
 	"github.com/broadinstitute/sherlock/sherlock/internal/errors"
 	"github.com/broadinstitute/sherlock/sherlock/internal/models"
 	"github.com/gin-gonic/gin"
+	"gorm.io/gorm/clause"
 	"net/http"
 )
 
@@ -57,6 +58,7 @@ func chartReleasesV3List(ctx *gin.Context) {
 	if err = chain.
 		Offset(offset).
 		Order("name asc").
+		Preload(clause.Associations).
 		Find(&results).Error; err != nil {
 		errors.AbortRequest(ctx, err)
 		return

--- a/sherlock/internal/api/sherlock/chart_releases_v3_list_test.go
+++ b/sherlock/internal/api/sherlock/chart_releases_v3_list_test.go
@@ -53,6 +53,12 @@ func (s *handlerSuite) TestChartReleasesV3List() {
 			&got)
 		s.Equal(http.StatusOK, code)
 		s.Len(got, 3)
+		s.Run("associations", func() {
+			for _, release := range got {
+				s.NotNil(release.ChartInfo)
+				s.NotNil(release.EnvironmentInfo)
+			}
+		})
 	})
 	s.Run("none", func() {
 		var got []ChartReleaseV3

--- a/sherlock/internal/api/sherlock/chart_version_v3_list.go
+++ b/sherlock/internal/api/sherlock/chart_version_v3_list.go
@@ -7,6 +7,7 @@ import (
 	"github.com/broadinstitute/sherlock/sherlock/internal/errors"
 	"github.com/broadinstitute/sherlock/sherlock/internal/models"
 	"github.com/gin-gonic/gin"
+	"gorm.io/gorm/clause"
 	"net/http"
 )
 
@@ -54,6 +55,7 @@ func chartVersionsV3List(ctx *gin.Context) {
 		Limit(limit).
 		Offset(offset).
 		Order("created_at desc").
+		Preload(clause.Associations).
 		Find(&results).Error; err != nil {
 		errors.AbortRequest(ctx, err)
 		return

--- a/sherlock/internal/api/sherlock/chart_version_v3_list_test.go
+++ b/sherlock/internal/api/sherlock/chart_version_v3_list_test.go
@@ -81,6 +81,11 @@ func (s *handlerSuite) TestChartVersionsV3List() {
 			&got)
 		s.Equal(http.StatusOK, code)
 		s.Len(got, 3)
+		s.Run("associations", func() {
+			for _, chartVersion := range got {
+				s.NotNil(chartVersion.ChartInfo)
+			}
+		})
 	})
 	s.Run("all via user filter", func() {
 		var got []ChartVersionV3

--- a/sherlock/internal/api/sherlock/charts_v3_delete.go
+++ b/sherlock/internal/api/sherlock/charts_v3_delete.go
@@ -10,6 +10,7 @@ import (
 )
 
 // chartsV3Delete godoc
+//
 //	@summary		Delete an individual Chart
 //	@description	Delete an individual Chart by its ID.
 //	@tags			Charts
@@ -33,7 +34,7 @@ func chartsV3Delete(ctx *gin.Context) {
 		errors.AbortRequest(ctx, err)
 		return
 	}
-	if err = db.Delete(&result).Error; err != nil {
+	if err = db.Omit(clause.Associations).Delete(&result).Error; err != nil {
 		errors.AbortRequest(ctx, err)
 		return
 	}

--- a/sherlock/internal/api/sherlock/charts_v3_list.go
+++ b/sherlock/internal/api/sherlock/charts_v3_list.go
@@ -7,6 +7,7 @@ import (
 	"github.com/broadinstitute/sherlock/sherlock/internal/errors"
 	"github.com/broadinstitute/sherlock/sherlock/internal/models"
 	"github.com/gin-gonic/gin"
+	"gorm.io/gorm/clause"
 	"net/http"
 )
 
@@ -53,6 +54,7 @@ func chartsV3List(ctx *gin.Context) {
 	if err = chain.
 		Offset(offset).
 		Order("name asc").
+		Preload(clause.Associations).
 		Find(&results).Error; err != nil {
 		errors.AbortRequest(ctx, err)
 		return

--- a/sherlock/internal/api/sherlock/clusters_v3_delete.go
+++ b/sherlock/internal/api/sherlock/clusters_v3_delete.go
@@ -34,7 +34,7 @@ func clustersV3Delete(ctx *gin.Context) {
 		errors.AbortRequest(ctx, err)
 		return
 	}
-	if err = db.Delete(&result).Error; err != nil {
+	if err = db.Omit(clause.Associations).Delete(&result).Error; err != nil {
 		errors.AbortRequest(ctx, err)
 		return
 	}

--- a/sherlock/internal/api/sherlock/clusters_v3_list.go
+++ b/sherlock/internal/api/sherlock/clusters_v3_list.go
@@ -7,6 +7,7 @@ import (
 	"github.com/broadinstitute/sherlock/sherlock/internal/errors"
 	"github.com/broadinstitute/sherlock/sherlock/internal/models"
 	"github.com/gin-gonic/gin"
+	"gorm.io/gorm/clause"
 	"net/http"
 )
 
@@ -53,6 +54,7 @@ func clustersV3List(ctx *gin.Context) {
 	if err = chain.
 		Offset(offset).
 		Order("name asc").
+		Preload(clause.Associations).
 		Find(&results).Error; err != nil {
 		errors.AbortRequest(ctx, err)
 		return

--- a/sherlock/internal/api/sherlock/database_instances_v3_delete.go
+++ b/sherlock/internal/api/sherlock/database_instances_v3_delete.go
@@ -34,7 +34,7 @@ func databaseInstancesV3Delete(ctx *gin.Context) {
 		errors.AbortRequest(ctx, err)
 		return
 	}
-	if err = db.Delete(&result).Error; err != nil {
+	if err = db.Omit(clause.Associations).Delete(&result).Error; err != nil {
 		errors.AbortRequest(ctx, err)
 		return
 	}

--- a/sherlock/internal/api/sherlock/database_instances_v3_list.go
+++ b/sherlock/internal/api/sherlock/database_instances_v3_list.go
@@ -7,6 +7,7 @@ import (
 	"github.com/broadinstitute/sherlock/sherlock/internal/errors"
 	"github.com/broadinstitute/sherlock/sherlock/internal/models"
 	"github.com/gin-gonic/gin"
+	"gorm.io/gorm/clause"
 	"net/http"
 )
 
@@ -57,6 +58,7 @@ func databaseInstancesV3List(ctx *gin.Context) {
 	if err = chain.
 		Offset(offset).
 		Order("created_at desc").
+		Preload(clause.Associations).
 		Find(&results).Error; err != nil {
 		errors.AbortRequest(ctx, err)
 		return

--- a/sherlock/internal/api/sherlock/database_instances_v3_list_test.go
+++ b/sherlock/internal/api/sherlock/database_instances_v3_list_test.go
@@ -53,6 +53,11 @@ func (s *handlerSuite) TestDatabaseInstancesV3List() {
 			&got)
 		s.Equal(http.StatusOK, code)
 		s.Len(got, 3)
+		s.Run("associations", func() {
+			for _, instance := range got {
+				s.NotNil(instance.ChartReleaseInfo)
+			}
+		})
 	})
 	s.Run("none", func() {
 		var got []DatabaseInstanceV3

--- a/sherlock/internal/api/sherlock/environments_v3_delete.go
+++ b/sherlock/internal/api/sherlock/environments_v3_delete.go
@@ -34,7 +34,7 @@ func environmentsV3Delete(ctx *gin.Context) {
 		errors.AbortRequest(ctx, err)
 		return
 	}
-	if err = db.Delete(&result).Error; err != nil {
+	if err = db.Omit(clause.Associations).Delete(&result).Error; err != nil {
 		errors.AbortRequest(ctx, err)
 		return
 	}

--- a/sherlock/internal/api/sherlock/environments_v3_list.go
+++ b/sherlock/internal/api/sherlock/environments_v3_list.go
@@ -7,6 +7,7 @@ import (
 	"github.com/broadinstitute/sherlock/sherlock/internal/errors"
 	"github.com/broadinstitute/sherlock/sherlock/internal/models"
 	"github.com/gin-gonic/gin"
+	"gorm.io/gorm/clause"
 	"net/http"
 )
 
@@ -57,6 +58,7 @@ func environmentsV3List(ctx *gin.Context) {
 	if err = chain.
 		Offset(offset).
 		Order("name asc").
+		Preload(clause.Associations).
 		Find(&results).Error; err != nil {
 		errors.AbortRequest(ctx, err)
 		return

--- a/sherlock/internal/api/sherlock/environments_v3_list_test.go
+++ b/sherlock/internal/api/sherlock/environments_v3_list_test.go
@@ -54,6 +54,11 @@ func (s *handlerSuite) TestEnvironmentsV3List() {
 			&got)
 		s.Equal(http.StatusOK, code)
 		s.Len(got, 4)
+		s.Run("associations", func() {
+			for _, env := range got {
+				s.NotNil(env.DefaultCluster)
+			}
+		})
 	})
 	s.Run("none", func() {
 		var got []EnvironmentV3

--- a/sherlock/internal/api/sherlock/incidents_v3_delete.go
+++ b/sherlock/internal/api/sherlock/incidents_v3_delete.go
@@ -34,7 +34,7 @@ func incidentsV3Delete(ctx *gin.Context) {
 		errors.AbortRequest(ctx, err)
 		return
 	}
-	if err = db.Delete(&result).Error; err != nil {
+	if err = db.Omit(clause.Associations).Delete(&result).Error; err != nil {
 		errors.AbortRequest(ctx, err)
 		return
 	}

--- a/sherlock/internal/api/sherlock/incidents_v3_list.go
+++ b/sherlock/internal/api/sherlock/incidents_v3_list.go
@@ -7,6 +7,7 @@ import (
 	"github.com/broadinstitute/sherlock/sherlock/internal/errors"
 	"github.com/broadinstitute/sherlock/sherlock/internal/models"
 	"github.com/gin-gonic/gin"
+	"gorm.io/gorm/clause"
 	"net/http"
 )
 
@@ -53,6 +54,7 @@ func incidentsV3List(ctx *gin.Context) {
 	if err = chain.
 		Offset(offset).
 		Order("started_at desc").
+		Preload(clause.Associations).
 		Find(&results).Error; err != nil {
 		errors.AbortRequest(ctx, err)
 		return

--- a/sherlock/internal/api/sherlock/pagerduty_integrations_v3_delete.go
+++ b/sherlock/internal/api/sherlock/pagerduty_integrations_v3_delete.go
@@ -34,7 +34,7 @@ func pagerdutyIntegrationsV3Delete(ctx *gin.Context) {
 		errors.AbortRequest(ctx, err)
 		return
 	}
-	if err = db.Delete(&result).Error; err != nil {
+	if err = db.Omit(clause.Associations).Delete(&result).Error; err != nil {
 		errors.AbortRequest(ctx, err)
 		return
 	}

--- a/sherlock/internal/api/sherlock/pagerduty_integrations_v3_list.go
+++ b/sherlock/internal/api/sherlock/pagerduty_integrations_v3_list.go
@@ -7,6 +7,7 @@ import (
 	"github.com/broadinstitute/sherlock/sherlock/internal/errors"
 	"github.com/broadinstitute/sherlock/sherlock/internal/models"
 	"github.com/gin-gonic/gin"
+	"gorm.io/gorm/clause"
 	"net/http"
 )
 
@@ -53,6 +54,7 @@ func pagerdutyIntegrationsV3List(ctx *gin.Context) {
 	if err = chain.
 		Offset(offset).
 		Order("pagerduty_id asc").
+		Preload(clause.Associations).
 		Find(&results).Error; err != nil {
 		errors.AbortRequest(ctx, err)
 		return

--- a/sherlock/internal/api/sherlock/users_v3_list.go
+++ b/sherlock/internal/api/sherlock/users_v3_list.go
@@ -7,6 +7,7 @@ import (
 	"github.com/broadinstitute/sherlock/sherlock/internal/errors"
 	"github.com/broadinstitute/sherlock/sherlock/internal/models"
 	"github.com/gin-gonic/gin"
+	"gorm.io/gorm/clause"
 	"net/http"
 )
 
@@ -49,7 +50,11 @@ func usersV3List(ctx *gin.Context) {
 	if limit > 0 {
 		chain = chain.Limit(limit)
 	}
-	if err = chain.Offset(offset).Order("email asc").Find(&results).Error; err != nil {
+	if err = chain.
+		Offset(offset).
+		Order("email asc").
+		Preload(clause.Associations).
+		Find(&results).Error; err != nil {
 		errors.AbortRequest(ctx, err)
 		return
 	}


### PR DESCRIPTION
I messed up with copying and pasting some of the more basic endpoint implementations, and accidentally copied around a list implementation that didn't try to load associations (which makes sense for clusters but not for, say, chart releases).

This PR fixes that, everywhere, because I figure the consistency in source code is more important than any minuscule performance gains (if there's no associations Gorm won't actually send more over the wire).

## Testing

I added tests for where the associative data actually shows up (there's some endpoints where this is a no-op)

## Risk

Very low
