### PR TITLE
[DDO-3470] Make environment deleteAfter clearable

### DIFF
--- a/sherlock/docs/docs.go
+++ b/sherlock/docs/docs.go
@@ -4936,7 +4936,7 @@ const docTemplate = `{
                     {
                         "type": "string",
                         "format": "date-time",
-                        "description": "If set, the BEE will be automatically deleted after this time (thelma checks this field)",
+                        "description": "If set, the BEE will be automatically deleted after this time. Can be set to \"\" or Go's zero time value to clear the field.",
                         "name": "deleteAfter",
                         "in": "query"
                     },
@@ -14751,7 +14751,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "deleteAfter": {
-                    "description": "If set, the BEE will be automatically deleted after this time (thelma checks this field)",
+                    "description": "If set, the BEE will be automatically deleted after this time. Can be set to \"\" or Go's zero time value to clear the field.",
                     "type": "string",
                     "format": "date-time"
                 },
@@ -14873,7 +14873,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "deleteAfter": {
-                    "description": "If set, the BEE will be automatically deleted after this time (thelma checks this field)",
+                    "description": "If set, the BEE will be automatically deleted after this time. Can be set to \"\" or Go's zero time value to clear the field.",
                     "type": "string",
                     "format": "date-time"
                 },
@@ -14966,7 +14966,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "deleteAfter": {
-                    "description": "If set, the BEE will be automatically deleted after this time (thelma checks this field)",
+                    "description": "If set, the BEE will be automatically deleted after this time. Can be set to \"\" or Go's zero time value to clear the field.",
                     "type": "string",
                     "format": "date-time"
                 },

--- a/sherlock/docs/swagger.json
+++ b/sherlock/docs/swagger.json
@@ -4932,7 +4932,7 @@
                     {
                         "type": "string",
                         "format": "date-time",
-                        "description": "If set, the BEE will be automatically deleted after this time (thelma checks this field)",
+                        "description": "If set, the BEE will be automatically deleted after this time. Can be set to \"\" or Go's zero time value to clear the field.",
                         "name": "deleteAfter",
                         "in": "query"
                     },
@@ -14747,7 +14747,7 @@
                     "type": "string"
                 },
                 "deleteAfter": {
-                    "description": "If set, the BEE will be automatically deleted after this time (thelma checks this field)",
+                    "description": "If set, the BEE will be automatically deleted after this time. Can be set to \"\" or Go's zero time value to clear the field.",
                     "type": "string",
                     "format": "date-time"
                 },
@@ -14869,7 +14869,7 @@
                     "type": "string"
                 },
                 "deleteAfter": {
-                    "description": "If set, the BEE will be automatically deleted after this time (thelma checks this field)",
+                    "description": "If set, the BEE will be automatically deleted after this time. Can be set to \"\" or Go's zero time value to clear the field.",
                     "type": "string",
                     "format": "date-time"
                 },
@@ -14962,7 +14962,7 @@
                     "type": "string"
                 },
                 "deleteAfter": {
-                    "description": "If set, the BEE will be automatically deleted after this time (thelma checks this field)",
+                    "description": "If set, the BEE will be automatically deleted after this time. Can be set to \"\" or Go's zero time value to clear the field.",
                     "type": "string",
                     "format": "date-time"
                 },

--- a/sherlock/docs/swagger.yaml
+++ b/sherlock/docs/swagger.yaml
@@ -1017,8 +1017,8 @@ definitions:
         description: When creating, will be calculated if left empty
         type: string
       deleteAfter:
-        description: If set, the BEE will be automatically deleted after this time
-          (thelma checks this field)
+        description: If set, the BEE will be automatically deleted after this time.
+          Can be set to "" or Go's zero time value to clear the field.
         format: date-time
         type: string
       description:
@@ -1113,8 +1113,8 @@ definitions:
         description: When creating, will be calculated if left empty
         type: string
       deleteAfter:
-        description: If set, the BEE will be automatically deleted after this time
-          (thelma checks this field)
+        description: If set, the BEE will be automatically deleted after this time.
+          Can be set to "" or Go's zero time value to clear the field.
         format: date-time
         type: string
       description:
@@ -1187,8 +1187,8 @@ definitions:
       defaultCluster:
         type: string
       deleteAfter:
-        description: If set, the BEE will be automatically deleted after this time
-          (thelma checks this field)
+        description: If set, the BEE will be automatically deleted after this time.
+          Can be set to "" or Go's zero time value to clear the field.
         format: date-time
         type: string
       description:
@@ -6197,8 +6197,8 @@ paths:
         in: query
         name: defaultNamespace
         type: string
-      - description: If set, the BEE will be automatically deleted after this time
-          (thelma checks this field)
+      - description: If set, the BEE will be automatically deleted after this time.
+          Can be set to "" or Go's zero time value to clear the field.
         format: date-time
         in: query
         name: deleteAfter

--- a/sherlock/internal/api/sherlock/environments_v3.go
+++ b/sherlock/internal/api/sherlock/environments_v3.go
@@ -42,7 +42,7 @@ type EnvironmentV3Edit struct {
 	NamePrefixesDomain          *bool      `json:"namePrefixesDomain" form:"namePrefixesDomain" default:"true"`
 	HelmfileRef                 *string    `json:"helmfileRef" form:"helmfileRef" default:"HEAD"`
 	PreventDeletion             *bool      `json:"preventDeletion" form:"preventDeletion" default:"false"`      // Used to protect specific BEEs from deletion (thelma checks this field)
-	DeleteAfter                 *string    `json:"deleteAfter,omitempty" form:"deleteAfter" format:"date-time"` // If set, the BEE will be automatically deleted after this time (thelma checks this field)
+	DeleteAfter                 *string    `json:"deleteAfter,omitempty" form:"deleteAfter" format:"date-time"` // If set, the BEE will be automatically deleted after this time. Can be set to "" or Go's zero time value to clear the field.
 	Description                 *string    `json:"description" form:"description"`
 	PactIdentifier              *uuid.UUID `json:"pactIdentifier" form:"PactIdentifier"`
 	PagerdutyIntegration        *string    `json:"pagerdutyIntegration,omitempty" form:"pagerdutyIntegration"`

--- a/sherlock/internal/api/sherlock/environments_v3.go
+++ b/sherlock/internal/api/sherlock/environments_v3.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"fmt"
 	"github.com/broadinstitute/sherlock/go-shared/pkg/utils"
+	"github.com/broadinstitute/sherlock/sherlock/internal/errors"
 	"github.com/broadinstitute/sherlock/sherlock/internal/models"
 	"github.com/google/uuid"
 	"github.com/rs/zerolog/log"
@@ -41,7 +42,7 @@ type EnvironmentV3Edit struct {
 	NamePrefixesDomain          *bool      `json:"namePrefixesDomain" form:"namePrefixesDomain" default:"true"`
 	HelmfileRef                 *string    `json:"helmfileRef" form:"helmfileRef" default:"HEAD"`
 	PreventDeletion             *bool      `json:"preventDeletion" form:"preventDeletion" default:"false"`      // Used to protect specific BEEs from deletion (thelma checks this field)
-	DeleteAfter                 *time.Time `json:"deleteAfter,omitempty" form:"deleteAfter" format:"date-time"` // If set, the BEE will be automatically deleted after this time (thelma checks this field)
+	DeleteAfter                 *string    `json:"deleteAfter,omitempty" form:"deleteAfter" format:"date-time"` // If set, the BEE will be automatically deleted after this time (thelma checks this field)
 	Description                 *string    `json:"description" form:"description"`
 	PactIdentifier              *uuid.UUID `json:"pactIdentifier" form:"PactIdentifier"`
 	PagerdutyIntegration        *string    `json:"pagerdutyIntegration,omitempty" form:"pagerdutyIntegration"`
@@ -78,7 +79,17 @@ func (e EnvironmentV3) toModel(db *gorm.DB) (models.Environment, error) {
 		PactIdentifier:              e.PactIdentifier,
 	}
 	if e.DeleteAfter != nil {
-		ret.DeleteAfter = sql.NullTime{Time: *e.DeleteAfter, Valid: true}
+		if *e.DeleteAfter == "" {
+			// DeleteAfter explicitly set to an empty string; this means the field should be cleared.
+			// We do that by explicitly storing the zero timestamp in the database
+			ret.DeleteAfter = sql.NullTime{Time: time.Time{}, Valid: true}
+		} else {
+			deleteAfter, err := time.Parse(time.RFC3339, *e.DeleteAfter)
+			if err != nil {
+				return models.Environment{}, fmt.Errorf("(%s) failed to parse deleteAfter '%s': %w", errors.BadRequest, *e.DeleteAfter, err)
+			}
+			ret.DeleteAfter = sql.NullTime{Time: deleteAfter, Valid: true}
+		}
 	}
 	if e.TemplateEnvironment != "" {
 		templateEnvironmentModel, err := environmentModelFromSelector(e.TemplateEnvironment)
@@ -181,8 +192,8 @@ func environmentFromModel(model models.Environment) EnvironmentV3 {
 	if model.Owner != nil {
 		ret.Owner = &model.Owner.Email
 	}
-	if model.DeleteAfter.Valid {
-		ret.DeleteAfter = &model.DeleteAfter.Time
+	if !model.DeleteAfter.Time.IsZero() {
+		ret.DeleteAfter = utils.PointerTo(model.DeleteAfter.Time.Format(time.RFC3339))
 	}
 	if model.PagerdutyIntegration != nil && model.PagerdutyIntegration.PagerdutyID != "" {
 		ret.PagerdutyIntegration = utils.PointerTo(fmt.Sprintf("pd-id/%s", model.PagerdutyIntegration.PagerdutyID))

--- a/sherlock/internal/api/sherlock/environments_v3_test.go
+++ b/sherlock/internal/api/sherlock/environments_v3_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func (s *handlerSuite) TestEnvironmentV3_toModel() {
-	now := time.Now()
+	now := time.Now().Truncate(time.Second)
 	templateEnvironment := s.TestData.Environment_Swatomation()
 	defaultCluster := s.TestData.Cluster_TerraQaBees()
 	pagerdutyIntegration := s.TestData.PagerdutyIntegration_ManuallyTriggeredTerraIncident()
@@ -39,7 +39,7 @@ func (s *handlerSuite) TestEnvironmentV3_toModel() {
 			fields: fields{
 				EnvironmentV3Create: EnvironmentV3Create{
 					EnvironmentV3Edit: EnvironmentV3Edit{
-						DeleteAfter: &now,
+						DeleteAfter: utils.PointerTo(now.Format(time.RFC3339)),
 					},
 				},
 			},
@@ -160,7 +160,7 @@ func (s *handlerSuite) TestEnvironmentV3_toModel() {
 						NamePrefixesDomain:          utils.PointerTo(true),
 						HelmfileRef:                 utils.PointerTo("HEAD"),
 						PreventDeletion:             utils.PointerTo(true),
-						DeleteAfter:                 utils.PointerTo(now),
+						DeleteAfter:                 utils.PointerTo(now.Format(time.RFC3339)),
 						Description:                 utils.PointerTo("description"),
 						PactIdentifier:              utils.PointerTo(pactUuid),
 						PagerdutyIntegration:        utils.PointerTo(utils.UintToString(pagerdutyIntegration.ID)),
@@ -316,7 +316,7 @@ func Test_environmentFromModel(t *testing.T) {
 						NamePrefixesDomain:          utils.PointerTo(true),
 						HelmfileRef:                 utils.PointerTo("HEAD"),
 						PreventDeletion:             utils.PointerTo(true),
-						DeleteAfter:                 utils.PointerTo(now),
+						DeleteAfter:                 utils.PointerTo(now.Format(time.RFC3339)),
 						Description:                 utils.PointerTo("description"),
 						PactIdentifier:              utils.PointerTo(pactUuid),
 						PagerdutyIntegration:        utils.PointerTo("pd-id/blah"),


### PR DESCRIPTION
@choover-broad brought up a great point about being able to clear this field. This fix means that a zero time or "" will be understood as clearing the field.

I'm not positive that this will actually make it easy to do from the Go client library, but it will at least be possible from the Swagger page or something.

## Testing

Added tests for various flows of editing and parsing this field specifically

## Risk

Very low