### PR TITLE
[DDO-3641] Fix dependabot so it squashes commits

### DIFF
--- a/.github/workflows/sherlock-dependabot-automerge.yaml
+++ b/.github/workflows/sherlock-dependabot-automerge.yaml
@@ -35,4 +35,4 @@ jobs:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.BROADBOT_TOKEN }}
         run: |
-          gh pr merge --auto --merge "$PR_URL"
+          gh pr merge --auto --squash "$PR_URL"


### PR DESCRIPTION
I did not realize that `--merge` was a merge commit _instead of a squash commit_, oops. Only squash commits are allowed in this repo.