### PR TITLE
[DDO-3470] Handle comma separated IDs better in Changeset requests

### DIFF
--- a/sherlock/internal/api/sherlock/changesets_v3_list.go
+++ b/sherlock/internal/api/sherlock/changesets_v3_list.go
@@ -18,7 +18,7 @@ import (
 //	@tags			Changesets
 //	@produce		json
 //	@param			filter					query		ChangesetV3Query	false	"Filter the returned Changesets"
-//	@param			id						query		[]int				false	"Get specific changesets by their IDs, can be passed multiple times"
+//	@param			id						query		[]int				false	"Get specific changesets by their IDs, can be passed multiple times and/or be comma-separated"
 //	@param			limit					query		int					false	"Control how many Changesets are returned (default 100), ignored if specific IDs are passed"
 //	@param			offset					query		int					false	"Control the offset for the returned Changesets (default 0), ignored if specific IDs are passed"
 //	@success		200						{array}		ChangesetV3

--- a/sherlock/internal/api/sherlock/changesets_v3_list_test.go
+++ b/sherlock/internal/api/sherlock/changesets_v3_list_test.go
@@ -81,10 +81,27 @@ func (s *handlerSuite) TestChangesetsV3List() {
 		s.Equal(http.StatusOK, code)
 		s.Len(got, 2)
 	})
+	s.Run("both via one id parameter", func() {
+		var got []ChangesetV3
+		code := s.HandleRequest(
+			s.NewRequest("GET", fmt.Sprintf("/api/changesets/v3?id=%d,%d", a.ID, b.ID), nil),
+			&got)
+		s.Equal(http.StatusOK, code)
+		s.Len(got, 2)
+	})
 	s.Run("filter when id also used", func() {
 		var got []ChangesetV3
 		code := s.HandleRequest(
 			s.NewRequest("GET", fmt.Sprintf("/api/changesets/v3?id=%d&id=%d&toAppVersionExact=%s", a.ID, b.ID, s.TestData.AppVersion_Leonardo_V3().AppVersion), nil),
+			&got)
+		s.Equal(http.StatusOK, code)
+		s.Len(got, 1)
+		s.Equal(a.ID, got[0].ID)
+	})
+	s.Run("filter when id via one parameter also used", func() {
+		var got []ChangesetV3
+		code := s.HandleRequest(
+			s.NewRequest("GET", fmt.Sprintf("/api/changesets/v3?id=%d,%d&toAppVersionExact=%s", a.ID, b.ID, s.TestData.AppVersion_Leonardo_V3().AppVersion), nil),
 			&got)
 		s.Equal(http.StatusOK, code)
 		s.Len(got, 1)


### PR DESCRIPTION
So there doesn't seem to be a way to actually document `id=1&id=2&...` in Swaggo. Instead, if you do

```go
//	@param  id  query  []int  false  "Get specific changesets by their IDs, can be passed multiple times"
```

that actually means `id=1,2&...` which I definitely did not write code for. This seems consistent both from the gin-swagger page and from the generated typescript client. Whatever.

This fixes the issue; Sherlock will now handle either format and notes it does so in the OpenAPI spec.

## Testing

Added cases to the unit tests for the new comma-separated format

## Risk

Very low