### PR TITLE
[DDO-3470] Add GitHub info to request logs when present

### DIFF
--- a/sherlock/internal/boot/middleware/logger.go
+++ b/sherlock/internal/boot/middleware/logger.go
@@ -67,6 +67,12 @@ func Logger() gin.HandlerFunc {
 			event.Stringer("latency", latency)
 			event.Msgf("GIN  | %-50s", path)
 		} else {
+			if claims, err := authentication.ShouldUseGithubClaims(ctx); err == nil {
+				// If we have GitHub claims -- meaning this request definitely came from GitHub Actions --
+				// we might as well log some info from it to help with debugging.
+				event.Str("githubWorkflowFile", claims.WorkflowRef)
+				event.Str("githubWorkflowLink", claims.WorkflowURL())
+			}
 			event.Dur("latency", latency)
 			event.Str("route", ctx.FullPath())
 			event.Str("client", ctx.ClientIP())


### PR DESCRIPTION
The kinds of madness we can do with Sherlock's authentication system. Six line diff including comments to log the workflow that made a given call to Sherlock.

I'm doing this to try to figure out what on earth is still calling Sherlock v2 endpoints.

## Testing

Worked locally. Deployed to sherlock-dev and used the GitHub auth test action to issue a call to it from GHA, this showed up in the logs! Truncating everything else so I don't post IPs and stuff.

![Screenshot 2024-02-14 at 3 04 20 PM](https://github.com/broadinstitute/sherlock/assets/29168264/3303cf2b-8e43-483c-b3b5-2285a1c86ecc)

## Risk

Very low