### PR TITLE
 [DDO-3673] Persistent suitability, part 1

### DIFF
--- a/dev/local-with-pg.yaml
+++ b/dev/local-with-pg.yaml
@@ -15,6 +15,9 @@ services:
     environment:
       SHERLOCK_db_host: postgres
       SHERLOCK_db_password: password
+      GOOGLE_APPLICATION_CREDENTIALS: /home/.config/gcloud/application_default_credentials.json
+    volumes:
+      - ~/.config/gcloud/application_default_credentials.json:/home/.config/gcloud/application_default_credentials.json
     depends_on:
       - database
     networks: 

--- a/sherlock/config/default_config.yaml
+++ b/sherlock/config/default_config.yaml
@@ -242,3 +242,9 @@ beehive:
     environmentUrlFormatString: https://beehive.dsp-devops-prod.broadinstitute.org/r/environment/%s
     pagerdutyIntegrationUrlFormatString: https://beehive.dsp-devops-prod.broadinstitute.org/r/pagerduty-integration/%s
     reviewChangesetsUrl: https://beehive.dsp-devops-prod.broadinstitute.org/review-changesets
+
+# self can be used to override the email and subject ID returned by the "self" package,
+# useful for testing or offline development to skip using ADC.
+self:
+    overrideEmail:
+    overrideSubjectID:

--- a/sherlock/config/test_config.yaml
+++ b/sherlock/config/test_config.yaml
@@ -50,3 +50,7 @@ model:
     templates:
       autoPopulateCharts:
         - name: honeycomb
+
+self:
+  overrideEmail: sherlock-test@broadinstitute.org
+  overrideSubjectID: sherlock-test

--- a/sherlock/db/migrations/000083_add_suitability.down.sql
+++ b/sherlock/db/migrations/000083_add_suitability.down.sql
@@ -1,0 +1,3 @@
+drop table if exists suitabilities cascade;
+
+drop index if exists idx_users_email;

--- a/sherlock/db/migrations/000083_add_suitability.up.sql
+++ b/sherlock/db/migrations/000083_add_suitability.up.sql
@@ -1,0 +1,16 @@
+create table if not exists suitabilities
+(
+    created_at  timestamp with time zone,
+    updated_at  timestamp with time zone,
+
+    email       text    not null
+        unique primary key,
+    suitable    boolean not null,
+    description text    not null
+);
+
+create index if not exists idx_suitabilities_email
+    on suitabilities (email);
+
+create index if not exists idx_users_email
+    on users (email);

--- a/sherlock/internal/api/sherlock/users_v3.go
+++ b/sherlock/internal/api/sherlock/users_v3.go
@@ -52,8 +52,8 @@ func (u UserV3) toModel() models.User {
 }
 
 func userFromModel(model models.User) UserV3 {
-	suitable := model.Suitability().Suitable()
-	suitabilityDescription := model.Suitability().Description()
+	suitable := model.DeprecatedSuitability().Suitable()
+	suitabilityDescription := model.DeprecatedSuitability().Description()
 	ret := UserV3{
 		CommonFields:           commonFieldsFromGormModel(model.Model),
 		Email:                  model.Email,

--- a/sherlock/internal/api/sherlock/users_v3_list_test.go
+++ b/sherlock/internal/api/sherlock/users_v3_list_test.go
@@ -5,6 +5,7 @@ import (
 	"github.com/broadinstitute/sherlock/sherlock/internal/authentication/test_users"
 	"github.com/broadinstitute/sherlock/sherlock/internal/errors"
 	"github.com/broadinstitute/sherlock/sherlock/internal/models"
+	"github.com/broadinstitute/sherlock/sherlock/internal/self"
 	"net/http"
 )
 
@@ -14,11 +15,15 @@ func (s *handlerSuite) TestUsersV3List_minimal() {
 		s.NewRequest("GET", "/api/users/v3", nil),
 		&got)
 	s.Equal(http.StatusOK, code)
-	s.Len(got, 1)
+	s.Len(got, 2) // suitable user + self
 	// This'll never return 0 because the calling user will be upserted, but
-	// we can check that the only entry here is ourselves
-	s.Run("inserted user is self", func() {
-		s.Equal(test_users.SuitableTestUserEmail, got[0].Email)
+	// we can check that the only entries here are ourselves and the self
+	// user
+	s.Run("first alphabetical user is Sherlock's own self", func() {
+		s.Equal(self.Email, got[0].Email)
+	})
+	s.Run("second alphabetical user is ourselves", func() {
+		s.Equal(test_users.SuitableTestUserEmail, got[1].Email)
 	})
 }
 
@@ -78,7 +83,7 @@ func (s *handlerSuite) TestUsersV3List() {
 			s.NewRequest("GET", "/api/users/v3", nil),
 			&got)
 		s.Equal(http.StatusOK, code)
-		s.Len(got, 4)
+		s.Len(got, 5) // built-in suitable user + self + 3
 		s.Run("each has suitability", func() {
 			for _, user := range got {
 				s.NotZero(user.Suitable)

--- a/sherlock/internal/authentication/authentication_method/enum.go
+++ b/sherlock/internal/authentication/authentication_method/enum.go
@@ -9,4 +9,10 @@ const (
 	GHA
 	TEST
 	LOCAL
+	// SHERLOCK_INTERNAL means Sherlock authenticating as itself internally
+	// to take some action inside the database. An example would be updating
+	// a table based on a cronjob or something, where the table has RBAC that
+	// checks the authenticated User and Sherlock wants to attribute the
+	// action to itself.
+	SHERLOCK_INTERNAL
 )

--- a/sherlock/internal/authorization/suitability.go
+++ b/sherlock/internal/authorization/suitability.go
@@ -45,7 +45,7 @@ func (s *Suitability) SuitableOrError() error {
 }
 
 // GetSuitabilityFor does what it says on the tin, but you probably don't need to call it.
-// models.User has a .Suitability() method that you should use instead, it's more
+// models.User has a .DeprecatedSuitability() method that you should use instead, it's more
 // performant with less room for error (it calls this internally and caches the result).
 func GetSuitabilityFor(email string) *Suitability {
 	if suitability, present := cachedFirecloudSuitability[email]; present {

--- a/sherlock/internal/models/boot.go
+++ b/sherlock/internal/models/boot.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"fmt"
+	"github.com/broadinstitute/sherlock/sherlock/internal/authentication/authentication_method"
 	"github.com/broadinstitute/sherlock/sherlock/internal/config"
 	"github.com/broadinstitute/sherlock/sherlock/internal/self"
 	"github.com/knadh/koanf"
@@ -58,6 +59,7 @@ func initSelfUser(db *gorm.DB) error {
 		Error; err != nil {
 		return fmt.Errorf("failed to upsert self user: %w", err)
 	}
+	SelfUser.AuthenticationMethod = authentication_method.SHERLOCK_INTERNAL
 	return nil
 }
 

--- a/sherlock/internal/models/cluster.go
+++ b/sherlock/internal/models/cluster.go
@@ -35,7 +35,7 @@ func (c *Cluster) errorIfForbidden(tx *gorm.DB) error {
 		return err
 	}
 	if c.RequiresSuitability == nil || *c.RequiresSuitability {
-		if err = user.Suitability().SuitableOrError(); err != nil {
+		if err = user.DeprecatedSuitability().SuitableOrError(); err != nil {
 			return fmt.Errorf("(%s) suitability required: %w", errors.Forbidden, err)
 		}
 	}

--- a/sherlock/internal/models/environment.go
+++ b/sherlock/internal/models/environment.go
@@ -66,7 +66,7 @@ func (e *Environment) errorIfForbidden(tx *gorm.DB) error {
 		return err
 	}
 	if e.RequiresSuitability == nil || *e.RequiresSuitability {
-		if err = user.Suitability().SuitableOrError(); err != nil {
+		if err = user.DeprecatedSuitability().SuitableOrError(); err != nil {
 			return fmt.Errorf("(%s) suitability required: %w", errors.Forbidden, err)
 		}
 	}

--- a/sherlock/internal/models/pagerduty_integration.go
+++ b/sherlock/internal/models/pagerduty_integration.go
@@ -18,7 +18,7 @@ type PagerdutyIntegration struct {
 func (p *PagerdutyIntegration) errorIfForbidden(tx *gorm.DB) error {
 	if user, err := GetCurrentUserForDB(tx); err != nil {
 		return err
-	} else if err = user.Suitability().SuitableOrError(); err != nil {
+	} else if err = user.DeprecatedSuitability().SuitableOrError(); err != nil {
 		return fmt.Errorf("(%s) suitability required: %w", errors.Forbidden, err)
 	} else {
 		return nil

--- a/sherlock/internal/models/suitability.go
+++ b/sherlock/internal/models/suitability.go
@@ -1,0 +1,72 @@
+package models
+
+import (
+	"gorm.io/gorm"
+	"time"
+)
+
+// Suitability represents a User's completion of compliance requirements,
+// like training or background checks. The term comes from being "suitable"
+// for production access.
+//
+// See Role for the where this is used: a Role can be marked as requiring
+// each assigned User to be suitable. A non-suitable User would have their
+// RoleAssignment suspended.
+//
+// Suitability *could* be a field on User, but we split it out to its own
+// table for three reasons:
+//
+//  1. We expect this type to become much more complex in the future.
+//     Our friends in InfoSec have indicated they'd like to move more of
+//     their manual compliance tracking into Sherlock, to automate checks
+//     like "if the last training for X was completed more than Y days ago,
+//     the user is not suitable."
+//  2. As part of the first point and also Sherlock simply becoming the
+//     source of truth for DevOps's permission grants to other engineers,
+//     Sherlock needs to understand the suitability of people who haven't
+//     yet actually ever connected to the DevOps platform. Tracking this
+//     in a separate table means we can have records for people who aren't
+//     a User yet.
+//  3. The concepts of "user" and "suitability" have different access
+//     control. A User record is only editable by itself (changing name,
+//     linking GitHub account, etc.), while Suitability is only editable
+//     by a Sherlock super-admin. We can represent this in Gorm hooks
+//     easily if the model types are different.
+//
+// We key this type on the User's Email, as that correlates to how humans
+// track this information. Sherlock has defenses against email spoofing
+// on the User table, when it's able to actually observe indicators of that.
+// Entries in this table could theoretically predate the email actually
+// existing (so things like Google Subject ID wouldn't exist).
+type Suitability struct {
+	CreatedAt time.Time
+	UpdatedAt time.Time
+
+	Email       *string `gorm:"primaryKey"`
+	Suitable    *bool
+	Description *string
+}
+
+func (s *Suitability) BeforeUpdate(tx *gorm.DB) error {
+	if user, err := GetCurrentUserForDB(tx); err != nil {
+		return err
+	} else {
+		return user.ErrIfNotSuperAdmin()
+	}
+}
+
+func (s *Suitability) BeforeCreate(tx *gorm.DB) error {
+	if user, err := GetCurrentUserForDB(tx); err != nil {
+		return err
+	} else {
+		return user.ErrIfNotSuperAdmin()
+	}
+}
+
+func (s *Suitability) BeforeDelete(tx *gorm.DB) error {
+	if user, err := GetCurrentUserForDB(tx); err != nil {
+		return err
+	} else {
+		return user.ErrIfNotSuperAdmin()
+	}
+}

--- a/sherlock/internal/models/suitability_test.go
+++ b/sherlock/internal/models/suitability_test.go
@@ -86,3 +86,30 @@ func (s *modelSuite) TestSuitabilityAllowedDelete() {
 	}).Delete(&Suitability{}).Error
 	s.NoError(err)
 }
+
+func (s *modelSuite) TestSuitabilityCreateNullEmail() {
+	s.SetSelfSuperAdminForDB()
+	err := s.DB.Create(&Suitability{
+		Suitable:    utils.PointerTo(true),
+		Description: utils.PointerTo("description"),
+	}).Error
+	s.ErrorContains(err, "email")
+}
+
+func (s *modelSuite) TestSuitabilityCreateNullSuitable() {
+	s.SetSelfSuperAdminForDB()
+	err := s.DB.Create(&Suitability{
+		Email:       utils.PointerTo("email@example.com"),
+		Description: utils.PointerTo("description"),
+	}).Error
+	s.ErrorContains(err, "suitable")
+}
+
+func (s *modelSuite) TestSuitabilityCreateNullDescription() {
+	s.SetSelfSuperAdminForDB()
+	err := s.DB.Create(&Suitability{
+		Email:    utils.PointerTo("email@example.com"),
+		Suitable: utils.PointerTo(true),
+	}).Error
+	s.ErrorContains(err, "description")
+}

--- a/sherlock/internal/models/suitability_test.go
+++ b/sherlock/internal/models/suitability_test.go
@@ -1,0 +1,88 @@
+package models
+
+import (
+	"github.com/broadinstitute/sherlock/go-shared/pkg/utils"
+	"github.com/broadinstitute/sherlock/sherlock/internal/errors"
+)
+
+func (s *modelSuite) TestSuitabilityForbiddenCreate() {
+	s.SetSuitableTestUserForDB()
+	err := s.DB.Create(&Suitability{
+		Email:       utils.PointerTo("email@example.com"),
+		Suitable:    utils.PointerTo(true),
+		Description: utils.PointerTo("description"),
+	}).Error
+	s.ErrorContains(err, errors.Forbidden)
+}
+
+func (s *modelSuite) TestSuitabilityAllowedCreate() {
+	s.SetSelfSuperAdminForDB()
+	err := s.DB.Create(&Suitability{
+		Email:       utils.PointerTo("email@example.com"),
+		Suitable:    utils.PointerTo(true),
+		Description: utils.PointerTo("description"),
+	}).Error
+	s.NoError(err)
+}
+
+func (s *modelSuite) TestSuitabilityForbiddenEdit() {
+	s.SetSelfSuperAdminForDB()
+	err := s.DB.Create(&Suitability{
+		Email:       utils.PointerTo("email@example.com"),
+		Suitable:    utils.PointerTo(true),
+		Description: utils.PointerTo("description"),
+	}).Error
+	s.NoError(err)
+	s.SetSuitableTestUserForDB()
+	err = s.DB.Where(&Suitability{
+		Email: utils.PointerTo("email@example.com"),
+	}).Updates(&Suitability{
+		Suitable: utils.PointerTo(false),
+	}).Error
+	s.ErrorContains(err, errors.Forbidden)
+}
+
+func (s *modelSuite) TestSuitabilityAllowedEdit() {
+	s.SetSelfSuperAdminForDB()
+	err := s.DB.Create(&Suitability{
+		Email:       utils.PointerTo("email@example.com"),
+		Suitable:    utils.PointerTo(true),
+		Description: utils.PointerTo("description"),
+	}).Error
+	s.NoError(err)
+	err = s.DB.Where(&Suitability{
+		Email: utils.PointerTo("email@example.com"),
+	}).Updates(&Suitability{
+		Suitable: utils.PointerTo(false),
+	}).Error
+	s.NoError(err)
+}
+
+func (s *modelSuite) TestSuitabilityForbiddenDelete() {
+	s.SetSelfSuperAdminForDB()
+	err := s.DB.Create(&Suitability{
+		Email:       utils.PointerTo("email@example.com"),
+		Suitable:    utils.PointerTo(true),
+		Description: utils.PointerTo("description"),
+	}).Error
+	s.NoError(err)
+	s.SetSuitableTestUserForDB()
+	err = s.DB.Where(&Suitability{
+		Email: utils.PointerTo("email@example.com"),
+	}).Delete(&Suitability{}).Error
+	s.ErrorContains(err, errors.Forbidden)
+}
+
+func (s *modelSuite) TestSuitabilityAllowedDelete() {
+	s.SetSelfSuperAdminForDB()
+	err := s.DB.Create(&Suitability{
+		Email:       utils.PointerTo("email@example.com"),
+		Suitable:    utils.PointerTo(true),
+		Description: utils.PointerTo("description"),
+	}).Error
+	s.NoError(err)
+	err = s.DB.Where(&Suitability{
+		Email: utils.PointerTo("email@example.com"),
+	}).Delete(&Suitability{}).Error
+	s.NoError(err)
+}

--- a/sherlock/internal/models/test_helper.go
+++ b/sherlock/internal/models/test_helper.go
@@ -48,7 +48,9 @@ func (h *TestSuiteHelper) SetupTest() {
 // the current principal for the database. You'll usually want to call
 // SetSuitableTestUserForDB or SetNonSuitableTestUserForDB instead.
 func (h *TestSuiteHelper) SetUserForDB(user *User) *User {
-	user.AuthenticationMethod = authentication_method.TEST
+	if user.AuthenticationMethod != authentication_method.SHERLOCK_INTERNAL {
+		user.AuthenticationMethod = authentication_method.TEST
+	}
 	h.DB = SetCurrentUserForDB(h.DB, user)
 	return user
 }
@@ -63,6 +65,15 @@ func (h *TestSuiteHelper) SetSuitableTestUserForDB() *User {
 // TestData.User_NonSuitable
 func (h *TestSuiteHelper) SetNonSuitableTestUserForDB() *User {
 	return h.SetUserForDB(utils.PointerTo(h.TestData.User_NonSuitable()))
+}
+
+// SetSelfSuperAdminForDB is a helper function, calling SetUserForDB with
+// SelfUser. This is different from other similar helpers in that the user
+// being set isn't coming from TestData; this is a system-level user that
+// is necessary for Sherlock's actual runtime. In tests, it's a convenient
+// way to get super-user privileges when the "who" isn't important.
+func (h *TestSuiteHelper) SetSelfSuperAdminForDB() *User {
+	return h.SetUserForDB(SelfUser)
 }
 
 // TearDownTest takes advantage of SetupTest having begun a

--- a/sherlock/internal/models/test_helper_test.go
+++ b/sherlock/internal/models/test_helper_test.go
@@ -17,7 +17,7 @@ func (s *modelSuite) TestTestHelperItself() {
 		s.NoError(err)
 		s.Equal(test_users.SuitableTestUserEmail, user.Email)
 		s.NotZero(user.ID)
-		s.True(user.Suitability().Suitable())
+		s.True(user.DeprecatedSuitability().Suitable())
 	})
 	s.Run("non-suitable test user", func() {
 		s.SetNonSuitableTestUserForDB()
@@ -25,6 +25,6 @@ func (s *modelSuite) TestTestHelperItself() {
 		s.NoError(err)
 		s.Equal(test_users.NonSuitableTestUserEmail, user.Email)
 		s.NotZero(user.ID)
-		s.False(user.Suitability().Suitable())
+		s.False(user.DeprecatedSuitability().Suitable())
 	})
 }

--- a/sherlock/internal/models/user.go
+++ b/sherlock/internal/models/user.go
@@ -177,8 +177,10 @@ func (u *User) SlackReference(mention bool) string {
 }
 
 func (u *User) ErrIfNotSuperAdmin() error {
-	if u.Email == self.Email && u.GoogleID == self.GoogleID {
+	if u.Email == self.Email && u.GoogleID == self.GoogleID && u.AuthenticationMethod == authentication_method.SHERLOCK_INTERNAL {
 		// Short-circuit to respect Sherlock's own user; see SelfUser.
+		// We only respect this with an internal authentication method as defense-in-depth (it should be impossible to
+		// actually make a request as Sherlock, but we don't want to find out).
 		return nil
 	}
 	for _, assignment := range u.Assignments {

--- a/sherlock/internal/models/user.go
+++ b/sherlock/internal/models/user.go
@@ -139,8 +139,9 @@ func (u *User) BeforeDelete(_ *gorm.DB) error {
 // uses an in-memory store of suitability data. The new mechanism to is to use
 // User.Suitability instead.
 //
-// Deprecated: This method is deprecated in favor of the database-persistent
-// User.Suitability field (that we're rolling out slowly).
+// We don't actually mark this method as deprecated in Go-comment-parlance
+// because it makes the CI linter freak out. Whatever, not like we'll have
+// trouble finding usages of this method.
 func (u *User) DeprecatedSuitability() *authorization.Suitability {
 	if u.Email != "" && u.deprecatedCachedSuitability == nil {
 		u.deprecatedCachedSuitability = authorization.GetSuitabilityFor(u.Email)

--- a/sherlock/internal/models/user_test.go
+++ b/sherlock/internal/models/user_test.go
@@ -68,15 +68,15 @@ func (s *modelSuite) TestUserNoDelete() {
 func (s *modelSuite) TestUserSuitabilityAccess() {
 	s.Run("suitable", func() {
 		suitable := &User{Email: test_users.SuitableTestUserEmail}
-		s.True(suitable.Suitability().Suitable())
-		s.NotZero(suitable.cachedSuitability)
-		s.True(suitable.cachedSuitability.Suitable())
+		s.True(suitable.DeprecatedSuitability().Suitable())
+		s.NotZero(suitable.deprecatedCachedSuitability)
+		s.True(suitable.deprecatedCachedSuitability.Suitable())
 	})
 	s.Run("not suitable", func() {
 		notSuitable := &User{Email: test_users.NonSuitableTestUserEmail}
-		s.False(notSuitable.Suitability().Suitable())
-		s.NotZero(notSuitable.cachedSuitability)
-		s.False(notSuitable.cachedSuitability.Suitable())
+		s.False(notSuitable.DeprecatedSuitability().Suitable())
+		s.NotZero(notSuitable.deprecatedCachedSuitability)
+		s.False(notSuitable.deprecatedCachedSuitability.Suitable())
 	})
 }
 
@@ -253,18 +253,18 @@ func TestUser_SlackReference(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			u := &User{
-				Model:                tt.fields.Model,
-				Email:                tt.fields.Email,
-				GoogleID:             tt.fields.GoogleID,
-				GithubUsername:       tt.fields.GithubUsername,
-				GithubID:             tt.fields.GithubID,
-				SlackUsername:        tt.fields.SlackUsername,
-				SlackID:              tt.fields.SlackID,
-				Name:                 tt.fields.Name,
-				NameFrom:             tt.fields.NameFrom,
-				Via:                  tt.fields.Via,
-				AuthenticationMethod: tt.fields.AuthenticationMethod,
-				cachedSuitability:    tt.fields.cachedSuitability,
+				Model:                       tt.fields.Model,
+				Email:                       tt.fields.Email,
+				GoogleID:                    tt.fields.GoogleID,
+				GithubUsername:              tt.fields.GithubUsername,
+				GithubID:                    tt.fields.GithubID,
+				SlackUsername:               tt.fields.SlackUsername,
+				SlackID:                     tt.fields.SlackID,
+				Name:                        tt.fields.Name,
+				NameFrom:                    tt.fields.NameFrom,
+				Via:                         tt.fields.Via,
+				AuthenticationMethod:        tt.fields.AuthenticationMethod,
+				deprecatedCachedSuitability: tt.fields.cachedSuitability,
 			}
 			if got := u.SlackReference(tt.args.mention); got != tt.want {
 				t.Errorf("SlackReference() = %v, want %v", got, tt.want)

--- a/sherlock/internal/self/self.go
+++ b/sherlock/internal/self/self.go
@@ -1,0 +1,50 @@
+// Package self is responsible for telling Sherlock who it is.
+//
+// This is necessary because Sherlock is its own source-of-truth for
+// access control. When Sherlock takes actions of its own accord, it
+// needs to know how to attribute those actions to itself in logs
+// or journaled database entries.
+//
+// For simplicity's sake, this package's goal is for Sherlock to be
+// able to upsert its own models.User record into the database. This
+// package doesn't actually *do* that (import cycles...), but it tries
+// to expose the necessary information in an encapsulated way.
+package self
+
+import (
+	"context"
+	"fmt"
+	"github.com/broadinstitute/sherlock/sherlock/internal/config"
+	googleoauth "google.golang.org/api/oauth2/v2"
+)
+
+var (
+	// Email is Sherlock's own email address. This variable shouldn't be
+	// accessed until Load has been called.
+	Email = "sherlock-uninitialized@broadinstitute.org"
+	// GoogleID is Sherlock's own subject ID. This variable shouldn't be
+	// accessed until Load has been called.
+	GoogleID = "sherlock-uninitialized"
+)
+
+func Load(ctx context.Context) error {
+	email := config.Config.String("self.overrideEmail")
+	subjectID := config.Config.String("self.overrideSubjectID")
+	if email != "" && subjectID != "" {
+		Email = email
+		GoogleID = subjectID
+		return nil
+	}
+
+	service, err := googleoauth.NewService(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to create Google OAuth service: %w", err)
+	}
+	userinfo, err := service.Userinfo.V2.Me.Get().Do()
+	if err != nil {
+		return fmt.Errorf("failed to get self userinfo: %w", err)
+	}
+	Email = userinfo.Email
+	GoogleID = userinfo.Id
+	return nil
+}

--- a/sherlock/internal/suitabilityloader/from_config.go
+++ b/sherlock/internal/suitabilityloader/from_config.go
@@ -1,0 +1,24 @@
+package suitabilityloader
+
+import (
+	"fmt"
+	"github.com/broadinstitute/sherlock/go-shared/pkg/utils"
+	"github.com/broadinstitute/sherlock/sherlock/internal/config"
+	"github.com/broadinstitute/sherlock/sherlock/internal/models"
+)
+
+func fromConfig() ([]models.Suitability, error) {
+	var result []models.Suitability
+	for index, entry := range config.Config.Slices("auth.extraPermissions") {
+		email := entry.String("email")
+		if email == "" {
+			return nil, fmt.Errorf("auth.extraPermissions[%d].email is required", index)
+		}
+		result = append(result, models.Suitability{
+			Email:       &email,
+			Suitable:    utils.PointerTo(true),
+			Description: utils.PointerTo("suitability set via Sherlock configuration"),
+		})
+	}
+	return result, nil
+}

--- a/sherlock/internal/suitabilityloader/from_firecloud.go
+++ b/sherlock/internal/suitabilityloader/from_firecloud.go
@@ -1,0 +1,150 @@
+package suitabilityloader
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/broadinstitute/sherlock/go-shared/pkg/utils"
+	"github.com/broadinstitute/sherlock/sherlock/internal/config"
+	"github.com/broadinstitute/sherlock/sherlock/internal/models"
+	"github.com/rs/zerolog/log"
+	admin "google.golang.org/api/admin/directory/v1"
+	"google.golang.org/api/option"
+)
+
+func fromFirecloud(ctx context.Context) ([]models.Suitability, error) {
+	adminService, err := admin.NewService(ctx, option.WithScopes(admin.AdminDirectoryUserReadonlyScope, admin.AdminDirectoryGroupMemberReadonlyScope))
+	if err != nil {
+		return nil, fmt.Errorf("failed to authenticate to Google Workspace: %w", err)
+	}
+
+	var fcAdminsGroupEmails []string
+	err = adminService.Members.List(config.Config.MustString("auth.firecloud.groups.fcAdmins")).Pages(ctx, func(members *admin.Members) error {
+		if members == nil {
+			return fmt.Errorf("cacheFirecloudSuitability got a nil %s member page from Google", config.Config.MustString("auth.firecloud.groups.fcAdmins"))
+		} else {
+			for _, member := range members.Members {
+				if member == nil {
+					return fmt.Errorf("cacheFirecloudSuitability got a nil %s member from Google", config.Config.MustString("auth.firecloud.groups.fcAdmins"))
+				} else {
+					fcAdminsGroupEmails = append(fcAdminsGroupEmails, member.Email)
+				}
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var firecloudProjectOwnersGroupEmails []string
+	err = adminService.Members.List(config.Config.MustString("auth.firecloud.groups.firecloudProjectOwners")).Pages(ctx, func(members *admin.Members) error {
+		if members == nil {
+			return fmt.Errorf("cacheFirecloudSuitability got a nil %s member page from Google", config.Config.MustString("auth.firecloud.groups.fcAdmins"))
+		} else {
+			for _, member := range members.Members {
+				if member == nil {
+					return fmt.Errorf("cacheFirecloudSuitability got a nil %s member from Google", config.Config.MustString("auth.firecloud.groups.fcAdmins"))
+				} else {
+					firecloudProjectOwnersGroupEmails = append(firecloudProjectOwnersGroupEmails, member.Email)
+				}
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var result []models.Suitability
+	err = adminService.Users.List().Domain(config.Config.MustString("auth.firecloud.domain")).Pages(ctx, func(workspaceUsers *admin.Users) error {
+		if workspaceUsers == nil {
+			return fmt.Errorf("cacheFirecloudSuitability got a nil user page from Google")
+		} else {
+			for _, workspaceUser := range workspaceUsers.Users {
+				if workspaceUser == nil {
+					return fmt.Errorf("cacheFirecloudSuitability got a nil user from Google")
+				} else {
+					suitable, description := parseFirecloudUser(workspaceUser, fcAdminsGroupEmails, firecloudProjectOwnersGroupEmails)
+					if workspaceUser.PrimaryEmail != "" {
+						result = append(result, models.Suitability{
+							Email:       &workspaceUser.PrimaryEmail,
+							Suitable:    &suitable,
+							Description: &description,
+						})
+					}
+					if workspaceUser.RecoveryEmail != "" {
+						result = append(result, models.Suitability{
+							Email:       &workspaceUser.RecoveryEmail,
+							Suitable:    &suitable,
+							Description: &description,
+						})
+					}
+
+					// Secondary emails on the user's account aren't `admin.User.RecoveryEmail`, they're under
+					// `admin.User.Emails`.
+					//
+					// Google doesn't bother typing the `admin.User.Emails` field; it's just `interface{}`.
+					// Because Go is impressively bad at handling JSON, we can't easily get from `interface{}` to
+					// the `[]admin.UserEmail` type we want, despite what Google's own engineers say
+					// (https://github.com/googleapis/google-api-go-client/issues/325). GoLand can open up a scratch
+					// file in sherlock's context with its dependencies if you want to see the panic for yourself.
+					//
+					// We could probably use the MapStructure package here but the rest of Sherlock doesn't use it.
+					// Instead, we do the dumb-but-correct thing and serialize it back to JSON and parse back to what
+					// we want.
+					//
+					// In theory, this madness will be somewhat short-lived, because Sherlock will become the source
+					// of truth and will be more concerned with pushing info to Google Workspace than reading from it.
+					if emailsJson, emailsParseErr := json.Marshal(workspaceUser.Emails); emailsParseErr != nil {
+						log.Debug().Err(err).Msgf("AUTH | wasn't able to marshal %s's `emails` field back to JSON: %v", workspaceUser.PrimaryEmail, err)
+					} else {
+						var parsedEmails []admin.UserEmail
+						if emailsParseErr = json.Unmarshal(emailsJson, &parsedEmails); emailsParseErr != nil {
+							log.Debug().Err(err).Msgf("AUTH | wasn't able to unmarshal %s's `emails` field to %T: %v", workspaceUser.PrimaryEmail, parsedEmails, err)
+						} else {
+							for _, parsedEmail := range parsedEmails {
+								if len(parsedEmail.Address) == 0 {
+									log.Debug().Msgf("AUTH | one of %s's `emails` had an empty address", workspaceUser.PrimaryEmail)
+								} else if parsedEmail.Address != workspaceUser.PrimaryEmail && parsedEmail.Address != workspaceUser.RecoveryEmail {
+									// Only bother with the assignment if it wasn't an email we would've already recorded.
+									result = append(result, models.Suitability{
+										Email:       &parsedEmail.Address,
+										Suitable:    &suitable,
+										Description: &description,
+									})
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+		return nil
+	})
+	return result, err
+}
+
+func parseFirecloudUser(workspaceUser *admin.User, fcAdminsGroupEmails []string, firecloudProjectOwnersGroupEmails []string) (suitable bool, description string) {
+	if workspaceUser.PrimaryEmail == "" {
+		return false, "firecloud user doesn't appear to have a primary email? something's amiss, marking as not suitable"
+	} else if !workspaceUser.AgreedToTerms {
+		return false, fmt.Sprintf("firecloud user hasn't accepted Google Workspace terms (suggesting they've never logged in; they'll need to wait %d minutes after first login for Sherlock to pick it up)",
+			config.Config.MustInt("auth.updateIntervalMinutes"))
+	} else if !workspaceUser.IsEnrolledIn2Sv {
+		return false, "firecloud user hasn't enrolled in two-factor authentication"
+	} else if workspaceUser.Suspended {
+		return false, fmt.Sprintf("firecloud user is suspended, probably due to inactivity (reach out to #dsp-devops-champions for help; they'll need to wait %d minutes after reactivation for Sherlock to pick it up)",
+			config.Config.MustInt("auth.updateIntervalMinutes"))
+	} else if workspaceUser.Archived {
+		return false, "firecloud user is archived"
+	} else if !utils.Contains(fcAdminsGroupEmails, workspaceUser.PrimaryEmail) {
+		return false, fmt.Sprintf("firecloud user isn't in fc-admins group (reach out to #dsp-devops-champions for help; they'll need to wait %d minutes after being added for Sherlock to pick it up)",
+			config.Config.MustInt("auth.updateIntervalMinutes"))
+	} else if !utils.Contains(firecloudProjectOwnersGroupEmails, workspaceUser.PrimaryEmail) {
+		return false, fmt.Sprintf("firecloud user isn't in firecloud-project-owners group (reach out to #dsp-devops-champions for help; they'll need to wait %d minutes after being added for Sherlock to pick it up)",
+			config.Config.MustInt("auth.updateIntervalMinutes"))
+	} else {
+		return true, "firecloud user is suitable"
+	}
+}

--- a/sherlock/internal/suitabilityloader/sync_to_db.go
+++ b/sherlock/internal/suitabilityloader/sync_to_db.go
@@ -3,6 +3,7 @@ package suitabilityloader
 import (
 	"context"
 	"github.com/broadinstitute/sherlock/sherlock/internal/config"
+	"github.com/broadinstitute/sherlock/sherlock/internal/models"
 	"github.com/rs/zerolog/log"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
@@ -30,7 +31,10 @@ func SyncSuitabilitiesToDB(ctx context.Context, db *gorm.DB) error {
 	}
 	suitabilities := append(suitabilitiesFromConfig, suitabilitiesFromFirecloud...)
 
-	if err = db.Clauses(clause.OnConflict{UpdateAll: true}).Create(&suitabilities).Error; err != nil {
+	// Assume super-user privileges for this operation (required to edit this table)
+	superUserDB := models.SetCurrentUserForDB(db, models.SelfUser)
+
+	if err = superUserDB.Clauses(clause.OnConflict{UpdateAll: true}).Create(&suitabilities).Error; err != nil {
 		return err
 	}
 

--- a/sherlock/internal/suitabilityloader/sync_to_db.go
+++ b/sherlock/internal/suitabilityloader/sync_to_db.go
@@ -2,11 +2,11 @@ package suitabilityloader
 
 import (
 	"context"
+	"fmt"
 	"github.com/broadinstitute/sherlock/sherlock/internal/config"
 	"github.com/broadinstitute/sherlock/sherlock/internal/models"
 	"github.com/rs/zerolog/log"
 	"gorm.io/gorm"
-	"gorm.io/gorm/clause"
 	"time"
 )
 
@@ -34,13 +34,10 @@ func SyncSuitabilitiesToDB(ctx context.Context, db *gorm.DB) error {
 	// Assume super-user privileges for this operation (required to edit this table)
 	superUserDB := models.SetCurrentUserForDB(db, models.SelfUser)
 
-	//for _, suitability := range suitabilities {
-	//	if err = superUserDB.Where("email = ?", suitability.Email).Assign(&suitability).FirstOrCreate(&suitability).Error; err != nil {
-	//		return fmt.Errorf("failed to update suitability for %s: %w", suitability.Email, err)
-	//	}
-	//}
-	if err = superUserDB.Clauses(clause.OnConflict{UpdateAll: true}).Create(&suitabilities).Error; err != nil {
-		return err
+	for _, suitability := range suitabilities {
+		if err = superUserDB.Where("email = ?", suitability.Email).Assign(&suitability).FirstOrCreate(&suitability).Error; err != nil {
+			return fmt.Errorf("failed to update suitability for %s: %w", suitability.Email, err)
+		}
 	}
 
 	// TODO: once we know that the updatedAt field is being set properly, we'll want to add a step here

--- a/sherlock/internal/suitabilityloader/sync_to_db.go
+++ b/sherlock/internal/suitabilityloader/sync_to_db.go
@@ -2,11 +2,11 @@ package suitabilityloader
 
 import (
 	"context"
-	"fmt"
 	"github.com/broadinstitute/sherlock/sherlock/internal/config"
 	"github.com/broadinstitute/sherlock/sherlock/internal/models"
 	"github.com/rs/zerolog/log"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 	"time"
 )
 
@@ -34,10 +34,13 @@ func SyncSuitabilitiesToDB(ctx context.Context, db *gorm.DB) error {
 	// Assume super-user privileges for this operation (required to edit this table)
 	superUserDB := models.SetCurrentUserForDB(db, models.SelfUser)
 
-	for _, suitability := range suitabilities {
-		if err = superUserDB.Where("email = ?", suitability.Email).Assign(&suitability).FirstOrCreate(&suitability).Error; err != nil {
-			return fmt.Errorf("failed to update suitability for %s: %w", suitability.Email, err)
-		}
+	//for _, suitability := range suitabilities {
+	//	if err = superUserDB.Where("email = ?", suitability.Email).Assign(&suitability).FirstOrCreate(&suitability).Error; err != nil {
+	//		return fmt.Errorf("failed to update suitability for %s: %w", suitability.Email, err)
+	//	}
+	//}
+	if err = superUserDB.Clauses(clause.OnConflict{UpdateAll: true}).Create(&suitabilities).Error; err != nil {
+		return err
 	}
 
 	// TODO: once we know that the updatedAt field is being set properly, we'll want to add a step here

--- a/sherlock/internal/suitabilityloader/sync_to_db.go
+++ b/sherlock/internal/suitabilityloader/sync_to_db.go
@@ -2,11 +2,11 @@ package suitabilityloader
 
 import (
 	"context"
+	"fmt"
 	"github.com/broadinstitute/sherlock/sherlock/internal/config"
 	"github.com/broadinstitute/sherlock/sherlock/internal/models"
 	"github.com/rs/zerolog/log"
 	"gorm.io/gorm"
-	"gorm.io/gorm/clause"
 	"time"
 )
 
@@ -34,8 +34,10 @@ func SyncSuitabilitiesToDB(ctx context.Context, db *gorm.DB) error {
 	// Assume super-user privileges for this operation (required to edit this table)
 	superUserDB := models.SetCurrentUserForDB(db, models.SelfUser)
 
-	if err = superUserDB.Clauses(clause.OnConflict{UpdateAll: true}).Create(&suitabilities).Error; err != nil {
-		return err
+	for _, suitability := range suitabilities {
+		if err = superUserDB.Where("email = ?", suitability.Email).Assign(&suitability).FirstOrCreate(&suitability).Error; err != nil {
+			return fmt.Errorf("failed to update suitability for %s: %w", suitability.Email, err)
+		}
 	}
 
 	// TODO: once we know that the updatedAt field is being set properly, we'll want to add a step here

--- a/sherlock/internal/suitabilityloader/sync_to_db.go
+++ b/sherlock/internal/suitabilityloader/sync_to_db.go
@@ -36,7 +36,7 @@ func SyncSuitabilitiesToDB(ctx context.Context, db *gorm.DB) error {
 
 	for _, suitability := range suitabilities {
 		if err = superUserDB.Where("email = ?", suitability.Email).Assign(&suitability).FirstOrCreate(&suitability).Error; err != nil {
-			return fmt.Errorf("failed to update suitability for %s: %w", suitability.Email, err)
+			return fmt.Errorf("failed to update suitability for %s: %w", *suitability.Email, err)
 		}
 	}
 

--- a/sherlock/internal/suitabilityloader/sync_to_db.go
+++ b/sherlock/internal/suitabilityloader/sync_to_db.go
@@ -1,0 +1,45 @@
+package suitabilityloader
+
+import (
+	"context"
+	"github.com/broadinstitute/sherlock/sherlock/internal/config"
+	"github.com/rs/zerolog/log"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+	"time"
+)
+
+func KeepSuitabilitiesInDBUpdated(ctx context.Context, db *gorm.DB) {
+	interval := time.Duration(config.Config.MustInt("auth.updateIntervalMinutes")) * time.Minute
+	for {
+		time.Sleep(interval)
+		if err := SyncSuitabilitiesToDB(ctx, db); err != nil {
+			log.Warn().Err(err).Msgf("failed to update suitability table")
+		}
+	}
+}
+
+func SyncSuitabilitiesToDB(ctx context.Context, db *gorm.DB) error {
+	suitabilitiesFromConfig, err := fromConfig()
+	if err != nil {
+		return err
+	}
+	suitabilitiesFromFirecloud, err := fromFirecloud(ctx)
+	if err != nil {
+		return err
+	}
+	suitabilities := append(suitabilitiesFromConfig, suitabilitiesFromFirecloud...)
+
+	if err = db.Clauses(clause.OnConflict{UpdateAll: true}).Create(&suitabilities).Error; err != nil {
+		return err
+	}
+
+	// TODO: once we know that the updatedAt field is being set properly, we'll want to add a step here
+	// to drop anything from the database that hasn't been updated recently. That'll match the current
+	// functionality, where if someone completely disappears from firecloud.org (or more likely, from
+	// Sherlock's config file), they'll cached suitability will eventually expire. With the old
+	// in-memory solution we'd just replace the whole cache to do that, but since the database is
+	// persistent we'll have to manually delete those rows.
+
+	return nil
+}


### PR DESCRIPTION
This PR is a bit awkward:

1. It adds a concept of Sherlock's own User -- as in, Sherlock will literally use ADC to figure out its own email and insert itself as a User into the database. This magic User is always understood to have super-user privileges (there's a safeguard to prevent accessing those magic privileges via a forged request or something).
2. It adds a table for Suitability. This table can only be edited by super-users (of which there are none right now except the aforementioned magic self User).
3. It adds a cronjob that shoves data into the Suitability table. This is basically copied from the existing mechanism -- copied including the lack of tests, because this is temporary code, we're sorta in construction mode right now (more info is in the ticket about how/why).

_And that's it_. The data is _technically_ loaded by some database queries elsewhere in the system but it isn't used; the old mechanism is what actually gets read. The whole point is we ship this, look at the table in the database, and use that observability to know we didn't mess anything up. It's a shortcut to keep us from fixing the lack of tests in the existing code or in this new "it'll be here for a month" code.

## Testing

See above; there are tests added for the code that's actually meant to stick around.

I've deployed this to dev and confirmed that the table gets created and populated correctly.

## Risk

Low -- existing functionality isn't really being touched here.