### PR TITLE
[DDO-3641] Fix webhook proxy deployment

### DIFF
--- a/.github/workflows/sherlock-deploy-webhook-proxy.yaml
+++ b/.github/workflows/sherlock-deploy-webhook-proxy.yaml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     paths:
-      - ".github/workflows/sherlock-webhook-proxy-deploy.yaml"
+      - ".github/workflows/sherlock-deploy-webhook-proxy.yaml"
       - "sherlock-webhook-proxy/**"
       - "sherlock-go-client/**"
       - "!**/*.md"
@@ -20,7 +20,8 @@ jobs:
   tag-build-publish:
     runs-on: ubuntu-latest
     permissions:
-      contents: "read"
+      # Push to the main branch
+      contents: "write"
       # Use OIDC for workload identity
       id-token: "write"
     steps:
@@ -43,3 +44,11 @@ jobs:
 
       - name: Deploy
         run: make deploy-webhook-proxy
+
+      - name: Commit and push changes
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: |
+            [sherlock-deploy-webhook-proxy] generated from ${{ github.sha }}
+          commit_user_name: broadbot
+          commit_user_email: broadbot@broadinstitute.org

--- a/makefile
+++ b/makefile
@@ -79,6 +79,7 @@ generate-mocks:
 # go.mod)
 deploy-webhook-proxy:
 	cd sherlock-webhook-proxy \
+		&& go mod tidy \
 		&& go mod vendor \
 		&& gcloud functions deploy sherlock-webhook-proxy \
 			--gen2 \


### PR DESCRIPTION
Webhook proxy stuff can break with updates because `go mod tidy` needs to be run. This adds it to the deployment makefile and also commits after that step is run during deployment. GitHub Actions is smart enough not to create a cycle here because the commit is made by GHA itself. I'm borrowing a neat little action with a bunch of stars to do the commit detection for me.