### PR TITLE
[DDO-3622] Cut over URLs

### DIFF
--- a/.github/workflows/client-get-chart-release.yaml
+++ b/.github/workflows/client-get-chart-release.yaml
@@ -3,7 +3,7 @@ name: Get Chart Release
 # This workflow provides GitHub Actions native access to information about Sherlock chart releases (chart instances).
 #
 # The caller repository must have Workload Identity Federation configured to allow impersonation of the
-# "dsp-tools-iap-access@dsp-tools-k8s.iam.gserviceaccount.com" service account; steps 1 and 2 of the documentation:
+# "gha-iap-accessor@dsp-devops-super-prod.iam.gserviceaccount.com" service account; steps 1 and 2 of the documentation:
 # https://docs.google.com/document/d/1bnhDmWQHAMat_Saoa_z28FHwXmGWw6kywjdbKf208h4/edit
 #
 # With that configured, here's how you can call this workflow:
@@ -66,9 +66,9 @@ jobs:
         uses: google-github-actions/auth@v2
         with:
           workload_identity_provider: 'projects/1038484894585/locations/global/workloadIdentityPools/github-wi-pool/providers/github-wi-provider'
-          service_account: 'dsp-tools-iap-access@dsp-tools-k8s.iam.gserviceaccount.com'
+          service_account: 'gha-iap-accessor@dsp-devops-super-prod.iam.gserviceaccount.com'
           token_format: 'id_token'
-          id_token_audience: '1038484894585-k8qvf7l876733laev0lm8kenfa2lj6bn.apps.googleusercontent.com'
+          id_token_audience: '257801540345-1gqi6qi66bjbssbv01horu9243el2r8b.apps.googleusercontent.com'
           id_token_include_email: true
           create_credentials_file: false
           export_environment_variables: false

--- a/.github/workflows/client-get-chart-release.yaml
+++ b/.github/workflows/client-get-chart-release.yaml
@@ -47,8 +47,8 @@ on:
         value: ${{ jobs.get-chart-release.outputs.cluster }}
 
 env:
-  SHERLOCK_PROD_URL: 'https://sherlock.dsp-devops.broadinstitute.org'
-  BEEHIVE_PROD_URL: 'https://beehive.dsp-devops.broadinsitute.org'
+  SHERLOCK_PROD_URL: 'https://sherlock.dsp-devops-prod.broadinstitute.org'
+  BEEHIVE_PROD_URL: 'https://beehive.dsp-devops-prod.broadinsitute.org'
   BEEHIVE_PROD_VANITY_URL: 'https://broad.io/beehive'
 
 jobs:

--- a/.github/workflows/client-get-environment.yaml
+++ b/.github/workflows/client-get-environment.yaml
@@ -44,8 +44,8 @@ on:
         value: ${{ jobs.get-environment.outputs.owner }}
 
 env:
-  SHERLOCK_PROD_URL: 'https://sherlock.dsp-devops.broadinstitute.org'
-  BEEHIVE_PROD_URL: 'https://beehive.dsp-devops.broadinsitute.org'
+  SHERLOCK_PROD_URL: 'https://sherlock.dsp-devops-prod.broadinstitute.org'
+  BEEHIVE_PROD_URL: 'https://beehive.dsp-devops-prod.broadinsitute.org'
   BEEHIVE_PROD_VANITY_URL: 'https://broad.io/beehive'
 
 jobs:

--- a/.github/workflows/client-get-environment.yaml
+++ b/.github/workflows/client-get-environment.yaml
@@ -3,7 +3,7 @@ name: Get Environment
 # This workflow provides GitHub Actions native access to information about Sherlock environments.
 #
 # The caller repository must have Workload Identity Federation configured to allow impersonation of the
-# "dsp-tools-iap-access@dsp-tools-k8s.iam.gserviceaccount.com" service account; steps 1 and 2 of the documentation:
+# "gha-iap-accessor@dsp-devops-super-prod.iam.gserviceaccount.com" service account; steps 1 and 2 of the documentation:
 # https://docs.google.com/document/d/1bnhDmWQHAMat_Saoa_z28FHwXmGWw6kywjdbKf208h4/edit
 #
 # With that configured, here's how you can call this workflow:
@@ -62,9 +62,9 @@ jobs:
         uses: google-github-actions/auth@v2
         with:
           workload_identity_provider: 'projects/1038484894585/locations/global/workloadIdentityPools/github-wi-pool/providers/github-wi-provider'
-          service_account: 'dsp-tools-iap-access@dsp-tools-k8s.iam.gserviceaccount.com'
+          service_account: 'gha-iap-accessor@dsp-devops-super-prod.iam.gserviceaccount.com'
           token_format: 'id_token'
-          id_token_audience: '1038484894585-k8qvf7l876733laev0lm8kenfa2lj6bn.apps.googleusercontent.com'
+          id_token_audience: '257801540345-1gqi6qi66bjbssbv01horu9243el2r8b.apps.googleusercontent.com'
           id_token_include_email: true
           create_credentials_file: false
           export_environment_variables: false

--- a/.github/workflows/client-refresh-environment.yaml
+++ b/.github/workflows/client-refresh-environment.yaml
@@ -69,8 +69,8 @@ on:
         description: "The name of the environment to update"
 
 env:
-  SHERLOCK_PROD_URL: 'https://sherlock.dsp-devops.broadinstitute.org'
-  BEEHIVE_PROD_URL: 'https://beehive.dsp-devops.broadinsitute.org'
+  SHERLOCK_PROD_URL: 'https://sherlock.dsp-devops-prod.broadinstitute.org'
+  BEEHIVE_PROD_URL: 'https://beehive.dsp-devops-prod.broadinsitute.org'
   BEEHIVE_PROD_VANITY_URL: 'https://broad.io/beehive'
 
 jobs:

--- a/.github/workflows/client-refresh-environment.yaml
+++ b/.github/workflows/client-refresh-environment.yaml
@@ -6,7 +6,7 @@ name: Refresh Environment
 # Note that this workflow cannot modify anything marked within Sherlock as requiring suitability.
 #
 # The caller repository must have Workload Identity Federation configured to allow impersonation of the
-# "dsp-tools-iap-access@dsp-tools-k8s.iam.gserviceaccount.com" service account; steps 1 and 2 of the documentation:
+# "gha-iap-accessor@dsp-devops-super-prod.iam.gserviceaccount.com" service account; steps 1 and 2 of the documentation:
 # https://docs.google.com/document/d/1bnhDmWQHAMat_Saoa_z28FHwXmGWw6kywjdbKf208h4/edit
 #
 # With that configured, here's how you can call this workflow:
@@ -113,9 +113,9 @@ jobs:
         uses: google-github-actions/auth@v2
         with:
           workload_identity_provider: 'projects/1038484894585/locations/global/workloadIdentityPools/github-wi-pool/providers/github-wi-provider'
-          service_account: 'dsp-tools-iap-access@dsp-tools-k8s.iam.gserviceaccount.com'
+          service_account: 'gha-iap-accessor@dsp-devops-super-prod.iam.gserviceaccount.com'
           token_format: 'id_token'
-          id_token_audience: '1038484894585-k8qvf7l876733laev0lm8kenfa2lj6bn.apps.googleusercontent.com'
+          id_token_audience: '257801540345-1gqi6qi66bjbssbv01horu9243el2r8b.apps.googleusercontent.com'
           id_token_include_email: true
           create_credentials_file: false
           export_environment_variables: false

--- a/.github/workflows/client-report-app-version.yaml
+++ b/.github/workflows/client-report-app-version.yaml
@@ -3,7 +3,7 @@ name: Report App Version
 # This workflow is meant to be called from other repositories' workflows to report a new app version to Sherlock.
 #
 # The caller repository must have Workload Identity Federation configured to allow impersonation of the
-# "dsp-tools-iap-access@dsp-tools-k8s.iam.gserviceaccount.com" service account; steps 1 and 2 of the documentation:
+# "gha-iap-accessor@dsp-devops-super-prod.iam.gserviceaccount.com" service account; steps 1 and 2 of the documentation:
 # https://docs.google.com/document/d/1bnhDmWQHAMat_Saoa_z28FHwXmGWw6kywjdbKf208h4/edit
 #
 # With that configured, here's how you can call this workflow from whatever workflow currently publishes the app:
@@ -239,9 +239,9 @@ jobs:
         uses: google-github-actions/auth@v2
         with:
           workload_identity_provider: 'projects/1038484894585/locations/global/workloadIdentityPools/github-wi-pool/providers/github-wi-provider'
-          service_account: 'dsp-tools-iap-access@dsp-tools-k8s.iam.gserviceaccount.com'
+          service_account: 'gha-iap-accessor@dsp-devops-super-prod.iam.gserviceaccount.com'
           token_format: 'id_token'
-          id_token_audience: '1038484894585-k8qvf7l876733laev0lm8kenfa2lj6bn.apps.googleusercontent.com'
+          id_token_audience: '257801540345-1gqi6qi66bjbssbv01horu9243el2r8b.apps.googleusercontent.com'
           id_token_include_email: true
           create_credentials_file: false
           export_environment_variables: false

--- a/.github/workflows/client-report-app-version.yaml
+++ b/.github/workflows/client-report-app-version.yaml
@@ -90,8 +90,8 @@ on:
         description: "Entirely omit the parent field, useful when the repository doesn't tag versions"
 
 env:
-  SHERLOCK_PROD_URL: 'https://sherlock.dsp-devops.broadinstitute.org'
-  BEEHIVE_PROD_URL: 'https://beehive.dsp-devops.broadinsitute.org'
+  SHERLOCK_PROD_URL: 'https://sherlock.dsp-devops-prod.broadinstitute.org'
+  BEEHIVE_PROD_URL: 'https://beehive.dsp-devops-prod.broadinsitute.org'
   BEEHIVE_PROD_VANITY_URL: 'https://broad.io/beehive'
 
 jobs:

--- a/.github/workflows/client-report-chart-version.yaml
+++ b/.github/workflows/client-report-chart-version.yaml
@@ -94,8 +94,8 @@ on:
         description: "Optionally provide a custom description for the version instead of the commit message"
 
 env:
-  SHERLOCK_PROD_URL: 'https://sherlock.dsp-devops.broadinstitute.org'
-  BEEHIVE_PROD_URL: 'https://beehive.dsp-devops.broadinsitute.org'
+  SHERLOCK_PROD_URL: 'https://sherlock.dsp-devops-prod.broadinstitute.org'
+  BEEHIVE_PROD_URL: 'https://beehive.dsp-devops-prod.broadinsitute.org'
   BEEHIVE_PROD_VANITY_URL: 'https://broad.io/beehive'
 
 jobs:

--- a/.github/workflows/client-report-chart-version.yaml
+++ b/.github/workflows/client-report-chart-version.yaml
@@ -3,7 +3,7 @@ name: Report Chart Version
 # This workflow is meant to be called from other repositories' workflows to report a new chart version to Sherlock.
 #
 # The caller repository must have Workload Identity Federation configured to allow impersonation of the
-# "dsp-tools-iap-access@dsp-tools-k8s.iam.gserviceaccount.com" service account; steps 1 and 2 of the documentation:
+# "gha-iap-accessor@dsp-devops-super-prod.iam.gserviceaccount.com" service account; steps 1 and 2 of the documentation:
 # https://docs.google.com/document/d/1bnhDmWQHAMat_Saoa_z28FHwXmGWw6kywjdbKf208h4/edit
 #
 # With that configured, here's how you can call this workflow from whatever workflow currently publishes the chart:
@@ -218,9 +218,9 @@ jobs:
         uses: google-github-actions/auth@v2
         with:
           workload_identity_provider: 'projects/1038484894585/locations/global/workloadIdentityPools/github-wi-pool/providers/github-wi-provider'
-          service_account: 'dsp-tools-iap-access@dsp-tools-k8s.iam.gserviceaccount.com'
+          service_account: 'gha-iap-accessor@dsp-devops-super-prod.iam.gserviceaccount.com'
           token_format: 'id_token'
-          id_token_audience: '1038484894585-k8qvf7l876733laev0lm8kenfa2lj6bn.apps.googleusercontent.com'
+          id_token_audience: '257801540345-1gqi6qi66bjbssbv01horu9243el2r8b.apps.googleusercontent.com'
           id_token_include_email: true
           create_credentials_file: false
           export_environment_variables: false

--- a/.github/workflows/client-report-workflow.yaml
+++ b/.github/workflows/client-report-workflow.yaml
@@ -203,7 +203,7 @@ on:
           and you'd rather this step still succeed if it doesn't.
 
 env:
-  SHERLOCK_PROD_URL: "https://sherlock.dsp-devops.broadinstitute.org"
+  SHERLOCK_PROD_URL: "https://sherlock.dsp-devops-prod.broadinstitute.org"
 
 jobs:
   report-workflow-relations:

--- a/.github/workflows/client-report-workflow.yaml
+++ b/.github/workflows/client-report-workflow.yaml
@@ -4,7 +4,7 @@ name: Report GitHub Actions Workflow
 # Sherlock.
 #
 # The caller repository must have Workload Identity Federation configured to allow impersonation of the
-# "dsp-tools-iap-access@dsp-tools-k8s.iam.gserviceaccount.com" service account; steps 1 and 2 of the documentation:
+# "gha-iap-accessor@dsp-devops-super-prod.iam.gserviceaccount.com" service account; steps 1 and 2 of the documentation:
 # https://docs.google.com/document/d/1bnhDmWQHAMat_Saoa_z28FHwXmGWw6kywjdbKf208h4/edit
 #
 # With that configured, here's an example of how you can call this workflow (all fields optional and many more available):
@@ -280,9 +280,9 @@ jobs:
         uses: google-github-actions/auth@v2
         with:
           workload_identity_provider: "projects/1038484894585/locations/global/workloadIdentityPools/github-wi-pool/providers/github-wi-provider"
-          service_account: "dsp-tools-iap-access@dsp-tools-k8s.iam.gserviceaccount.com"
+          service_account: "gha-iap-accessor@dsp-devops-super-prod.iam.gserviceaccount.com"
           token_format: "id_token"
-          id_token_audience: "1038484894585-k8qvf7l876733laev0lm8kenfa2lj6bn.apps.googleusercontent.com"
+          id_token_audience: "257801540345-1gqi6qi66bjbssbv01horu9243el2r8b.apps.googleusercontent.com"
           id_token_include_email: true
           create_credentials_file: false
           export_environment_variables: false

--- a/.github/workflows/client-set-environment-app-version.yaml
+++ b/.github/workflows/client-set-environment-app-version.yaml
@@ -88,8 +88,8 @@ on:
         description: "The name of the environment to update"
 
 env:
-  SHERLOCK_PROD_URL: 'https://sherlock.dsp-devops.broadinstitute.org'
-  BEEHIVE_PROD_URL: 'https://beehive.dsp-devops.broadinsitute.org'
+  SHERLOCK_PROD_URL: 'https://sherlock.dsp-devops-prod.broadinstitute.org'
+  BEEHIVE_PROD_URL: 'https://beehive.dsp-devops-prod.broadinsitute.org'
   BEEHIVE_PROD_VANITY_URL: 'https://broad.io/beehive'
 
 jobs:

--- a/.github/workflows/client-set-environment-app-version.yaml
+++ b/.github/workflows/client-set-environment-app-version.yaml
@@ -6,7 +6,7 @@ name: Set Environment App Version
 # Note that this workflow cannot modify anything marked within Sherlock as requiring suitability.
 #
 # The caller repository must have Workload Identity Federation configured to allow impersonation of the
-# "dsp-tools-iap-access@dsp-tools-k8s.iam.gserviceaccount.com" service account; steps 1 and 2 of the documentation:
+# "gha-iap-accessor@dsp-devops-super-prod.iam.gserviceaccount.com" service account; steps 1 and 2 of the documentation:
 # https://docs.google.com/document/d/1bnhDmWQHAMat_Saoa_z28FHwXmGWw6kywjdbKf208h4/edit
 #
 # With that configured, here's how you can call this workflow from whatever workflow currently publishes the app:
@@ -142,9 +142,9 @@ jobs:
         uses: google-github-actions/auth@v2
         with:
           workload_identity_provider: 'projects/1038484894585/locations/global/workloadIdentityPools/github-wi-pool/providers/github-wi-provider'
-          service_account: 'dsp-tools-iap-access@dsp-tools-k8s.iam.gserviceaccount.com'
+          service_account: 'gha-iap-accessor@dsp-devops-super-prod.iam.gserviceaccount.com'
           token_format: 'id_token'
-          id_token_audience: '1038484894585-k8qvf7l876733laev0lm8kenfa2lj6bn.apps.googleusercontent.com'
+          id_token_audience: '257801540345-1gqi6qi66bjbssbv01horu9243el2r8b.apps.googleusercontent.com'
           id_token_include_email: true
           create_credentials_file: false
           export_environment_variables: false

--- a/.github/workflows/client-set-environment-chart-version.yaml
+++ b/.github/workflows/client-set-environment-chart-version.yaml
@@ -90,8 +90,8 @@ on:
         description: "The name of the environment to update"
 
 env:
-  SHERLOCK_PROD_URL: 'https://sherlock.dsp-devops.broadinstitute.org'
-  BEEHIVE_PROD_URL: 'https://beehive.dsp-devops.broadinsitute.org'
+  SHERLOCK_PROD_URL: 'https://sherlock.dsp-devops-prod.broadinstitute.org'
+  BEEHIVE_PROD_URL: 'https://beehive.dsp-devops-prod.broadinsitute.org'
   BEEHIVE_PROD_VANITY_URL: 'https://broad.io/beehive'
 
 jobs:

--- a/.github/workflows/client-set-environment-chart-version.yaml
+++ b/.github/workflows/client-set-environment-chart-version.yaml
@@ -8,7 +8,7 @@ name: Set Environment Chart Version
 # Note that this workflow cannot modify anything marked within Sherlock as requiring suitability.
 #
 # The caller repository must have Workload Identity Federation configured to allow impersonation of the
-# "dsp-tools-iap-access@dsp-tools-k8s.iam.gserviceaccount.com" service account; steps 1 and 2 of the documentation:
+# "gha-iap-accessor@dsp-devops-super-prod.iam.gserviceaccount.com" service account; steps 1 and 2 of the documentation:
 # https://docs.google.com/document/d/1bnhDmWQHAMat_Saoa_z28FHwXmGWw6kywjdbKf208h4/edit
 #
 # With that configured, here's how you can call this workflow from whatever workflow currently publishes the app:
@@ -144,9 +144,9 @@ jobs:
         uses: google-github-actions/auth@v2
         with:
           workload_identity_provider: 'projects/1038484894585/locations/global/workloadIdentityPools/github-wi-pool/providers/github-wi-provider'
-          service_account: 'dsp-tools-iap-access@dsp-tools-k8s.iam.gserviceaccount.com'
+          service_account: 'gha-iap-accessor@dsp-devops-super-prod.iam.gserviceaccount.com'
           token_format: 'id_token'
-          id_token_audience: '1038484894585-k8qvf7l876733laev0lm8kenfa2lj6bn.apps.googleusercontent.com'
+          id_token_audience: '257801540345-1gqi6qi66bjbssbv01horu9243el2r8b.apps.googleusercontent.com'
           id_token_include_email: true
           create_credentials_file: false
           export_environment_variables: false

--- a/.github/workflows/test-auth-transparency.yaml
+++ b/.github/workflows/test-auth-transparency.yaml
@@ -23,9 +23,9 @@ jobs:
         uses: google-github-actions/auth@v2
         with:
           workload_identity_provider: 'projects/1038484894585/locations/global/workloadIdentityPools/github-wi-pool/providers/github-wi-provider'
-          service_account: 'dsp-tools-iap-access@dsp-tools-k8s.iam.gserviceaccount.com'
+          service_account: 'gha-iap-accessor@dsp-devops-super-prod.iam.gserviceaccount.com'
           token_format: 'id_token'
-          id_token_audience: '1038484894585-k8qvf7l876733laev0lm8kenfa2lj6bn.apps.googleusercontent.com'
+          id_token_audience: '257801540345-1gqi6qi66bjbssbv01horu9243el2r8b.apps.googleusercontent.com'
           id_token_include_email: true
           create_credentials_file: false
           export_environment_variables: false

--- a/.github/workflows/test-auth-transparency.yaml
+++ b/.github/workflows/test-auth-transparency.yaml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 env:
-  SHERLOCK_PROD_URL: 'https://sherlock.dsp-devops.broadinstitute.org'
+  SHERLOCK_PROD_URL: 'https://sherlock.dsp-devops-prod.broadinstitute.org'
   SHERLOCK_DEV_URL: 'https://sherlock-dev.dsp-devops.broadinstitute.org'
 
 jobs:

--- a/sherlock-go-client/client/sherlock_client.go
+++ b/sherlock-go-client/client/sherlock_client.go
@@ -35,7 +35,7 @@ var Default = NewHTTPClient(nil)
 const (
 	// DefaultHost is the default Host
 	// found in Meta (info) section of spec file
-	DefaultHost string = "sherlock.dsp-devops.broadinstitute.org"
+	DefaultHost string = "sherlock.dsp-devops-prod.broadinstitute.org"
 	// DefaultBasePath is the default BasePath
 	// found in Meta (info) section of spec file
 	DefaultBasePath string = "/"

--- a/sherlock-typescript-client/src/runtime.ts
+++ b/sherlock-typescript-client/src/runtime.ts
@@ -13,7 +13,7 @@
  */
 
 
-export const BASE_PATH = "https://sherlock.dsp-devops.broadinstitute.org".replace(/\/+$/, "");
+export const BASE_PATH = "https://sherlock.dsp-devops-prod.broadinstitute.org".replace(/\/+$/, "");
 
 export interface ConfigurationParameters {
     basePath?: string; // override base path
@@ -247,7 +247,7 @@ export class BaseAPI {
         next.middleware = this.middleware.slice();
         return next;
     }
-};
+}
 
 function isBlob(value: any): value is Blob {
     return typeof Blob !== 'undefined' && value instanceof Blob;

--- a/sherlock-webhook-proxy/pkg/handler.go
+++ b/sherlock-webhook-proxy/pkg/handler.go
@@ -27,7 +27,7 @@ import (
 )
 
 const (
-	// sherlockUrlEnvVar should be set like "https://sherlock.dsp-devops.broadinstitute.org" or "http://localhost:8080"
+	// sherlockUrlEnvVar should be set like "https://sherlock.dsp-devops-prod.broadinstitute.org" or "http://localhost:8080"
 	sherlockUrlEnvVar = "SHERLOCK_URL"
 	// iapTokenOverrideEnvVar overrides IAP-token generating behavior, to allow local dev
 	iapTokenOverrideEnvVar = "IAP_TOKEN"

--- a/sherlock/config/default_config.yaml
+++ b/sherlock/config/default_config.yaml
@@ -238,7 +238,7 @@ model:
         githubActionsWorkflowPath: .github/workflows/sync-environment.yaml
 
 beehive:
-    chartReleaseUrlFormatString: https://beehive.dsp-devops.broadinstitute.org/r/chart-release/%s
-    environmentUrlFormatString: https://beehive.dsp-devops.broadinstitute.org/r/environment/%s
-    pagerdutyIntegrationUrlFormatString: https://beehive.dsp-devops.broadinstitute.org/r/pagerduty-integration/%s
-    reviewChangesetsUrl: https://beehive.dsp-devops.broadinstitute.org/review-changesets
+    chartReleaseUrlFormatString: https://beehive.dsp-devops-prod.broadinstitute.org/r/chart-release/%s
+    environmentUrlFormatString: https://beehive.dsp-devops-prod.broadinstitute.org/r/environment/%s
+    pagerdutyIntegrationUrlFormatString: https://beehive.dsp-devops-prod.broadinstitute.org/r/pagerduty-integration/%s
+    reviewChangesetsUrl: https://beehive.dsp-devops-prod.broadinstitute.org/review-changesets

--- a/sherlock/docs/docs.go
+++ b/sherlock/docs/docs.go
@@ -9195,7 +9195,7 @@ const docTemplate = `{
 // SwaggerInfo holds exported Swagger Info so clients can modify it
 var SwaggerInfo = &swag.Spec{
 	Version:          "development",
-	Host:             "sherlock.dsp-devops.broadinstitute.org",
+	Host:             "sherlock.dsp-devops-prod.broadinstitute.org",
 	BasePath:         "",
 	Schemes:          []string{"https"},
 	Title:            "Sherlock",

--- a/sherlock/docs/swagger.json
+++ b/sherlock/docs/swagger.json
@@ -22,7 +22,7 @@
         },
         "version": "development"
     },
-    "host": "sherlock.dsp-devops.broadinstitute.org",
+    "host": "sherlock.dsp-devops-prod.broadinstitute.org",
     "paths": {
         "/api/app-versions/procedures/v3/changelog": {
             "get": {

--- a/sherlock/docs/swagger.yaml
+++ b/sherlock/docs/swagger.yaml
@@ -1671,7 +1671,7 @@ definitions:
           Will be set to true if the user account has no name and a GitHub account is linked.
         type: boolean
     type: object
-host: sherlock.dsp-devops.broadinstitute.org
+host: sherlock.dsp-devops-prod.broadinstitute.org
 info:
   contact:
     email: dsp-devops@broadinstitute.org

--- a/sherlock/internal/boot/router.go
+++ b/sherlock/internal/boot/router.go
@@ -28,7 +28,7 @@ import (
 //	@accept			json
 //	@produce		json
 
-//	@host	sherlock.dsp-devops.broadinstitute.org
+//	@host	sherlock.dsp-devops-prod.broadinstitute.org
 
 //	@contact.name	DSP DevOps
 //	@contact.email	dsp-devops@broadinstitute.org

--- a/sherlock/internal/hooks/slack_deploy_hook_utils_test.go
+++ b/sherlock/internal/hooks/slack_deploy_hook_utils_test.go
@@ -153,7 +153,7 @@ func Test_slackDeployHookBeehiveLink(t *testing.T) {
 					{Model: gorm.Model{ID: 2}},
 				},
 			},
-			want: "https://beehive.dsp-devops.broadinstitute.org/review-changesets?changeset=1&changeset=2",
+			want: "https://beehive.dsp-devops-prod.broadinstitute.org/review-changesets?changeset=1&changeset=2",
 		},
 	}
 	for _, tt := range tests {
@@ -251,11 +251,11 @@ func Test_slackDeployHookChangesetsToChangelogSections(t *testing.T) {
 			},
 			want: [][]string{
 				{
-					"*<https://beehive.dsp-devops.broadinstitute.org/r/chart-release/cr-1|cr-1>* [app 1.0.0⭢1.0.1]",
+					"*<https://beehive.dsp-devops-prod.broadinstitute.org/r/chart-release/cr-1|cr-1>* [app 1.0.0⭢1.0.1]",
 					"• *app 1.0.1*: a description",
 				},
 				{
-					"*<https://beehive.dsp-devops.broadinstitute.org/r/chart-release/cr-2|cr-2>* [configuration change]",
+					"*<https://beehive.dsp-devops-prod.broadinstitute.org/r/chart-release/cr-2|cr-2>* [configuration change]",
 					"• *No changelog entries found;* <beehive URL|Beehive might have more information>",
 				},
 			},

--- a/sherlock/internal/models/ci_run.go
+++ b/sherlock/internal/models/ci_run.go
@@ -182,7 +182,7 @@ func (c *CiRun) WebURL() string {
 		return fmt.Sprintf("%s/workflows/%s/%s", config.Config.String("argoWorkflows.url"), c.ArgoWorkflowsNamespace, c.ArgoWorkflowsName)
 	default:
 		// c.Platform is an enum so we should never be able to hit this case
-		return fmt.Sprintf("https://sherlock.dsp-devops.broadinstitute.org/api/ci-runs/v3/%d", c.ID)
+		return fmt.Sprintf("https://sherlock.dsp-devops-prod.broadinstitute.org/api/ci-runs/v3/%d", c.ID)
 	}
 }
 

--- a/sherlock/internal/models/ci_run_test.go
+++ b/sherlock/internal/models/ci_run_test.go
@@ -224,7 +224,7 @@ func TestCiRun_WebURL(t *testing.T) {
 				Model:    gorm.Model{ID: 123},
 				Platform: "something invalid",
 			},
-			want: "https://sherlock.dsp-devops.broadinstitute.org/api/ci-runs/v3/123",
+			want: "https://sherlock.dsp-devops-prod.broadinstitute.org/api/ci-runs/v3/123",
 		},
 	}
 	for _, tt := range tests {
@@ -585,7 +585,7 @@ func (s *modelSuite) TestCiRun_SlackCompletionTextt() {
 					{ResourceType: "environment", ResourceID: environment.ID},
 				},
 			},
-			want: "repo's workflow workflow against <https://beehive.dsp-devops.broadinstitute.org/r/chart-release/leonardo-dev|leonardo-dev>: <https://github.com/owner/repo/actions/runs/1/attempts/3|success>",
+			want: "repo's workflow workflow against <https://beehive.dsp-devops-prod.broadinstitute.org/r/chart-release/leonardo-dev|leonardo-dev>: <https://github.com/owner/repo/actions/runs/1/attempts/3|success>",
 		},
 		{
 			name: "environment",
@@ -603,7 +603,7 @@ func (s *modelSuite) TestCiRun_SlackCompletionTextt() {
 					{ResourceType: "environment", ResourceID: environment.ID},
 				},
 			},
-			want: "repo's workflow workflow against <https://beehive.dsp-devops.broadinstitute.org/r/environment/dev|dev>: <https://github.com/owner/repo/actions/runs/1/attempts/3|success>",
+			want: "repo's workflow workflow against <https://beehive.dsp-devops-prod.broadinstitute.org/r/environment/dev|dev>: <https://github.com/owner/repo/actions/runs/1/attempts/3|success>",
 		},
 		{
 			name: "with jobs",
@@ -652,7 +652,7 @@ func (s *modelSuite) TestCiRun_SlackCompletionTextt() {
 					Response: &http.Response{StatusCode: http.StatusOK},
 				}, nil).Once()
 			},
-			want: "repo's workflow workflow against <https://beehive.dsp-devops.broadinstitute.org/r/environment/dev|dev>: <https://github.com/owner/repo/actions/runs/1/attempts/3|success> (job3: <https://github.com/owner/repo/actions/runs/1/job/3|failure>)",
+			want: "repo's workflow workflow against <https://beehive.dsp-devops-prod.broadinstitute.org/r/environment/dev|dev>: <https://github.com/owner/repo/actions/runs/1/attempts/3|success> (job3: <https://github.com/owner/repo/actions/runs/1/job/3|failure>)",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Cutting over URLs, access SAs, and audiences in line with the new Sherlock and Beehive. This is a baby version of the Thelma PR that does most of the brunt work here.

See also:

- https://github.com/broadinstitute/thelma/pull/295
- https://github.com/broadinstitute/sherlock/pull/537
- https://github.com/broadinstitute/beehive/pull/467
- https://github.com/broadinstitute/terra-helmfile/pull/5471
- https://github.com/broadinstitute/terra-github-workflows/pull/189