### PR TITLE
[DDO-3535] Actually delete deleted files during client library generation

### DIFF
--- a/.github/workflows/sherlock-build.yaml
+++ b/.github/workflows/sherlock-build.yaml
@@ -129,6 +129,11 @@ jobs:
       - name: Update Pact provider documentation
         run: make document-pact-provider
 
+      - name: Delete existing Go client library code
+        if: ${{ github.event_name != 'pull_request' }}
+        # Just delete code, not config
+        run: rm -rf sherlock-go-client/client
+
       - name: Generate Go client library
         if: ${{ github.event_name != 'pull_request' }}
         run: |
@@ -143,6 +148,11 @@ jobs:
         if: ${{ github.event_name != 'pull_request' }}
         working-directory: sherlock-go-client
         run: go mod tidy
+
+      - name: Delete existing Typescript client library code
+        if: ${{ github.event_name != 'pull_request' }}
+        # Just delete code, not config
+        run: rm -rf sherlock-typescript-client/src
 
       - name: Generate Typescript client library
         if: ${{ github.event_name != 'pull_request' }}


### PR DESCRIPTION
Systemically fix the issue surfaced from https://github.com/broadinstitute/sherlock/actions/runs/8235205030/job/22518779627, where "deleted" generated client library files wouldn't get properly deleted and could cause problems down the line if they expose models that shouldn't exist anymore of if the files just get out of date and don't compile.

## Testing

Did this process locally and it seemed to fix the issue seen in CI but we'll see

## Risk

Very low, either the build works or it doesn't