### PR TITLE
[DDO-3577] API for GHA jobs

### DIFF
--- a/sherlock/db/migrations/000080_add_github_actions_jobs.down.sql
+++ b/sherlock/db/migrations/000080_add_github_actions_jobs.down.sql
@@ -1,0 +1,1 @@
+drop table if exists github_actions_jobs cascade;

--- a/sherlock/db/migrations/000080_add_github_actions_jobs.up.sql
+++ b/sherlock/db/migrations/000080_add_github_actions_jobs.up.sql
@@ -1,0 +1,29 @@
+create table if not exists github_actions_jobs
+(
+    id                            bigserial
+        primary key,
+    created_at                    timestamp with time zone,
+    updated_at                    timestamp with time zone,
+    deleted_at                    timestamp with time zone,
+    github_actions_owner          text   not null,
+    github_actions_repo           text   not null,
+    github_actions_run_id         bigint,
+    github_actions_attempt_number bigint,
+    github_actions_job_id         bigint not null,
+
+    job_created_at                timestamp with time zone,
+    job_started_at                timestamp with time zone,
+    job_completed_at              timestamp with time zone,
+    status                        text
+);
+
+create unique index if not exists github_actions_jobs_selector_unique_constraint
+    on github_actions_jobs (
+                            github_actions_owner,
+                            github_actions_repo,
+                            github_actions_job_id
+        )
+    where deleted_at is null;
+
+create index if not exists idx_github_actions_jobs_deleted_at
+    on github_actions_jobs (deleted_at);

--- a/sherlock/db/migrations/000080_add_github_actions_jobs.up.sql
+++ b/sherlock/db/migrations/000080_add_github_actions_jobs.up.sql
@@ -13,7 +13,7 @@ create table if not exists github_actions_jobs
 
     job_created_at                timestamp with time zone,
     job_started_at                timestamp with time zone,
-    job_completed_at              timestamp with time zone,
+    job_terminal_at               timestamp with time zone,
     status                        text
 );
 

--- a/sherlock/docs/docs.go
+++ b/sherlock/docs/docs.go
@@ -5465,6 +5465,271 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/github-actions-jobs/v3": {
+            "get": {
+                "description": "List GithubActionsJobs matching a filter.\nResults are ordered by start time, starting at most recent.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "GithubActionsJobs"
+                ],
+                "summary": "List GithubActionsJobs matching a filter",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "date-time",
+                        "name": "createdAt",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "name": "githubActionsAttemptNumber",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "name": "githubActionsJobID",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "name": "githubActionsOwner",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "name": "githubActionsRepo",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "name": "githubActionsRunID",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "name": "id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "name": "jobCreatedAt",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "name": "jobStartedAt",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "name": "jobTerminalAt",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "name": "status",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "format": "date-time",
+                        "name": "updatedAt",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Control how many GithubActionsJobs are returned (default 100)",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Control the offset for the returned GithubActionsJobs (default 0)",
+                        "name": "offset",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/sherlock.GithubActionsJobV3"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "407": {
+                        "description": "Proxy Authentication Required",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "description": "Upsert GithubActionsJob.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "GithubActionsJobs"
+                ],
+                "summary": "Upsert GithubActionsJob",
+                "parameters": [
+                    {
+                        "description": "The GithubActionsJob to upsert",
+                        "name": "githubActionsJob",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/sherlock.GithubActionsJobV3Create"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/sherlock.GithubActionsJobV3"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "407": {
+                        "description": "Proxy Authentication Required",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/github-actions-jobs/v3/{selector}": {
+            "get": {
+                "description": "Get an individual GithubActionsJob.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "GithubActionsJobs"
+                ],
+                "summary": "Get an individual GithubActionsJob",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "The selector of the GithubActionsJob, either Sherlock ID or '{owner}/{repo}/{job ID}'",
+                        "name": "selector",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/sherlock.GithubActionsJobV3"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "407": {
+                        "description": "Proxy Authentication Required",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/incidents/v3": {
             "get": {
                 "description": "List Incidents matching a filter.",
@@ -8514,6 +8779,81 @@ const docTemplate = `{
                 },
                 "onSuccess": {
                     "type": "boolean"
+                }
+            }
+        },
+        "sherlock.GithubActionsJobV3": {
+            "type": "object",
+            "properties": {
+                "createdAt": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "githubActionsAttemptNumber": {
+                    "type": "integer"
+                },
+                "githubActionsJobID": {
+                    "type": "integer"
+                },
+                "githubActionsOwner": {
+                    "type": "string"
+                },
+                "githubActionsRepo": {
+                    "type": "string"
+                },
+                "githubActionsRunID": {
+                    "type": "integer"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "jobCreatedAt": {
+                    "type": "string"
+                },
+                "jobStartedAt": {
+                    "type": "string"
+                },
+                "jobTerminalAt": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "updatedAt": {
+                    "type": "string",
+                    "format": "date-time"
+                }
+            }
+        },
+        "sherlock.GithubActionsJobV3Create": {
+            "type": "object",
+            "properties": {
+                "githubActionsAttemptNumber": {
+                    "type": "integer"
+                },
+                "githubActionsJobID": {
+                    "type": "integer"
+                },
+                "githubActionsOwner": {
+                    "type": "string"
+                },
+                "githubActionsRepo": {
+                    "type": "string"
+                },
+                "githubActionsRunID": {
+                    "type": "integer"
+                },
+                "jobCreatedAt": {
+                    "type": "string"
+                },
+                "jobStartedAt": {
+                    "type": "string"
+                },
+                "jobTerminalAt": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
                 }
             }
         },

--- a/sherlock/docs/docs.go
+++ b/sherlock/docs/docs.go
@@ -5514,16 +5514,19 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
+                        "format": "date-time",
                         "name": "jobCreatedAt",
                         "in": "query"
                     },
                     {
                         "type": "string",
+                        "format": "date-time",
                         "name": "jobStartedAt",
                         "in": "query"
                     },
                     {
                         "type": "string",
+                        "format": "date-time",
                         "name": "jobTerminalAt",
                         "in": "query"
                     },
@@ -8808,13 +8811,16 @@ const docTemplate = `{
                     "type": "integer"
                 },
                 "jobCreatedAt": {
-                    "type": "string"
+                    "type": "string",
+                    "format": "date-time"
                 },
                 "jobStartedAt": {
-                    "type": "string"
+                    "type": "string",
+                    "format": "date-time"
                 },
                 "jobTerminalAt": {
-                    "type": "string"
+                    "type": "string",
+                    "format": "date-time"
                 },
                 "status": {
                     "type": "string"
@@ -8844,13 +8850,16 @@ const docTemplate = `{
                     "type": "integer"
                 },
                 "jobCreatedAt": {
-                    "type": "string"
+                    "type": "string",
+                    "format": "date-time"
                 },
                 "jobStartedAt": {
-                    "type": "string"
+                    "type": "string",
+                    "format": "date-time"
                 },
                 "jobTerminalAt": {
-                    "type": "string"
+                    "type": "string",
+                    "format": "date-time"
                 },
                 "status": {
                     "type": "string"

--- a/sherlock/docs/swagger.json
+++ b/sherlock/docs/swagger.json
@@ -5510,16 +5510,19 @@
                     },
                     {
                         "type": "string",
+                        "format": "date-time",
                         "name": "jobCreatedAt",
                         "in": "query"
                     },
                     {
                         "type": "string",
+                        "format": "date-time",
                         "name": "jobStartedAt",
                         "in": "query"
                     },
                     {
                         "type": "string",
+                        "format": "date-time",
                         "name": "jobTerminalAt",
                         "in": "query"
                     },
@@ -8804,13 +8807,16 @@
                     "type": "integer"
                 },
                 "jobCreatedAt": {
-                    "type": "string"
+                    "type": "string",
+                    "format": "date-time"
                 },
                 "jobStartedAt": {
-                    "type": "string"
+                    "type": "string",
+                    "format": "date-time"
                 },
                 "jobTerminalAt": {
-                    "type": "string"
+                    "type": "string",
+                    "format": "date-time"
                 },
                 "status": {
                     "type": "string"
@@ -8840,13 +8846,16 @@
                     "type": "integer"
                 },
                 "jobCreatedAt": {
-                    "type": "string"
+                    "type": "string",
+                    "format": "date-time"
                 },
                 "jobStartedAt": {
-                    "type": "string"
+                    "type": "string",
+                    "format": "date-time"
                 },
                 "jobTerminalAt": {
-                    "type": "string"
+                    "type": "string",
+                    "format": "date-time"
                 },
                 "status": {
                     "type": "string"

--- a/sherlock/docs/swagger.json
+++ b/sherlock/docs/swagger.json
@@ -5461,6 +5461,271 @@
                 }
             }
         },
+        "/api/github-actions-jobs/v3": {
+            "get": {
+                "description": "List GithubActionsJobs matching a filter.\nResults are ordered by start time, starting at most recent.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "GithubActionsJobs"
+                ],
+                "summary": "List GithubActionsJobs matching a filter",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "date-time",
+                        "name": "createdAt",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "name": "githubActionsAttemptNumber",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "name": "githubActionsJobID",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "name": "githubActionsOwner",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "name": "githubActionsRepo",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "name": "githubActionsRunID",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "name": "id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "name": "jobCreatedAt",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "name": "jobStartedAt",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "name": "jobTerminalAt",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "name": "status",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "format": "date-time",
+                        "name": "updatedAt",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Control how many GithubActionsJobs are returned (default 100)",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Control the offset for the returned GithubActionsJobs (default 0)",
+                        "name": "offset",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/sherlock.GithubActionsJobV3"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "407": {
+                        "description": "Proxy Authentication Required",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "description": "Upsert GithubActionsJob.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "GithubActionsJobs"
+                ],
+                "summary": "Upsert GithubActionsJob",
+                "parameters": [
+                    {
+                        "description": "The GithubActionsJob to upsert",
+                        "name": "githubActionsJob",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/sherlock.GithubActionsJobV3Create"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/sherlock.GithubActionsJobV3"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "407": {
+                        "description": "Proxy Authentication Required",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/github-actions-jobs/v3/{selector}": {
+            "get": {
+                "description": "Get an individual GithubActionsJob.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "GithubActionsJobs"
+                ],
+                "summary": "Get an individual GithubActionsJob",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "The selector of the GithubActionsJob, either Sherlock ID or '{owner}/{repo}/{job ID}'",
+                        "name": "selector",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/sherlock.GithubActionsJobV3"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "407": {
+                        "description": "Proxy Authentication Required",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/incidents/v3": {
             "get": {
                 "description": "List Incidents matching a filter.",
@@ -8510,6 +8775,81 @@
                 },
                 "onSuccess": {
                     "type": "boolean"
+                }
+            }
+        },
+        "sherlock.GithubActionsJobV3": {
+            "type": "object",
+            "properties": {
+                "createdAt": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "githubActionsAttemptNumber": {
+                    "type": "integer"
+                },
+                "githubActionsJobID": {
+                    "type": "integer"
+                },
+                "githubActionsOwner": {
+                    "type": "string"
+                },
+                "githubActionsRepo": {
+                    "type": "string"
+                },
+                "githubActionsRunID": {
+                    "type": "integer"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "jobCreatedAt": {
+                    "type": "string"
+                },
+                "jobStartedAt": {
+                    "type": "string"
+                },
+                "jobTerminalAt": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "updatedAt": {
+                    "type": "string",
+                    "format": "date-time"
+                }
+            }
+        },
+        "sherlock.GithubActionsJobV3Create": {
+            "type": "object",
+            "properties": {
+                "githubActionsAttemptNumber": {
+                    "type": "integer"
+                },
+                "githubActionsJobID": {
+                    "type": "integer"
+                },
+                "githubActionsOwner": {
+                    "type": "string"
+                },
+                "githubActionsRepo": {
+                    "type": "string"
+                },
+                "githubActionsRunID": {
+                    "type": "integer"
+                },
+                "jobCreatedAt": {
+                    "type": "string"
+                },
+                "jobStartedAt": {
+                    "type": "string"
+                },
+                "jobTerminalAt": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
                 }
             }
         },

--- a/sherlock/docs/swagger.yaml
+++ b/sherlock/docs/swagger.yaml
@@ -1393,6 +1393,56 @@ definitions:
       onSuccess:
         type: boolean
     type: object
+  sherlock.GithubActionsJobV3:
+    properties:
+      createdAt:
+        format: date-time
+        type: string
+      githubActionsAttemptNumber:
+        type: integer
+      githubActionsJobID:
+        type: integer
+      githubActionsOwner:
+        type: string
+      githubActionsRepo:
+        type: string
+      githubActionsRunID:
+        type: integer
+      id:
+        type: integer
+      jobCreatedAt:
+        type: string
+      jobStartedAt:
+        type: string
+      jobTerminalAt:
+        type: string
+      status:
+        type: string
+      updatedAt:
+        format: date-time
+        type: string
+    type: object
+  sherlock.GithubActionsJobV3Create:
+    properties:
+      githubActionsAttemptNumber:
+        type: integer
+      githubActionsJobID:
+        type: integer
+      githubActionsOwner:
+        type: string
+      githubActionsRepo:
+        type: string
+      githubActionsRunID:
+        type: integer
+      jobCreatedAt:
+        type: string
+      jobStartedAt:
+        type: string
+      jobTerminalAt:
+        type: string
+      status:
+        type: string
+    type: object
   sherlock.IncidentV3:
     properties:
       createdAt:
@@ -5291,6 +5341,182 @@ paths:
       summary: Upsert a GitCommit
       tags:
       - GitCommits
+  /api/github-actions-jobs/v3:
+    get:
+      description: |-
+        List GithubActionsJobs matching a filter.
+        Results are ordered by start time, starting at most recent.
+      parameters:
+      - format: date-time
+        in: query
+        name: createdAt
+        type: string
+      - in: query
+        name: githubActionsAttemptNumber
+        type: integer
+      - in: query
+        name: githubActionsJobID
+        type: integer
+      - in: query
+        name: githubActionsOwner
+        type: string
+      - in: query
+        name: githubActionsRepo
+        type: string
+      - in: query
+        name: githubActionsRunID
+        type: integer
+      - in: query
+        name: id
+        type: integer
+      - in: query
+        name: jobCreatedAt
+        type: string
+      - in: query
+        name: jobStartedAt
+        type: string
+      - in: query
+        name: jobTerminalAt
+        type: string
+      - in: query
+        name: status
+        type: string
+      - format: date-time
+        in: query
+        name: updatedAt
+        type: string
+      - description: Control how many GithubActionsJobs are returned (default 100)
+        in: query
+        name: limit
+        type: integer
+      - description: Control the offset for the returned GithubActionsJobs (default
+          0)
+        in: query
+        name: offset
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/sherlock.GithubActionsJobV3'
+            type: array
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/errors.ErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/errors.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/errors.ErrorResponse'
+        "407":
+          description: Proxy Authentication Required
+          schema:
+            $ref: '#/definitions/errors.ErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/errors.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/errors.ErrorResponse'
+      summary: List GithubActionsJobs matching a filter
+      tags:
+      - GithubActionsJobs
+    put:
+      description: Upsert GithubActionsJob.
+      parameters:
+      - description: The GithubActionsJob to upsert
+        in: body
+        name: githubActionsJob
+        required: true
+        schema:
+          $ref: '#/definitions/sherlock.GithubActionsJobV3Create'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/sherlock.GithubActionsJobV3'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/errors.ErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/errors.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/errors.ErrorResponse'
+        "407":
+          description: Proxy Authentication Required
+          schema:
+            $ref: '#/definitions/errors.ErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/errors.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/errors.ErrorResponse'
+      summary: Upsert GithubActionsJob
+      tags:
+      - GithubActionsJobs
+  /api/github-actions-jobs/v3/{selector}:
+    get:
+      description: Get an individual GithubActionsJob.
+      parameters:
+      - description: The selector of the GithubActionsJob, either Sherlock ID or '{owner}/{repo}/{job
+          ID}'
+        in: path
+        name: selector
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/sherlock.GithubActionsJobV3'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/errors.ErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/errors.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/errors.ErrorResponse'
+        "407":
+          description: Proxy Authentication Required
+          schema:
+            $ref: '#/definitions/errors.ErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/errors.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/errors.ErrorResponse'
+      summary: Get an individual GithubActionsJob
+      tags:
+      - GithubActionsJobs
   /api/incidents/v3:
     get:
       description: List Incidents matching a filter.

--- a/sherlock/docs/swagger.yaml
+++ b/sherlock/docs/swagger.yaml
@@ -1411,10 +1411,13 @@ definitions:
       id:
         type: integer
       jobCreatedAt:
+        format: date-time
         type: string
       jobStartedAt:
+        format: date-time
         type: string
       jobTerminalAt:
+        format: date-time
         type: string
       status:
         type: string
@@ -1435,10 +1438,13 @@ definitions:
       githubActionsRunID:
         type: integer
       jobCreatedAt:
+        format: date-time
         type: string
       jobStartedAt:
+        format: date-time
         type: string
       jobTerminalAt:
+        format: date-time
         type: string
       status:
         type: string
@@ -5369,13 +5375,16 @@ paths:
       - in: query
         name: id
         type: integer
-      - in: query
+      - format: date-time
+        in: query
         name: jobCreatedAt
         type: string
-      - in: query
+      - format: date-time
+        in: query
         name: jobStartedAt
         type: string
-      - in: query
+      - format: date-time
+        in: query
         name: jobTerminalAt
         type: string
       - in: query

--- a/sherlock/internal/api/sherlock/github_actions_jobs_v3.go
+++ b/sherlock/internal/api/sherlock/github_actions_jobs_v3.go
@@ -26,6 +26,7 @@ type GithubActionsJobV3Edit struct {
 	Status        *string    `json:"status" form:"status"`
 }
 
+//nolint:unused
 func (j GithubActionsJobV3) toModel() models.GithubActionsJob {
 	return models.GithubActionsJob{
 		Model:                      j.toGormModel(),
@@ -41,10 +42,12 @@ func (j GithubActionsJobV3) toModel() models.GithubActionsJob {
 	}
 }
 
+//nolint:unused
 func (j GithubActionsJobV3Create) toModel() models.GithubActionsJob {
 	return GithubActionsJobV3{GithubActionsJobV3Create: j}.toModel()
 }
 
+//nolint:unused
 func (j GithubActionsJobV3Edit) toModel() models.GithubActionsJob {
 	return GithubActionsJobV3Create{GithubActionsJobV3Edit: j}.toModel()
 }

--- a/sherlock/internal/api/sherlock/github_actions_jobs_v3.go
+++ b/sherlock/internal/api/sherlock/github_actions_jobs_v3.go
@@ -1,0 +1,69 @@
+package sherlock
+
+import (
+	"github.com/broadinstitute/sherlock/sherlock/internal/models"
+	"time"
+)
+
+type GithubActionsJobV3 struct {
+	CommonFields
+	GithubActionsJobV3Create
+}
+
+type GithubActionsJobV3Create struct {
+	GithubActionsOwner         string `json:"githubActionsOwner"`
+	GithubActionsRepo          string `json:"githubActionsRepo"`
+	GithubActionsRunID         uint   `json:"githubActionsRunID"`
+	GithubActionsAttemptNumber uint   `json:"githubActionsAttemptNumber"`
+	GithubActionsJobID         uint   `json:"githubActionsJobID"`
+	GithubActionsJobV3Edit
+}
+
+type GithubActionsJobV3Edit struct {
+	JobCreatedAt  *time.Time `json:"jobCreatedAt"`
+	JobStartedAt  *time.Time `json:"jobStartedAt"`
+	JobTerminalAt *time.Time `json:"jobTerminalAt"`
+	Status        *string    `json:"status"`
+}
+
+func (j GithubActionsJobV3) toModel() models.GithubActionsJob {
+	return models.GithubActionsJob{
+		Model:                      j.toGormModel(),
+		GithubActionsOwner:         j.GithubActionsOwner,
+		GithubActionsRepo:          j.GithubActionsRepo,
+		GithubActionsRunID:         j.GithubActionsRunID,
+		GithubActionsAttemptNumber: j.GithubActionsAttemptNumber,
+		GithubActionsJobID:         j.GithubActionsJobID,
+		JobCreatedAt:               j.JobCreatedAt,
+		JobStartedAt:               j.JobStartedAt,
+		JobTerminalAt:              j.JobTerminalAt,
+		Status:                     j.Status,
+	}
+}
+
+func (j GithubActionsJobV3Create) toModel() models.GithubActionsJob {
+	return GithubActionsJobV3{GithubActionsJobV3Create: j}.toModel()
+}
+
+func (j GithubActionsJobV3Edit) toModel() models.GithubActionsJob {
+	return GithubActionsJobV3Create{GithubActionsJobV3Edit: j}.toModel()
+}
+
+func githubActionsJobFromModel(model models.GithubActionsJob) GithubActionsJobV3 {
+	return GithubActionsJobV3{
+		CommonFields: commonFieldsFromGormModel(model.Model),
+		GithubActionsJobV3Create: GithubActionsJobV3Create{
+			GithubActionsOwner:         model.GithubActionsOwner,
+			GithubActionsRepo:          model.GithubActionsRepo,
+			GithubActionsRunID:         model.GithubActionsRunID,
+			GithubActionsAttemptNumber: model.GithubActionsAttemptNumber,
+			GithubActionsJobID:         model.GithubActionsJobID,
+			GithubActionsJobV3Edit: GithubActionsJobV3Edit{
+				JobCreatedAt:  model.JobCreatedAt,
+				JobStartedAt:  model.JobStartedAt,
+				JobTerminalAt: model.JobTerminalAt,
+				Status:        model.Status,
+			},
+		},
+	}
+}

--- a/sherlock/internal/api/sherlock/github_actions_jobs_v3.go
+++ b/sherlock/internal/api/sherlock/github_actions_jobs_v3.go
@@ -11,19 +11,19 @@ type GithubActionsJobV3 struct {
 }
 
 type GithubActionsJobV3Create struct {
-	GithubActionsOwner         string `json:"githubActionsOwner"`
-	GithubActionsRepo          string `json:"githubActionsRepo"`
-	GithubActionsRunID         uint   `json:"githubActionsRunID"`
-	GithubActionsAttemptNumber uint   `json:"githubActionsAttemptNumber"`
-	GithubActionsJobID         uint   `json:"githubActionsJobID"`
+	GithubActionsOwner         string `json:"githubActionsOwner" form:"githubActionsOwner"`
+	GithubActionsRepo          string `json:"githubActionsRepo" form:"githubActionsRepo"`
+	GithubActionsRunID         uint   `json:"githubActionsRunID" form:"githubActionsRunID"`
+	GithubActionsAttemptNumber uint   `json:"githubActionsAttemptNumber" form:"githubActionsAttemptNumber"`
+	GithubActionsJobID         uint   `json:"githubActionsJobID" form:"githubActionsJobID"`
 	GithubActionsJobV3Edit
 }
 
 type GithubActionsJobV3Edit struct {
-	JobCreatedAt  *time.Time `json:"jobCreatedAt"`
-	JobStartedAt  *time.Time `json:"jobStartedAt"`
-	JobTerminalAt *time.Time `json:"jobTerminalAt"`
-	Status        *string    `json:"status"`
+	JobCreatedAt  *time.Time `json:"jobCreatedAt"  format:"date-time" form:"jobCreatedAt"`
+	JobStartedAt  *time.Time `json:"jobStartedAt" format:"date-time" form:"jobStartedAt"`
+	JobTerminalAt *time.Time `json:"jobTerminalAt" format:"date-time" form:"jobTerminalAt"`
+	Status        *string    `json:"status" form:"status"`
 }
 
 func (j GithubActionsJobV3) toModel() models.GithubActionsJob {

--- a/sherlock/internal/api/sherlock/github_actions_jobs_v3_get.go
+++ b/sherlock/internal/api/sherlock/github_actions_jobs_v3_get.go
@@ -1,0 +1,67 @@
+package sherlock
+
+import (
+	"fmt"
+	"github.com/broadinstitute/sherlock/go-shared/pkg/utils"
+	"github.com/broadinstitute/sherlock/sherlock/internal/authentication"
+	"github.com/broadinstitute/sherlock/sherlock/internal/errors"
+	"github.com/broadinstitute/sherlock/sherlock/internal/models"
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm/clause"
+	"net/http"
+	"strings"
+)
+
+// githubActionsJobsV3Get godoc
+//
+//	@summary		Get an individual GithubActionsJob
+//	@description	Get an individual GithubActionsJob.
+//	@tags			GithubActionsJobs
+//	@produce		json
+//	@param			selector				path		string	true	"The selector of the GithubActionsJob, either Sherlock ID or '{owner}/{repo}/{job ID}'"
+//	@success		200						{object}	GithubActionsJobV3
+//	@failure		400,403,404,407,409,500	{object}	errors.ErrorResponse
+//	@router			/api/github-actions-jobs/v3/{selector} [get]
+func githubActionsJobsV3Get(ctx *gin.Context) {
+	db, err := authentication.MustUseDB(ctx)
+	if err != nil {
+		return
+	}
+	query, err := githubActionsJobModelFromSelector(canonicalizeSelector(ctx.Param("selector")))
+	if err != nil {
+		errors.AbortRequest(ctx, err)
+		return
+	}
+	var result models.GithubActionsJob
+	if err = db.Preload(clause.Associations).Where(&query).First(&result).Error; err != nil {
+		errors.AbortRequest(ctx, err)
+		return
+	}
+	ctx.JSON(http.StatusOK, githubActionsJobFromModel(result))
+}
+
+func githubActionsJobModelFromSelector(selector string) (query models.GithubActionsJob, err error) {
+	if len(selector) == 0 {
+		return models.GithubActionsJob{}, fmt.Errorf("(%s) incident selector cannot be empty", errors.BadRequest)
+	}
+	if utils.IsNumeric(selector) { // ID
+		query.ID, err = utils.ParseUint(selector)
+		return query, err
+	} else if strings.Count(selector, "/") == 2 { // owner + repo + job ID
+		parts := strings.Split(selector, "/")
+		query.GithubActionsOwner = parts[0]
+		if query.GithubActionsOwner == "" {
+			return models.GithubActionsJob{}, fmt.Errorf("(%s) invalid incident selector '%s', owner sub-selector was empty", errors.BadRequest, selector)
+		}
+		query.GithubActionsRepo = parts[1]
+		if query.GithubActionsRepo == "" {
+			return models.GithubActionsJob{}, fmt.Errorf("(%s) invalid incident selector '%s', repo sub-selector was empty", errors.BadRequest, selector)
+		}
+		query.GithubActionsJobID, err = utils.ParseUint(parts[2])
+		if err != nil {
+			return models.GithubActionsJob{}, fmt.Errorf("(%s) invalid incident selector '%s', job ID sub-selector was invalid", errors.BadRequest, selector)
+		}
+		return query, nil
+	}
+	return models.GithubActionsJob{}, fmt.Errorf("(%s) invalid incident selector '%s'", errors.BadRequest, selector)
+}

--- a/sherlock/internal/api/sherlock/github_actions_jobs_v3_list.go
+++ b/sherlock/internal/api/sherlock/github_actions_jobs_v3_list.go
@@ -1,0 +1,53 @@
+package sherlock
+
+import (
+	"fmt"
+	"github.com/broadinstitute/sherlock/go-shared/pkg/utils"
+	"github.com/broadinstitute/sherlock/sherlock/internal/authentication"
+	"github.com/broadinstitute/sherlock/sherlock/internal/errors"
+	"github.com/broadinstitute/sherlock/sherlock/internal/models"
+	"github.com/gin-gonic/gin"
+	"net/http"
+)
+
+// githubActionsJobsV3List godoc
+//
+//	@summary		List GithubActionsJobs matching a filter
+//	@description	List GithubActionsJobs matching a filter.
+//	@description	Results are ordered by start time, starting at most recent.
+//	@tags			GithubActionsJobs
+//	@produce		json
+//	@param			filter					query		GithubActionsJobV3	false	"Filter the returned GithubActionsJobs"
+//	@param			limit					query		int					false	"Control how many GithubActionsJobs are returned (default 100)"
+//	@param			offset					query		int					false	"Control the offset for the returned GithubActionsJobs (default 0)"
+//	@success		200						{array}		GithubActionsJobV3
+//	@failure		400,403,404,407,409,500	{object}	errors.ErrorResponse
+//	@router			/api/github-actions-jobs/v3 [get]
+func githubActionsJobsV3List(ctx *gin.Context) {
+	db, err := authentication.MustUseDB(ctx)
+	if err != nil {
+		return
+	}
+	var filter GithubActionsJobV3
+	if err = ctx.ShouldBindQuery(&filter); err != nil {
+		errors.AbortRequest(ctx, err)
+		return
+	}
+	modelFilter := filter.toModel()
+	limit, err := utils.ParseInt(ctx.DefaultQuery("limit", "100"))
+	if err != nil {
+		errors.AbortRequest(ctx, fmt.Errorf("(%s) %v", errors.BadRequest, err))
+		return
+	}
+	offset, err := utils.ParseInt(ctx.DefaultQuery("offset", "0"))
+	if err != nil {
+		errors.AbortRequest(ctx, fmt.Errorf("(%s) %v", errors.BadRequest, err))
+		return
+	}
+	var results []models.GithubActionsJob
+	if err = db.Where(&modelFilter).Limit(limit).Offset(offset).Order("job_created_at desc").Find(&results).Error; err != nil {
+		errors.AbortRequest(ctx, err)
+		return
+	}
+	ctx.JSON(http.StatusOK, utils.Map(results, githubActionsJobFromModel))
+}

--- a/sherlock/internal/api/sherlock/github_actions_jobs_v3_upsert.go
+++ b/sherlock/internal/api/sherlock/github_actions_jobs_v3_upsert.go
@@ -1,0 +1,58 @@
+package sherlock
+
+import (
+	"fmt"
+	"github.com/broadinstitute/sherlock/sherlock/internal/authentication"
+	"github.com/broadinstitute/sherlock/sherlock/internal/errors"
+	"github.com/broadinstitute/sherlock/sherlock/internal/models"
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm/clause"
+	"net/http"
+)
+
+// githubActionsJobsV3Upsert godoc
+//
+//	@summary		Upsert GithubActionsJob
+//	@description	Upsert GithubActionsJob.
+//	@tags			GithubActionsJobs
+//	@produce		json
+//	@param			githubActionsJob		body		GithubActionsJobV3Create	true	"The GithubActionsJob to upsert"
+//	@success		200						{object}	GithubActionsJobV3
+//	@failure		400,403,404,407,409,500	{object}	errors.ErrorResponse
+//	@router			/api/github-actions-jobs/v3 [put]
+func githubActionsJobsV3Upsert(ctx *gin.Context) {
+	db, err := authentication.MustUseDB(ctx)
+	if err != nil {
+		return
+	}
+	var body GithubActionsJobV3Create
+	if err = ctx.ShouldBindJSON(&body); err != nil {
+		errors.AbortRequest(ctx, fmt.Errorf("(%s) request validation error: %w", errors.BadRequest, err))
+		return
+	}
+
+	toUpsert := body.toModel()
+	if err = db.Where(&models.GithubActionsJob{
+		GithubActionsOwner: toUpsert.GithubActionsOwner,
+		GithubActionsRepo:  toUpsert.GithubActionsRepo,
+		GithubActionsJobID: toUpsert.GithubActionsJobID,
+	}).Assign(&models.GithubActionsJob{
+		// GitHub technically just identifies by owner, repo, and job ID, so we assign this data rather than filtering on it
+		GithubActionsRunID:         toUpsert.GithubActionsRunID,
+		GithubActionsAttemptNumber: toUpsert.GithubActionsAttemptNumber,
+		JobCreatedAt:               toUpsert.JobCreatedAt,
+		JobStartedAt:               toUpsert.JobStartedAt,
+		JobTerminalAt:              toUpsert.JobTerminalAt,
+		Status:                     toUpsert.Status,
+	}).FirstOrCreate(&toUpsert).Error; err != nil {
+		errors.AbortRequest(ctx, err)
+		return
+	}
+
+	var result models.GithubActionsJob
+	if err = db.Preload(clause.Associations).First(&result, toUpsert.ID).Error; err != nil {
+		errors.AbortRequest(ctx, err)
+		return
+	}
+	ctx.JSON(http.StatusOK, githubActionsJobFromModel(result))
+}

--- a/sherlock/internal/api/sherlock/routes.go
+++ b/sherlock/internal/api/sherlock/routes.go
@@ -114,6 +114,10 @@ func ConfigureRoutes(apiRouter gin.IRoutes) {
 	apiRouter.PATCH("environments/v3/*selector", environmentsV3Edit)
 	apiRouter.GET("environments/v3/*selector", environmentsV3Get)
 
+	apiRouter.GET("github-actions-jobs/v3", githubActionsJobsV3List)
+	apiRouter.GET("github-actions-jobs/v3/*selector", githubActionsJobsV3Get)
+	apiRouter.PUT("github-actions-jobs/v3", githubActionsJobsV3Upsert)
+
 	apiRouter.PUT("git-commits/v3", gitCommitsV3Upsert)
 
 	apiRouter.POST("incidents/v3", incidentsV3Create)

--- a/sherlock/internal/models/github_actions_job.go
+++ b/sherlock/internal/models/github_actions_job.go
@@ -1,0 +1,21 @@
+package models
+
+import (
+	"gorm.io/gorm"
+	"time"
+)
+
+type GithubActionsJob struct {
+	gorm.Model
+	GithubActionsOwner         string
+	GithubActionsRepo          string
+	GithubActionsRunID         uint
+	GithubActionsAttemptNumber uint
+	GithubActionsJobID         uint
+
+	// Mutable
+	JobCreatedAt  *time.Time
+	JobStartedAt  *time.Time
+	JobTerminalAt *time.Time
+	Status        *string
+}


### PR DESCRIPTION
Adds a simple API to store GHA jobs with data on when they were queued, when they started, and when they completed. I'm not adding automated testing here, at least not right now -- Sherlock's tests will check that this won't break anything else, and I just want to move as quickly as possible to start collecting data.