### PR TITLE
[DDO-3470] Fix Changeset response when there were no changes

### DIFF
--- a/sherlock/internal/api/sherlock/changesets_procedures_v3_plan.go
+++ b/sherlock/internal/api/sherlock/changesets_procedures_v3_plan.go
@@ -88,6 +88,9 @@ func changesetsProceduresV3Plan(ctx *gin.Context) {
 	if createdChangesetIDs, err = models.PlanChangesets(db, changesets); err != nil {
 		errors.AbortRequest(ctx, fmt.Errorf("error planning changesets: %w", err))
 		return
+	} else if len(createdChangesetIDs) == 0 {
+		ctx.JSON(http.StatusOK, []ChangesetV3{})
+		return
 	} else if verboseOutput {
 		if err = db.Scopes(models.ReadChangesetScope).Find(&ret, createdChangesetIDs).Error; err != nil {
 			errors.AbortRequest(ctx, fmt.Errorf("error querying planned changesets: %w", err))

--- a/sherlock/internal/api/sherlock/changesets_procedures_v3_plan_and_apply.go
+++ b/sherlock/internal/api/sherlock/changesets_procedures_v3_plan_and_apply.go
@@ -67,6 +67,9 @@ func changesetsProceduresV3PlanAndApply(ctx *gin.Context) {
 	if createdChangesetIDs, err = models.PlanChangesets(db, changesets); err != nil {
 		errors.AbortRequest(ctx, fmt.Errorf("error planning changesets: %w", err))
 		return
+	} else if len(createdChangesetIDs) == 0 {
+		ctx.JSON(http.StatusOK, []ChangesetV3{})
+		return
 	} else if err = models.ApplyChangesets(db, createdChangesetIDs); err != nil {
 		errors.AbortRequest(ctx, fmt.Errorf("error applying changesets: %w", err))
 		return

--- a/sherlock/internal/api/sherlock/changesets_procedures_v3_plan_and_apply_test.go
+++ b/sherlock/internal/api/sherlock/changesets_procedures_v3_plan_and_apply_test.go
@@ -160,6 +160,32 @@ func (s *handlerSuite) TestChangesetsProceduresV3PlanAndApply() {
 	}
 }
 
+func (s *handlerSuite) TestChangesetProceduresV3PlanAndApply_noneGiven() {
+	var got []ChangesetV3
+	code := s.HandleRequest(
+		s.NewRequest("POST", "/api/changesets/procedures/v3/plan-and-apply", ChangesetV3PlanRequest{}),
+		&got)
+	s.Equal(http.StatusOK, code)
+	s.NotNil(got)
+	s.Empty(got)
+}
+
+func (s *handlerSuite) TestChangesetsProceduresV3PlanAndApply_nonePlanned() {
+	var got []ChangesetV3
+	code := s.HandleRequest(
+		s.NewRequest("POST", "/api/changesets/procedures/v3/plan-and-apply", ChangesetV3PlanRequest{
+			Environments: []ChangesetV3PlanRequestEnvironmentEntry{
+				{
+					Environment: s.TestData.Environment_Staging().Name,
+				},
+			},
+		}),
+		&got)
+	s.Equal(http.StatusOK, code)
+	s.NotNil(got)
+	s.Empty(got)
+}
+
 func (s *handlerSuite) TestChangesetsProceduresV3PlanAndApply_notVerbose() {
 	changesetToRecreate := s.TestData.Changeset_LeonardoDev_V1toV2Superseded()
 	chartReleaseToUpdate := s.TestData.ChartRelease_LeonardoProd()

--- a/sherlock/internal/api/sherlock/changesets_procedures_v3_plan_test.go
+++ b/sherlock/internal/api/sherlock/changesets_procedures_v3_plan_test.go
@@ -140,6 +140,32 @@ func (s *handlerSuite) TestChangesetsProceduresV3Plan() {
 	}
 }
 
+func (s *handlerSuite) TestChangesetProceduresV3Plan_noneGiven() {
+	var got []ChangesetV3
+	code := s.HandleRequest(
+		s.NewRequest("POST", "/api/changesets/procedures/v3/plan", ChangesetV3PlanRequest{}),
+		&got)
+	s.Equal(http.StatusOK, code)
+	s.NotNil(got)
+	s.Empty(got)
+}
+
+func (s *handlerSuite) TestChangesetsProceduresV3Plan_nonePlanned() {
+	var got []ChangesetV3
+	code := s.HandleRequest(
+		s.NewRequest("POST", "/api/changesets/procedures/v3/plan", ChangesetV3PlanRequest{
+			Environments: []ChangesetV3PlanRequestEnvironmentEntry{
+				{
+					Environment: s.TestData.Environment_Staging().Name,
+				},
+			},
+		}),
+		&got)
+	s.Equal(http.StatusOK, code)
+	s.NotNil(got)
+	s.Empty(got)
+}
+
 func (s *handlerSuite) TestChangesetsProceduresV3Plan_notVerbose() {
 	changesetToRecreate := s.TestData.Changeset_LeonardoDev_V1toV2Superseded()
 	chartReleaseToUpdate := s.TestData.ChartRelease_LeonardoDev()

--- a/sherlock/internal/models/changeset_plan_apply.go
+++ b/sherlock/internal/models/changeset_plan_apply.go
@@ -45,6 +45,7 @@ func PlanChangesets(db *gorm.DB, changesets []Changeset) (created []uint, err er
 			changesetsToCreate = append(changesetsToCreate, changeset)
 		}
 	}
+	created = make([]uint, 0, len(changesetsToCreate))
 	if len(changesetsToCreate) > 0 {
 		err = db.Transaction(func(tx *gorm.DB) error {
 			for _, changeset := range changesetsToCreate {

--- a/sherlock/internal/models/changeset_plan_apply_test.go
+++ b/sherlock/internal/models/changeset_plan_apply_test.go
@@ -117,6 +117,17 @@ func (s *modelSuite) TestPlanChangesets_changelogConnected() {
 	}
 }
 
+func (s *modelSuite) TestPlanChangesets_none() {
+	// This isn't the error discussed in https://broadinstitute.slack.com/archives/CQ6SL4N5T/p1707836110299439 --
+	// Gorm's annoying behavior happens with both `Find(&ret, nil)` and `Find(&ret, []uint{})` -- but in the course
+	// of debugging I decided to make this function never return `nil, nil`, which is what it would do before it
+	// created nothing.
+	ids, err := PlanChangesets(s.DB, []Changeset{})
+	s.NoError(err)
+	s.NotNil(ids)
+	s.Len(ids, 0)
+}
+
 func (s *modelSuite) TestApplyChangesets_userNotSet() {
 	err := ApplyChangesets(s.DB, []uint{})
 	s.ErrorContains(err, "unable to get current user for changeset applying")


### PR DESCRIPTION
Discussed in https://broadinstitute.slack.com/archives/CQ6SL4N5T/p1707836110299439, the issue is that `db.Find(&ret, []uint{})` loads everything rather than nothing. So we guard that and bail out beforehand.

## Testing

Added tests for both /plan and /plan-and-apply for exactly this case (in two different variants)

## Risk

Low