### PR TITLE
[DDO-3470] Fix v3 changelog direction

### DIFF
--- a/sherlock/internal/api/sherlock/app_version_procedures_v3_changelog.go
+++ b/sherlock/internal/api/sherlock/app_version_procedures_v3_changelog.go
@@ -60,7 +60,7 @@ func appVersionsProceduresV3Changelog(ctx *gin.Context) {
 	var path []uint
 	var foundPath bool
 
-	if path, foundPath, err = models.GetAppVersionPathIDs(db, child.ID, parent.ID); err != nil {
+	if path, foundPath, err = models.GetAppVersionPathIDs(db, parent.ID, child.ID); err != nil {
 		errors.AbortRequest(ctx, fmt.Errorf("(%s) error calculating changelog components: %w", errors.InternalServerError, err))
 		return
 	}

--- a/sherlock/internal/api/sherlock/chart_version_procedures_v3_changelog.go
+++ b/sherlock/internal/api/sherlock/chart_version_procedures_v3_changelog.go
@@ -60,7 +60,7 @@ func chartVersionsProceduresV3Changelog(ctx *gin.Context) {
 	var path []uint
 	var foundPath bool
 
-	if path, foundPath, err = models.GetChartVersionPathIDs(db, child.ID, parent.ID); err != nil {
+	if path, foundPath, err = models.GetChartVersionPathIDs(db, parent.ID, child.ID); err != nil {
 		errors.AbortRequest(ctx, fmt.Errorf("(%s) error calculating changelog components: %w", errors.InternalServerError, err))
 		return
 	}

--- a/sherlock/internal/models/app_version.go
+++ b/sherlock/internal/models/app_version.go
@@ -46,7 +46,7 @@ func (a *AppVersion) BeforeCreate(tx *gorm.DB) error {
 // - It will always be exclusive of the end AppVersion
 // - It will be inclusive of the start AppVersion when possible
 // - It will be ordered by iteration (the last entry in the path is the one whose parent is the end AppVersion)
-func GetAppVersionPathIDs(db *gorm.DB, inclusiveStartID uint, exclusiveEndID uint) (path []uint, foundPath bool, err error) {
+func GetAppVersionPathIDs(db *gorm.DB, exclusiveEndID uint, inclusiveStartID uint) (path []uint, foundPath bool, err error) {
 	if inclusiveStartID == exclusiveEndID {
 		// If the start and end are the same, there's no path to calculate
 		return []uint{}, true, nil

--- a/sherlock/internal/models/app_version_test.go
+++ b/sherlock/internal/models/app_version_test.go
@@ -101,63 +101,70 @@ func (s *modelSuite) TestGetAppVersionPathIDs() {
 	})
 
 	s.Run("B to C (normal)", func() {
-		path, foundPath, err := GetAppVersionPathIDs(s.DB, b.ID, c.ID)
+		path, foundPath, err := GetAppVersionPathIDs(s.DB, c.ID, b.ID)
 		s.Equal([]uint{b.ID}, path)
 		s.True(foundPath)
 		s.NoError(err)
 	})
 
 	s.Run("A to D (normal)", func() {
-		path, foundPath, err := GetAppVersionPathIDs(s.DB, a.ID, d.ID)
+		path, foundPath, err := GetAppVersionPathIDs(s.DB, d.ID, a.ID)
 		s.Equal([]uint{a.ID, b.ID, c.ID}, path)
 		s.True(foundPath)
 		s.NoError(err)
 	})
 
+	s.Run("D to A (no path, reverse from normal)", func() {
+		path, foundPath, err := GetAppVersionPathIDs(s.DB, a.ID, d.ID)
+		s.Empty(path)
+		s.False(foundPath)
+		s.NoError(err)
+	})
+
 	s.Run("E to D (normal)", func() {
-		path, foundPath, err := GetAppVersionPathIDs(s.DB, e.ID, d.ID)
+		path, foundPath, err := GetAppVersionPathIDs(s.DB, d.ID, e.ID)
 		s.Equal([]uint{e.ID, c.ID}, path)
 		s.True(foundPath)
 		s.NoError(err)
 	})
 
 	s.Run("C to B (no path)", func() {
-		path, foundPath, err := GetAppVersionPathIDs(s.DB, c.ID, b.ID)
+		path, foundPath, err := GetAppVersionPathIDs(s.DB, b.ID, c.ID)
 		s.Empty(path)
 		s.False(foundPath)
 		s.NoError(err)
 	})
 
 	s.Run("A to F (no path)", func() {
-		path, foundPath, err := GetAppVersionPathIDs(s.DB, a.ID, f.ID)
-		s.Empty(path)
-		s.False(foundPath)
-		s.NoError(err)
-	})
-
-	s.Run("F to A (no path)", func() {
 		path, foundPath, err := GetAppVersionPathIDs(s.DB, f.ID, a.ID)
 		s.Empty(path)
 		s.False(foundPath)
 		s.NoError(err)
 	})
 
+	s.Run("F to A (no path)", func() {
+		path, foundPath, err := GetAppVersionPathIDs(s.DB, a.ID, f.ID)
+		s.Empty(path)
+		s.False(foundPath)
+		s.NoError(err)
+	})
+
 	s.Run("F to non-existent (no path, doesn't error)", func() {
-		path, foundPath, err := GetAppVersionPathIDs(s.DB, f.ID, 0)
+		path, foundPath, err := GetAppVersionPathIDs(s.DB, 0, f.ID)
 		s.Empty(path)
 		s.False(foundPath)
 		s.NoError(err)
 	})
 
 	s.Run("A to non-existent (no path, doesn't error)", func() {
-		path, foundPath, err := GetAppVersionPathIDs(s.DB, a.ID, 0)
+		path, foundPath, err := GetAppVersionPathIDs(s.DB, 0, a.ID)
 		s.Empty(path)
 		s.False(foundPath)
 		s.NoError(err)
 	})
 
 	s.Run("non-existent to A (no path, doesn't error)", func() {
-		path, foundPath, err := GetAppVersionPathIDs(s.DB, 0, a.ID)
+		path, foundPath, err := GetAppVersionPathIDs(s.DB, a.ID, 0)
 		s.Empty(path)
 		s.False(foundPath)
 		s.NoError(err)
@@ -168,7 +175,7 @@ func (s *modelSuite) TestGetAppVersionPathIDs() {
 		deleted := AppVersion{ChartID: chart.ID, AppVersion: "deleted"}
 		s.NoError(s.DB.Create(&deleted).Error)
 		s.NoError(s.DB.Unscoped().Delete(&deleted).Error)
-		path, foundPath, err := GetAppVersionPathIDs(s.DB, 0, deleted.ID)
+		path, foundPath, err := GetAppVersionPathIDs(s.DB, deleted.ID, 0)
 		s.Empty(path)
 		s.False(foundPath)
 		s.NoError(err)

--- a/sherlock/internal/models/chart_version.go
+++ b/sherlock/internal/models/chart_version.go
@@ -44,7 +44,7 @@ func (c *ChartVersion) BeforeCreate(tx *gorm.DB) error {
 // - It will always be exclusive of the end ChartVersion
 // - It will be inclusive of the start ChartVersion when possible
 // - It will be ordered by iteration (the last entry in the path is the one whose parent is the end ChartVersion)
-func GetChartVersionPathIDs(db *gorm.DB, inclusiveStartID uint, exclusiveEndID uint) (path []uint, foundPath bool, err error) {
+func GetChartVersionPathIDs(db *gorm.DB, exclusiveEndID uint, inclusiveStartID uint) (path []uint, foundPath bool, err error) {
 	if inclusiveStartID == exclusiveEndID {
 		// If the start and end are the same, there's no path to calculate
 		return []uint{}, true, nil

--- a/sherlock/internal/models/chart_version_test.go
+++ b/sherlock/internal/models/chart_version_test.go
@@ -97,63 +97,70 @@ func (s *modelSuite) TestGetChartVersionPathIDs() {
 	})
 
 	s.Run("B to C (normal)", func() {
-		path, foundPath, err := GetChartVersionPathIDs(s.DB, b.ID, c.ID)
+		path, foundPath, err := GetChartVersionPathIDs(s.DB, c.ID, b.ID)
 		s.Equal([]uint{b.ID}, path)
 		s.True(foundPath)
 		s.NoError(err)
 	})
 
 	s.Run("A to D (normal)", func() {
-		path, foundPath, err := GetChartVersionPathIDs(s.DB, a.ID, d.ID)
+		path, foundPath, err := GetChartVersionPathIDs(s.DB, d.ID, a.ID)
 		s.Equal([]uint{a.ID, b.ID, c.ID}, path)
 		s.True(foundPath)
 		s.NoError(err)
 	})
 
+	s.Run("D to A (no path, reverse from normal)", func() {
+		path, foundPath, err := GetChartVersionPathIDs(s.DB, a.ID, d.ID)
+		s.Empty(path)
+		s.False(foundPath)
+		s.NoError(err)
+	})
+
 	s.Run("E to D (normal)", func() {
-		path, foundPath, err := GetChartVersionPathIDs(s.DB, e.ID, d.ID)
+		path, foundPath, err := GetChartVersionPathIDs(s.DB, d.ID, e.ID)
 		s.Equal([]uint{e.ID, c.ID}, path)
 		s.True(foundPath)
 		s.NoError(err)
 	})
 
 	s.Run("C to B (no path)", func() {
-		path, foundPath, err := GetChartVersionPathIDs(s.DB, c.ID, b.ID)
+		path, foundPath, err := GetChartVersionPathIDs(s.DB, b.ID, c.ID)
 		s.Empty(path)
 		s.False(foundPath)
 		s.NoError(err)
 	})
 
 	s.Run("A to F (no path)", func() {
-		path, foundPath, err := GetChartVersionPathIDs(s.DB, a.ID, f.ID)
-		s.Empty(path)
-		s.False(foundPath)
-		s.NoError(err)
-	})
-
-	s.Run("F to A (no path)", func() {
 		path, foundPath, err := GetChartVersionPathIDs(s.DB, f.ID, a.ID)
 		s.Empty(path)
 		s.False(foundPath)
 		s.NoError(err)
 	})
 
+	s.Run("F to A (no path)", func() {
+		path, foundPath, err := GetChartVersionPathIDs(s.DB, a.ID, f.ID)
+		s.Empty(path)
+		s.False(foundPath)
+		s.NoError(err)
+	})
+
 	s.Run("F to non-existent (no path, doesn't error)", func() {
-		path, foundPath, err := GetChartVersionPathIDs(s.DB, f.ID, 0)
+		path, foundPath, err := GetChartVersionPathIDs(s.DB, 0, f.ID)
 		s.Empty(path)
 		s.False(foundPath)
 		s.NoError(err)
 	})
 
 	s.Run("A to non-existent (no path, doesn't error)", func() {
-		path, foundPath, err := GetChartVersionPathIDs(s.DB, a.ID, 0)
+		path, foundPath, err := GetChartVersionPathIDs(s.DB, 0, a.ID)
 		s.Empty(path)
 		s.False(foundPath)
 		s.NoError(err)
 	})
 
 	s.Run("non-existent to A (no path, doesn't error)", func() {
-		path, foundPath, err := GetChartVersionPathIDs(s.DB, 0, a.ID)
+		path, foundPath, err := GetChartVersionPathIDs(s.DB, a.ID, 0)
 		s.Empty(path)
 		s.False(foundPath)
 		s.NoError(err)
@@ -164,7 +171,7 @@ func (s *modelSuite) TestGetChartVersionPathIDs() {
 		deleted := ChartVersion{ChartID: chart.ID, ChartVersion: "deleted"}
 		s.NoError(s.DB.Create(&deleted).Error)
 		s.NoError(s.DB.Unscoped().Delete(&deleted).Error)
-		path, foundPath, err := GetChartVersionPathIDs(s.DB, 0, deleted.ID)
+		path, foundPath, err := GetChartVersionPathIDs(s.DB, deleted.ID, 0)
 		s.Empty(path)
 		s.False(foundPath)
 		s.NoError(err)

--- a/sherlock/internal/models/test_data.go
+++ b/sherlock/internal/models/test_data.go
@@ -1063,24 +1063,23 @@ func (td *testDataImpl) Changeset_LeonardoDev_V1toV3() Changeset {
 			},
 			AppliedAt:    utils.PointerTo(time.Now().Add(-(18 * time.Hour))),
 			SupersededAt: nil,
-			// We manually specify these so that they're stable when this test data is accessed.
-			// Changeset's AfterCreate hook is what builds these associations normally, but when it
-			// does so it doesn't rehydrate the struct. For simplicty's sake we just create it
-			// fully hydrated already, and the hook will on-conflict-do-nothing when it tries to
-			// add the associations again.
-			NewAppVersions: []*AppVersion{
-				utils.PointerTo(td.AppVersion_Leonardo_V2()),
-				utils.PointerTo(td.AppVersion_Leonardo_V3()),
-			},
-			NewChartVersions: []*ChartVersion{
-				utils.PointerTo(td.ChartVersion_Leonardo_V2()),
-				utils.PointerTo(td.ChartVersion_Leonardo_V3()),
-			},
-			PlannedByID: utils.PointerTo(td.User_Suitable().ID),
-			AppliedByID: utils.PointerTo(td.User_Suitable().ID),
+			PlannedByID:  utils.PointerTo(td.User_Suitable().ID),
+			AppliedByID:  utils.PointerTo(td.User_Suitable().ID),
 		}
 		td.h.SetSuitableTestUserForDB()
 		td.create(&td.changeset_leonardoDev_v1toV3)
+		// Reload from the database so we get data from hooks and everything
+		td.h.DB.Scopes(ReadChangesetScope).Take(&td.changeset_leonardoDev_v1toV3, td.changeset_leonardoDev_v1toV3.ID)
+		// We don't typically want to run assertions from the test data package, but if the hooks didn't work properly,
+		// you'll be in for a hell of a time debugging. We panic if any of the changelog entries aren't as expected
+		if len(td.changeset_leonardoDev_v1toV3.NewAppVersions) != 2 ||
+			td.changeset_leonardoDev_v1toV3.NewAppVersions[0].AppVersion != td.AppVersion_Leonardo_V2().AppVersion ||
+			td.changeset_leonardoDev_v1toV3.NewAppVersions[1].AppVersion != td.AppVersion_Leonardo_V3().AppVersion ||
+			len(td.changeset_leonardoDev_v1toV3.NewChartVersions) != 2 ||
+			td.changeset_leonardoDev_v1toV3.NewChartVersions[0].ChartVersion != td.ChartVersion_Leonardo_V2().ChartVersion ||
+			td.changeset_leonardoDev_v1toV3.NewChartVersions[1].ChartVersion != td.ChartVersion_Leonardo_V3().ChartVersion {
+			panic("Changeset's AfterCreate hook didn't work properly")
+		}
 	}
 	return td.changeset_leonardoDev_v1toV3
 }
@@ -1117,21 +1116,20 @@ func (td *testDataImpl) Changeset_LeonardoDev_V1toV2Superseded() Changeset {
 			},
 			AppliedAt:    nil,
 			SupersededAt: utils.PointerTo(time.Now().Add(-(18 * time.Hour))),
-			// We manually specify these so that they're stable when this test data is accessed.
-			// Changeset's AfterCreate hook is what builds these associations normally, but when it
-			// does so it doesn't rehydrate the struct. For simplicty's sake we just create it
-			// fully hydrated already, and the hook will on-conflict-do-nothing when it tries to
-			// add the associations again.
-			NewAppVersions: []*AppVersion{
-				utils.PointerTo(td.AppVersion_Leonardo_V2()),
-			},
-			NewChartVersions: []*ChartVersion{
-				utils.PointerTo(td.ChartVersion_Leonardo_V2()),
-			},
-			PlannedByID: utils.PointerTo(td.User_Suitable().ID),
+			PlannedByID:  utils.PointerTo(td.User_Suitable().ID),
 		}
 		td.h.SetSuitableTestUserForDB()
 		td.create(&td.changeset_leonardoDev_v1toV2Superseded)
+		// Reload from the database so we get data from hooks and everything
+		td.h.DB.Scopes(ReadChangesetScope).Take(&td.changeset_leonardoDev_v1toV2Superseded, td.changeset_leonardoDev_v1toV2Superseded.ID)
+		// We don't typically want to run assertions from the test data package, but if the hooks didn't work properly,
+		// you'll be in for a hell of a time debugging. We panic if any of the changelog entries aren't as expected
+		if len(td.changeset_leonardoDev_v1toV2Superseded.NewAppVersions) != 1 ||
+			td.changeset_leonardoDev_v1toV2Superseded.NewAppVersions[0].AppVersion != td.AppVersion_Leonardo_V2().AppVersion ||
+			len(td.changeset_leonardoDev_v1toV2Superseded.NewChartVersions) != 1 ||
+			td.changeset_leonardoDev_v1toV2Superseded.NewChartVersions[0].ChartVersion != td.ChartVersion_Leonardo_V2().ChartVersion {
+			panic("Changeset's AfterCreate hook didn't work properly")
+		}
 	}
 	return td.changeset_leonardoDev_v1toV2Superseded
 }


### PR DESCRIPTION
Embarrassing bug with the directionality of changelogs. The database function was working fine, so the tests passed, but I was literally calling it with the IDs in the wrong order.

I changed the order of the arguments to what's more intuitive (db, fromID, toID) in my head and added tests for getting the directionality right.

I also modified the TestData to defer to the standard changelog capability, which is marginally slower but would've also caught this.

## Testing

Modified tests both for the currently correct usage and the incorrect usage to get them aligned

## Risk

Very low