### PR TITLE
[DDO-3689] Fix pointer/variable assignment in Firecloud account loader

### DIFF
--- a/sherlock/internal/suitabilityloader/from_firecloud.go
+++ b/sherlock/internal/suitabilityloader/from_firecloud.go
@@ -103,7 +103,8 @@ func fromFirecloud(ctx context.Context) ([]models.Suitability, error) {
 						if emailsParseErr = json.Unmarshal(emailsJson, &parsedEmails); emailsParseErr != nil {
 							log.Debug().Err(err).Msgf("AUTH | wasn't able to unmarshal %s's `emails` field to %T: %v", workspaceUser.PrimaryEmail, parsedEmails, err)
 						} else {
-							for _, parsedEmail := range parsedEmails {
+							for _, unsafeEmail := range parsedEmails {
+								parsedEmail := unsafeEmail
 								if len(parsedEmail.Address) == 0 {
 									log.Debug().Msgf("AUTH | one of %s's `emails` had an empty address", workspaceUser.PrimaryEmail)
 								} else if parsedEmail.Address != workspaceUser.PrimaryEmail && parsedEmail.Address != workspaceUser.RecoveryEmail {


### PR DESCRIPTION
You can see the diff -- this entire function was copied from what worked previously, _except_ the `parsedEmail` is now being stored as `&parsedEmail` instead of `parsedEmail`. That matters because `for _, parsedEmail := range parsedEmails {` initializes `parsedEmail` once and then reassigns it each time, meaning that `&parsedEmail` was changing! Lovely, I love go, I love that there's no linter check for this.

I desperately want to throw this code out but we need it for another couple of weeks, I think the right thing to do is just fix it here and move on. There's not a good way to test this code beyond putting it on dev which is a _problem_ which is why I'm throwing the whole architecture out.