### PR TITLE
[DDO-3641] Dependabot and review automatin

### DIFF
--- a/.github/workflows/sherlock-check-reviews.yaml
+++ b/.github/workflows/sherlock-check-reviews.yaml
@@ -1,0 +1,30 @@
+name: Review Check
+on:
+  pull_request:
+    types:
+      - ready_for_review
+    branches:
+      - main
+  pull_request_review:
+    types:
+      - edited
+      - dismissed
+      - submitted
+    branches:
+      - main
+jobs:
+  check-reviews:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - name: Get review counts
+        id: reviews
+        uses: jrylan/github-action-reviews-counter@main
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Fail if insufficient reviews
+        if: github.actor != 'dependabot[bot]' && (steps.reviews.outputs.approved < 2 || steps.reviews.outputs.changes_requested > 0)
+        run: |
+          echo "Insufficient reviews"
+          exit 1

--- a/.github/workflows/sherlock-check-ticket.yaml
+++ b/.github/workflows/sherlock-check-ticket.yaml
@@ -1,6 +1,8 @@
-name: 'Ticket Check'
+name: Ticket Check
 on:
   pull_request:
+    types:
+      - ready_for_review
     branches:
       - main
 jobs:

--- a/.github/workflows/sherlock-dependabot-automerge.yaml
+++ b/.github/workflows/sherlock-dependabot-automerge.yaml
@@ -1,0 +1,23 @@
+name: Dependabot Auto-Merge
+on:
+  pull_request:
+    types:
+      - ready_for_review
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot-automerge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Enable auto-merge for Dependabot PRs
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr merge --auto --merge "$PR_URL"


### PR DESCRIPTION
- Adds a GHA that checks that each PR has two reviewers, except for dependabot
- Adds a GHA to enable automerge on dependabot PRs
- Tweaks the ticket check to only run on PRs that are ready for review