### PR TITLE
[DDO-3470] Switch GHA workflows to use v3 endpoints

### DIFF
--- a/.github/workflows/client-get-chart-release.yaml
+++ b/.github/workflows/client-get-chart-release.yaml
@@ -84,7 +84,7 @@ jobs:
         run: |
           set -ex
           curl --fail-with-body \
-            "$SHERLOCK_PROD_URL/api/v2/chart-releases/${{ inputs.chart-release-name }}" \
+            "$SHERLOCK_PROD_URL/api/chart-releases/v3/${{ inputs.chart-release-name }}" \
             -H 'Content-Type: application/json' \
             -H 'Authorization: Bearer ${{ steps.iap_auth.outputs.id_token }}' \
             -H 'X-GHA-OIDC-JWT: ${{ steps.gha_auth.outputs.id_token }}' \

--- a/.github/workflows/client-get-environment.yaml
+++ b/.github/workflows/client-get-environment.yaml
@@ -80,7 +80,7 @@ jobs:
         run: |
           set -ex
           curl --fail-with-body \
-            "$SHERLOCK_PROD_URL/api/v2/environments/${{ inputs.environment-name }}" \
+            "$SHERLOCK_PROD_URL/api/environments/v3/${{ inputs.environment-name }}" \
             -H 'Content-Type: application/json' \
             -H 'Authorization: Bearer ${{ steps.iap_auth.outputs.id_token }}' \
             -H 'X-GHA-OIDC-JWT: ${{ steps.gha_auth.outputs.id_token }}' \

--- a/.github/workflows/client-refresh-environment.yaml
+++ b/.github/workflows/client-refresh-environment.yaml
@@ -131,7 +131,7 @@ jobs:
         run: |
           set -ex
           curl --fail-with-body -X 'POST' \
-            "$SHERLOCK_PROD_URL/api/v2/procedures/changesets/plan-and-apply" \
+            "$SHERLOCK_PROD_URL/api/changesets/procedures/v3/plan-and-apply" \
             -H 'Content-Type: application/json' \
             -H 'Authorization: Bearer ${{ steps.iap_auth.outputs.id_token }}' \
             -H 'X-GHA-OIDC-JWT: ${{ steps.gha_auth.outputs.id_token }}' \

--- a/.github/workflows/client-set-environment-app-version.yaml
+++ b/.github/workflows/client-set-environment-app-version.yaml
@@ -160,7 +160,7 @@ jobs:
         run: |
           set -ex
           curl --fail-with-body -X 'POST' \
-            "$SHERLOCK_PROD_URL/api/v2/procedures/changesets/plan-and-apply" \
+            "$SHERLOCK_PROD_URL/api/changesets/procedures/v3/plan-and-apply" \
             -H 'Content-Type: application/json' \
             -H 'Authorization: Bearer ${{ steps.iap_auth.outputs.id_token }}' \
             -H 'X-GHA-OIDC-JWT: ${{ steps.gha_auth.outputs.id_token }}' \

--- a/.github/workflows/client-set-environment-chart-version.yaml
+++ b/.github/workflows/client-set-environment-chart-version.yaml
@@ -162,7 +162,7 @@ jobs:
         run: |
           set -ex
           curl --fail-with-body -X 'POST' \
-            "$SHERLOCK_PROD_URL/api/v2/procedures/changesets/plan-and-apply" \
+            "$SHERLOCK_PROD_URL/api/changesets/procedures/v3/plan-and-apply" \
             -H 'Content-Type: application/json' \
             -H 'Authorization: Bearer ${{ steps.iap_auth.outputs.id_token }}' \
             -H 'X-GHA-OIDC-JWT: ${{ steps.gha_auth.outputs.id_token }}' \


### PR DESCRIPTION
Thankfully here the APIs are directly compatible (nothing here uses deleteAfter or namePrefix or PUT methods, which are the only breaking changes)

## Testing

I don't think it's necessary to make a half dozen PRs to some Terra service to test this given that app and chart version workflows have been using v3 endpoints for months without issue.

Here's the diffs one by one and the API they're set to contact:

```diff
-            "$SHERLOCK_PROD_URL/api/v2/chart-releases/${{ inputs.chart-release-name }}" \
+            "$SHERLOCK_PROD_URL/api/chart-releases/v3/${{ inputs.chart-release-name }}" \
```

https://sherlock.dsp-devops.broadinstitute.org/swagger/index.html#/ChartReleases/get_api_chart_releases_v3__selector_

```diff
-            "$SHERLOCK_PROD_URL/api/v2/environments/${{ inputs.environment-name }}" \
+            "$SHERLOCK_PROD_URL/api/environments/v3/${{ inputs.environment-name }}" \
```

https://sherlock.dsp-devops.broadinstitute.org/swagger/index.html#/Environments/get_api_environments_v3__selector_

```diff
-            "$SHERLOCK_PROD_URL/api/v2/procedures/changesets/plan-and-apply" \
+            "$SHERLOCK_PROD_URL/api/changesets/procedures/v3/plan-and-apply" \
```

https://sherlock.dsp-devops.broadinstitute.org/swagger/index.html#/Changesets/post_api_changesets_procedures_v3_plan_and_apply

## Risk

Low -- if there's a problem, the request body is logged anyway and could be manually posted (and any fixes here would roll out everywhere instantly)