### PR TITLE
[DDO-3534] Don't crash if requesting chart release version history when there's none

### DIFF
--- a/sherlock/internal/api/sherlock/changesets_procedures_v3_apply.go
+++ b/sherlock/internal/api/sherlock/changesets_procedures_v3_apply.go
@@ -46,10 +46,6 @@ func changesetsProceduresV3Apply(ctx *gin.Context) {
 			return
 		}
 	}
-	if len(changesetIDs) == 0 {
-		errors.AbortRequest(ctx, fmt.Errorf("(%s) no changesets specified", errors.BadRequest))
-		return
-	}
 
 	var verboseOutput bool
 	if verboseOutputString := ctx.DefaultQuery("verbose-output", "true"); verboseOutputString == "true" {
@@ -62,7 +58,10 @@ func changesetsProceduresV3Apply(ctx *gin.Context) {
 	}
 
 	var ret []models.Changeset
-	if err = models.ApplyChangesets(db, changesetIDs); err != nil {
+	if len(changesetIDs) == 0 {
+		errors.AbortRequest(ctx, fmt.Errorf("(%s) no changesets specified", errors.BadRequest))
+		return
+	} else if err = models.ApplyChangesets(db, changesetIDs); err != nil {
 		errors.AbortRequest(ctx, fmt.Errorf("error applying changesets: %w", err))
 		return
 	} else if verboseOutput {

--- a/sherlock/internal/api/sherlock/changesets_procedures_v3_chart_release_history.go
+++ b/sherlock/internal/api/sherlock/changesets_procedures_v3_chart_release_history.go
@@ -72,9 +72,11 @@ func changesetsProceduresV3ChartReleaseHistory(ctx *gin.Context) {
 	}
 
 	var ret []models.Changeset
-	if err = db.Scopes(models.ReadChangesetScope).Order("applied_at desc").Find(&ret, changesetIDs).Error; err != nil {
-		errors.AbortRequest(ctx, fmt.Errorf("error querying changesets to return: %w", err))
-		return
+	if len(changesetIDs) > 0 {
+		if err = db.Scopes(models.ReadChangesetScope).Order("applied_at desc").Find(&ret, changesetIDs).Error; err != nil {
+			errors.AbortRequest(ctx, fmt.Errorf("error querying changesets to return: %w", err))
+			return
+		}
 	}
 	ctx.JSON(http.StatusOK, utils.Map(ret, changesetFromModel))
 }

--- a/sherlock/internal/api/sherlock/changesets_procedures_v3_chart_release_history_test.go
+++ b/sherlock/internal/api/sherlock/changesets_procedures_v3_chart_release_history_test.go
@@ -46,3 +46,17 @@ func (s *handlerSuite) TestChangesetsProceduresV3ChartReleaseHistory() {
 		s.Equal(s.TestData.Changeset_LeonardoDev_V1toV3().ID, got[0].ID)
 	}
 }
+
+func (s *handlerSuite) TestChangesetsProceduresV3ChartReleaseHistory_notFound() {
+	s.TestData.Changeset_LeonardoDev_V1toV3()
+	s.TestData.Changeset_LeonardoDev_V1toV2Superseded()
+	s.TestData.Environment_Swatomation()
+	s.TestData.ChartRelease_LeonardoSwatomation()
+	s.TestData.Environment_Swatomation_DevBee()
+	var got []ChangesetV3
+	code := s.HandleRequest(
+		s.NewRequest("GET", "/api/changesets/procedures/v3/chart-release-history/leonardo-"+s.TestData.Environment_Swatomation_DevBee().Name, nil),
+		&got)
+	s.Equal(http.StatusOK, code)
+	s.Empty(got)
+}

--- a/sherlock/internal/api/sherlock/changesets_procedures_v3_version_history.go
+++ b/sherlock/internal/api/sherlock/changesets_procedures_v3_version_history.go
@@ -47,7 +47,7 @@ func changesetsProceduresV3VersionHistory(ctx *gin.Context) {
 		return
 	}
 
-	var changesetIDs uint
+	var changesetIDs []uint
 	switch ctx.Param("version-type") {
 	case "app":
 		// check if this app version exists in our database
@@ -155,9 +155,11 @@ order by changesets.applied_at desc
 	}
 
 	var ret []models.Changeset
-	if err = db.Scopes(models.ReadChangesetScope).Order("applied_at desc").Find(&ret, changesetIDs).Error; err != nil {
-		errors.AbortRequest(ctx, fmt.Errorf("error querying changesets to return: %w", err))
-		return
+	if len(changesetIDs) > 0 {
+		if err = db.Scopes(models.ReadChangesetScope).Order("applied_at desc").Find(&ret, changesetIDs).Error; err != nil {
+			errors.AbortRequest(ctx, fmt.Errorf("error querying changesets to return: %w", err))
+			return
+		}
 	}
 	ctx.JSON(http.StatusOK, utils.Map(ret, changesetFromModel))
 }


### PR DESCRIPTION
Fixes https://broadinstitute.slack.com/archives/CQ6SL4N5T/p1710166948331509?thread_ts=1710165100.662849&cid=CQ6SL4N5T and also https://broadinstitute.slack.com/archives/CQ6SL4N5T/p1710168821496979?thread_ts=1710165100.662849&cid=CQ6SL4N5T for good measure.

## Testing

Added a failing test for the case Chelsea found. For the `uint` vs `[]uint` thing I don't even want to know how that was possible -- we literally have tests for that already -- and I'm choosing just to not spend extra time on it.

## Risk

Low -- test case captures the issue Chelsea found and the behavior couldn't be much worse in that case anyway