### PR TITLE
[DDO-3609] Parse mentionBool upon creation

### DIFF
--- a/sherlock/internal/api/sherlock/slack_deploy_hooks_v3.go
+++ b/sherlock/internal/api/sherlock/slack_deploy_hooks_v3.go
@@ -12,8 +12,8 @@ type SlackDeployHookV3 struct {
 }
 
 type SlackDeployHookFields struct {
-	SlackChannel  *string `json:"slackChannel,omitempty" form:"slackChannel"`
-	MentionPeople *bool   `json:"mentionPeople,omitempty" form:"mentionPeople"`
+	SlackChannel  *string `json:"slackChannel" form:"slackChannel"`
+	MentionPeople *bool   `json:"mentionPeople" form:"mentionPeople"`
 }
 
 func (s SlackDeployHookV3) toModel(db *gorm.DB) (models.SlackDeployHook, error) {

--- a/sherlock/internal/api/sherlock/slack_deploy_hooks_v3.go
+++ b/sherlock/internal/api/sherlock/slack_deploy_hooks_v3.go
@@ -12,8 +12,8 @@ type SlackDeployHookV3 struct {
 }
 
 type SlackDeployHookFields struct {
-	SlackChannel  *string `json:"slackChannel" form:"slackChannel"`
-	MentionPeople *bool   `json:"mentionPeople" form:"mentionPeople"`
+	SlackChannel  *string `json:"slackChannel,omitempty" form:"slackChannel"`
+	MentionPeople *bool   `json:"mentionPeople,omitempty" form:"mentionPeople"`
 }
 
 func (s SlackDeployHookV3) toModel(db *gorm.DB) (models.SlackDeployHook, error) {

--- a/sherlock/internal/api/sherlock/slack_deploy_hooks_v3_create.go
+++ b/sherlock/internal/api/sherlock/slack_deploy_hooks_v3_create.go
@@ -51,8 +51,9 @@ func slackDeployHooksV3Create(ctx *gin.Context) {
 	}
 
 	hook := models.SlackDeployHook{
-		Trigger:      trigger,
-		SlackChannel: body.SlackChannel,
+		Trigger:       trigger,
+		MentionPeople: body.MentionPeople,
+		SlackChannel:  body.SlackChannel,
 	}
 	if err = db.Create(&hook).Error; err != nil {
 		errors.AbortRequest(ctx, err)

--- a/sherlock/internal/api/sherlock/slack_deploy_hooks_v3_create_test.go
+++ b/sherlock/internal/api/sherlock/slack_deploy_hooks_v3_create_test.go
@@ -84,4 +84,32 @@ func (s *handlerSuite) TestSlackDeployHooksV3Create() {
 	if s.NotNil(got.OnEnvironment) {
 		s.Equal(s.TestData.Environment_Dev().Name, *got.OnEnvironment)
 	}
+	if s.NotNil(got.MentionPeople) {
+		s.False(*got.MentionPeople)
+	}
+}
+
+func (s *handlerSuite) TestSlackDeployHooksV3Create_mentionPeople() {
+	var got SlackDeployHookV3
+	code := s.HandleRequest(
+		s.NewRequest("POST", "/api/deploy-hooks/slack/v3", SlackDeployHookV3Create{
+			DeployHookTriggerConfigV3: DeployHookTriggerConfigV3{
+				OnEnvironment: utils.PointerTo(s.TestData.Environment_Dev().Name),
+			},
+			SlackDeployHookFields: SlackDeployHookFields{
+				SlackChannel:  utils.PointerTo("channel"),
+				MentionPeople: utils.PointerTo(true),
+			},
+		}),
+		&got)
+	s.Equal(http.StatusCreated, code)
+	if s.NotNil(got.SlackChannel) {
+		s.Equal("channel", *got.SlackChannel)
+	}
+	if s.NotNil(got.OnEnvironment) {
+		s.Equal(s.TestData.Environment_Dev().Name, *got.OnEnvironment)
+	}
+	if s.NotNil(got.MentionPeople) {
+		s.True(*got.MentionPeople)
+	}
 }

--- a/sherlock/internal/api/sherlock/slack_deploy_hooks_v3_create_test.go
+++ b/sherlock/internal/api/sherlock/slack_deploy_hooks_v3_create_test.go
@@ -84,9 +84,7 @@ func (s *handlerSuite) TestSlackDeployHooksV3Create() {
 	if s.NotNil(got.OnEnvironment) {
 		s.Equal(s.TestData.Environment_Dev().Name, *got.OnEnvironment)
 	}
-	if s.NotNil(got.MentionPeople) {
-		s.False(*got.MentionPeople)
-	}
+	s.Nil(got.MentionPeople)
 }
 
 func (s *handlerSuite) TestSlackDeployHooksV3Create_mentionPeople() {


### PR DESCRIPTION
turns out that POST /api/deploy-hooks/slack/v3 wasn't actually parsing the mentionPeople field. PATCH was working so that's why we didn't really notice.

I just missed the field in the handler, one line fix

## Testing

Added a test for the positive case, added validation of the existing negative case

## Risk

Very low