### PR TITLE
[DDO-3625] Sherlock Database IAM Auth, Step 2 (Docs/Testing)

### DIFF
--- a/dev/local-with-pg.yaml
+++ b/dev/local-with-pg.yaml
@@ -22,7 +22,7 @@ services:
 
   database:
     container_name: postgres
-    image: postgres:13
+    image: postgres:15
     ports:
       - "5432:5432"
     expose: 

--- a/makefile
+++ b/makefile
@@ -14,14 +14,14 @@ local-down:
 ## Normal testing (depends on install-pact)
 
 test:
-	docker run --name test-postgres -e POSTGRES_PASSWORD=password -e POSTGRES_USER=sherlock -d -p 5431:5432 postgres:13 -c max_connections=200
+	docker run --name test-postgres -e POSTGRES_PASSWORD=password -e POSTGRES_USER=sherlock -d -p 5431:5432 postgres:15 -c max_connections=200
 	cd go-shared && go test -p 1 -race ./...
 	cd sherlock && go test -p 1 -race ./...
 	docker stop test-postgres
 	docker rm test-postgres
 
 test-with-coverage:
-	docker run --name test-postgres -e POSTGRES_PASSWORD=password -e POSTGRES_USER=sherlock -d -p 5431:5432 postgres:13 -c max_connections=200
+	docker run --name test-postgres -e POSTGRES_PASSWORD=password -e POSTGRES_USER=sherlock -d -p 5431:5432 postgres:15 -c max_connections=200
 	cd go-shared && go test -p 1 -race -coverprofile=cover.out -covermode=atomic ./...
 	cd sherlock && go test -p 1 -race -coverprofile=cover.out -covermode=atomic ./...
 	docker stop test-postgres
@@ -34,7 +34,7 @@ install-pact:
 	sudo -s $$(which pact-go) -l DEBUG install -f
 
 test-pact-provider:
-	docker run --name test-postgres -e POSTGRES_PASSWORD=password -e POSTGRES_USER=sherlock -d -p 5431:5432 postgres:13 -c max_connections=200
+	docker run --name test-postgres -e POSTGRES_PASSWORD=password -e POSTGRES_USER=sherlock -d -p 5431:5432 postgres:15 -c max_connections=200
 	cd sherlock && go test -p 1 -v -race -ldflags="-X 'github.com/broadinstitute/sherlock/go-shared/pkg/version.BuildVersion=${BUILD_VERSION}'" ./internal/pact/...
 
 document-pact-provider:
@@ -46,7 +46,7 @@ document-pact-provider:
 ## Long running test database (so tests can be run from GoLand)
 
 pg-up:
-	docker run --name test-postgres -e POSTGRES_PASSWORD=password -e POSTGRES_USER=sherlock -d -p 5431:5432 postgres:13 -c max_connections=200
+	docker run --name test-postgres -e POSTGRES_PASSWORD=password -e POSTGRES_USER=sherlock -d -p 5431:5432 postgres:15 -c max_connections=200
 
 pg-down:
 	docker stop test-postgres

--- a/sherlock/db/README.md
+++ b/sherlock/db/README.md
@@ -1,18 +1,16 @@
 # How to rollback the PROD DATABASE to a previous migration version
 
-With Google's cloud_sql_proxy ([link](https://cloud.google.com/sql/docs/mysql/sql-proxy#install)) and gcloud authenticated with DevOps user credentials:
+With Google's cloud-sql-proxy ([link](https://cloud.google.com/sql/docs/postgres/sql-proxy#mac-m1)) and gcloud authenticated with DevOps user credentials:
 ```bash
-export SHERLOCK_DB_INSTANCE_PROJECT=$(vault read -field=project secret/suitable/sherlock/prod/postgres/instance)
-export SHERLOCK_DB_INSTANCE_REGION=$(vault read -field=region secret/suitable/sherlock/prod/postgres/instance)
-export SHERLOCK_DB_INSTANCE_NAME=$(vault read -field=name secret/suitable/sherlock/prod/postgres/instance)
-cloud_sql_proxy -instances=$SHERLOCK_DB_INSTANCE_PROJECT:$SHERLOCK_DB_INSTANCE_REGION:$SHERLOCK_DB_INSTANCE_NAME=tcp:5432
+export SHERLOCK_DB_CONNECTION_NAME=$(gcloud secrets versions access latest --secret=sherlock-cloudsql-maintenance-credentials --project=dsp-devops-super-prod | jq -r '.instance')
+cloud-sql-proxy $SHERLOCK_DB_CONNECTION_NAME
 ```
 
 In a new console, with golang-migrate (`brew install golang-migrate`):
 ```bash
-export SHERLOCK_DB_NAME=$(vault read -field=db secret/suitable/sherlock/prod/postgres/sherlock-db-creds)
-export SHERLOCK_DB_USER=$(vault read -field=username secret/suitable/sherlock/prod/postgres/sherlock-db-creds)
-export SHERLOCK_DB_PASSWORD=$(vault read -field=password secret/suitable/sherlock/prod/postgres/sherlock-db-creds)
+export SHERLOCK_DB_NAME=$(gcloud secrets versions access latest --secret=sherlock-cloudsql-maintenance-credentials --project=dsp-devops-super-prod | jq -r '.database')
+export SHERLOCK_DB_USER=$(gcloud secrets versions access latest --secret=sherlock-cloudsql-maintenance-credentials --project=dsp-devops-super-prod | jq -r '.username')
+export SHERLOCK_DB_PASSWORD=$(gcloud secrets versions access latest --secret=sherlock-cloudsql-maintenance-credentials --project=dsp-devops-super-prod | jq -r '.password')
 export SHERLOCK_DB_URL="postgres://$SHERLOCK_DB_USER:$SHERLOCK_DB_PASSWORD@localhost:5432/$SHERLOCK_DB_NAME?sslmode=disable"
 migrate -path ./db/migrations -database $SHERLOCK_DB_URL version
 ```


### PR DESCRIPTION
Steps:

1. Add IAM database users for automated access and a built-in user for maintenance access (https://github.com/broadinstitute/terraform-ap-deployments/pull/1524)
2. Cut over codebase to IAM user and docs to maintenance user **<- We're here**
3. Remove other users from database

This PR updates docs to reference IAM database users and test harnesses to use Postgres 15, which is what we had to jump to for this change to work.

I'm jumping the shark a tiny bit here and just going ahead and mentioning the super-prod project name because we're only a few days away from that being correct.