### PR TITLE
[DDO-3577] Expose GHA job metrics

### DIFF
--- a/sherlock/internal/api/sherlock/github_actions_jobs_v3_upsert.go
+++ b/sherlock/internal/api/sherlock/github_actions_jobs_v3_upsert.go
@@ -1,12 +1,17 @@
 package sherlock
 
 import (
+	"context"
 	"fmt"
 	"github.com/broadinstitute/sherlock/sherlock/internal/authentication"
 	"github.com/broadinstitute/sherlock/sherlock/internal/errors"
+	"github.com/broadinstitute/sherlock/sherlock/internal/metrics"
 	"github.com/broadinstitute/sherlock/sherlock/internal/models"
 	"github.com/gin-gonic/gin"
-	"gorm.io/gorm/clause"
+	"github.com/rs/zerolog/log"
+	"go.opencensus.io/stats"
+	"go.opencensus.io/tag"
+	"math"
 	"net/http"
 )
 
@@ -49,10 +54,82 @@ func githubActionsJobsV3Upsert(ctx *gin.Context) {
 		return
 	}
 
-	var result models.GithubActionsJob
-	if err = db.Preload(clause.Associations).First(&result, toUpsert.ID).Error; err != nil {
-		errors.AbortRequest(ctx, err)
-		return
+	ctx.JSON(http.StatusCreated, githubActionsJobFromModel(toUpsert))
+
+	// We're done with the actual request and would be good to return, but let's fire
+	// off some metrics if the job completed
+	if toUpsert.JobTerminalAt != nil && !toUpsert.JobTerminalAt.IsZero() &&
+		toUpsert.Status != nil && *toUpsert.Status != "skipped" {
+
+		// If the job has a completed timestamp and wasn't skipped, calculate how long
+		// it was queued and how long it was running
+		var queuedSeconds, runningSeconds int64
+		if toUpsert.JobCreatedAt != nil && !toUpsert.JobCreatedAt.IsZero() &&
+			toUpsert.JobStartedAt != nil && !toUpsert.JobStartedAt.IsZero() {
+			queuedSeconds = int64(math.Ceil(toUpsert.JobStartedAt.Sub(*toUpsert.JobCreatedAt).Seconds()))
+		}
+		if toUpsert.JobStartedAt != nil && !toUpsert.JobStartedAt.IsZero() &&
+			toUpsert.JobTerminalAt != nil && !toUpsert.JobTerminalAt.IsZero() {
+			runningSeconds = int64(math.Ceil(toUpsert.JobTerminalAt.Sub(*toUpsert.JobStartedAt).Seconds()))
+		}
+
+		// If either of those times are non-zero, we'll report both as metrics
+		// (GHA internals are complex, and a good way to understand if a job
+		// actually happened is to check if time elapsed during it)
+		if queuedSeconds > 0 || runningSeconds > 0 {
+
+			// We'll make a new context for the tags and add the base ones
+			var tagCtx context.Context
+			if tagCtx, err = tag.New(ctx,
+				tag.Upsert(metrics.GithubActionsOrganizationKey, toUpsert.GithubActionsOwner),
+				tag.Upsert(metrics.GithubActionsRepoKey, fmt.Sprintf("%s/%s", toUpsert.GithubActionsOwner, toUpsert.GithubActionsRepo))); err != nil {
+				log.Error().Err(err).Msg("unable to create tag context")
+				return
+			}
+
+			// It's potentially helpful to include the file of the workflow that
+			// defined the job. We don't have that info here, but the CiRun table
+			// might, if it already got a webhook payload for the overall workflow.
+			if toUpsert.GithubActionsRunID != 0 && toUpsert.GithubActionsAttemptNumber != 0 {
+				var matchingWorkflowFiles []string
+				if err = db.
+					Model(&models.CiRun{}).
+					Where(&models.CiRun{
+						GithubActionsRunID:         toUpsert.GithubActionsRunID,
+						GithubActionsAttemptNumber: toUpsert.GithubActionsAttemptNumber,
+					}).
+					Limit(1).
+					Pluck("github_actions_workflow_path", &matchingWorkflowFiles).Error; err != nil {
+					log.Error().Err(err).Msg("errored finding matching workflow runs for job")
+					return
+				} else if len(matchingWorkflowFiles) > 0 {
+					// We have a match for the workflow file, so we'll mutate the tag
+					// context to include it
+					if tagCtx, err = tag.New(tagCtx,
+						tag.Upsert(metrics.GithubActionsWorkflowFileKey, matchingWorkflowFiles[0])); err != nil {
+						log.Error().Err(err).Msg("unable to create tag context")
+						return
+					}
+				}
+			}
+
+			// Send off the queued time
+			if tagCtx, err = tag.New(tagCtx,
+				tag.Upsert(metrics.GithubActionsJobStageKey, "queued")); err != nil {
+				log.Error().Err(err).Msg("unable to create tag context")
+				return
+			} else {
+				stats.Record(tagCtx, metrics.GithubActionsJobLatencyMeasure.M(queuedSeconds))
+			}
+
+			// Send off the running time
+			if tagCtx, err = tag.New(tagCtx,
+				tag.Upsert(metrics.GithubActionsJobStageKey, "running")); err != nil {
+				log.Error().Err(err).Msg("unable to create tag context")
+				return
+			} else {
+				stats.Record(tagCtx, metrics.GithubActionsJobLatencyMeasure.M(runningSeconds))
+			}
+		}
 	}
-	ctx.JSON(http.StatusCreated, githubActionsJobFromModel(result))
 }

--- a/sherlock/internal/metrics/metrics.go
+++ b/sherlock/internal/metrics/metrics.go
@@ -65,6 +65,11 @@ var (
 		"sherlock/response_latency",
 		"the latency of responses served from sherlock",
 		"ms")
+	GithubActionsJobLatencyMeasure = stats.Int64(
+		"sherlock/github_actions_job_latency",
+		"the latency of GitHub Actions jobs",
+		"seconds",
+	)
 )
 
 var (
@@ -80,9 +85,11 @@ var (
 	PagerdutyRequestTypeKey       = tag.MustNewKey("pd_request_type")
 	PagerdutyResponseCodeKey      = tag.MustNewKey("pd_response_code")
 	GithubActionsRepoKey          = tag.MustNewKey("gha_repo")
+	GithubActionsOrganizationKey  = tag.MustNewKey("gha_organization")
 	GithubActionsWorkflowFileKey  = tag.MustNewKey("gha_workflow_file")
 	GithubActionsOutcomeKey       = tag.MustNewKey("gha_outcome")
 	GithubActionsRetryKey         = tag.MustNewKey("gha_retry")
+	GithubActionsJobStageKey      = tag.MustNewKey("gha_job_stage")
 	RouteKey                      = tag.MustNewKey("route")
 	MethodKey                     = tag.MustNewKey("method")
 	StatusKey                     = tag.MustNewKey("status")
@@ -187,6 +194,22 @@ var (
 		// [>=0ms, >=25ms, >=50ms, >=75ms, >=100ms, >=200ms, >=400ms, >=600ms, >=800ms, >=1s, >=2s, >=4s, >=6s, >=8s, >=10s]
 		Aggregation: view.Distribution(0, 25, 50, 75, 100, 200, 400, 600, 800, 1000, 2000, 4000, 6000, 8000, 10000),
 	}
+	GithubActionsJobCountView = &view.View{
+		Name:        "github_actions_job_count",
+		Measure:     GithubActionsJobLatencyMeasure,
+		TagKeys:     []tag.Key{GithubActionsOrganizationKey, GithubActionsRepoKey, GithubActionsJobStageKey, GithubActionsWorkflowFileKey},
+		Description: "The number of GitHub Actions jobs",
+		Aggregation: view.Count(),
+	}
+	GithubActionsJobLatencyView = &view.View{
+		Name:        "github_actions_job_latency",
+		Measure:     GithubActionsJobLatencyMeasure,
+		TagKeys:     []tag.Key{GithubActionsOrganizationKey, GithubActionsRepoKey, GithubActionsJobStageKey, GithubActionsWorkflowFileKey},
+		Description: "The distribution of the latencies of GitHub Actions jobs",
+		// Latency in buckets:
+		// [>=0s, >=2s, >=4s, >=6s, >=8s, >=10s, >=20s, >=40s, >=60s, >=90s, >=2m, >=3m, >=4m, >=5m, >=10m, >=15m, >=20m, >=30m, >=40m, >=50m, >=70m, >=90m, >=120m]
+		Aggregation: view.Distribution(0, 2, 4, 6, 8, 10, 20, 40, 60, 90, 120, 180, 240, 300, 600, 900, 1200, 1800, 2400, 3000, 4200, 5400, 7200),
+	}
 )
 
 func RegisterViews() error {
@@ -205,5 +228,7 @@ func RegisterViews() error {
 		GithubActions7DayTotalDurationView,
 		ResponseCountView,
 		ResponseLatencyView,
+		GithubActionsJobCountView,
+		GithubActionsJobLatencyView,
 	)
 }


### PR DESCRIPTION
I decided to expose these metrics like real-time latency, rather than building out a system to generate them from the database. It's just a judgement call based on how this data will be used and the volume -- I think this is the right way to do it. We're still collecting the data, so if we change our mind we can.

## Testing

Used API locally and checked that the expected metrics get emitted

## Risk

Lower than it would be otherwise, there's no impact to existing metrics with this approach