### PR TITLE
[DDO-3696] Tests and fixes for Role and RoleAssignment APIs

### DIFF
--- a/.idea/runConfigurations/_template__of_Go_Test.xml
+++ b/.idea/runConfigurations/_template__of_Go_Test.xml
@@ -1,0 +1,13 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="true" type="GoTestRunConfiguration" factoryName="Go Test">
+    <module name="sherlock" />
+    <working_directory value="$PROJECT_DIR$" />
+    <go_parameters value="-p 1" />
+    <kind value="DIRECTORY" />
+    <package value="github.com/broadinstitute/sherlock" />
+    <directory value="$PROJECT_DIR$" />
+    <filePath value="$PROJECT_DIR$" />
+    <framework value="gotest" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/sherlock/db/migrations/000088_fix_role_operations_duration_type_again.down.sql
+++ b/sherlock/db/migrations/000088_fix_role_operations_duration_type_again.down.sql
@@ -1,0 +1,2 @@
+alter table if exists role_operations
+    alter column to_default_glass_break_duration type text using to_default_glass_break_duration::text;

--- a/sherlock/db/migrations/000088_fix_role_operations_duration_type_again.up.sql
+++ b/sherlock/db/migrations/000088_fix_role_operations_duration_type_again.up.sql
@@ -1,0 +1,2 @@
+alter table if exists role_operations
+    alter column to_default_glass_break_duration type bigint using to_default_glass_break_duration::bigint;

--- a/sherlock/internal/api/sherlock/handler_test.go
+++ b/sherlock/internal/api/sherlock/handler_test.go
@@ -48,6 +48,12 @@ func (s *handlerSuite) NewRequest(method string, url string, toJsonBody any) *ht
 	return req
 }
 
+func (s *handlerSuite) NewSuperAdminRequest(method string, url string, toJsonBody any) *http.Request {
+	req := s.NewRequest(method, url, toJsonBody)
+	s.UseSuperAdminUserFor(req)
+	return req
+}
+
 func (s *handlerSuite) NewSuitableRequest(method string, url string, toJsonBody any) *http.Request {
 	req := s.NewRequest(method, url, toJsonBody)
 	s.UseSuitableUserFor(req)

--- a/sherlock/internal/api/sherlock/role_assignments_v3.go
+++ b/sherlock/internal/api/sherlock/role_assignments_v3.go
@@ -13,7 +13,7 @@ type RoleAssignmentV3 struct {
 }
 
 type RoleAssignmentV3Edit struct {
-	Suspended *bool      `json:"suspended,omitempty" form:"suspended"`
+	Suspended *bool      `json:"suspended,omitempty" form:"suspended" default:"false"`
 	ExpiresAt *time.Time `json:"expiresAt,omitempty" form:"expiresAt" format:"date-time"`
 }
 

--- a/sherlock/internal/api/sherlock/role_assignments_v3_create.go
+++ b/sherlock/internal/api/sherlock/role_assignments_v3_create.go
@@ -5,6 +5,7 @@ import (
 	"github.com/broadinstitute/sherlock/sherlock/internal/authentication"
 	"github.com/broadinstitute/sherlock/sherlock/internal/errors"
 	"github.com/broadinstitute/sherlock/sherlock/internal/models"
+	"github.com/creasty/defaults"
 	"github.com/gin-gonic/gin"
 	"gorm.io/gorm/clause"
 	"net/http"
@@ -32,6 +33,10 @@ func roleAssignmentsV3Create(ctx *gin.Context) {
 	var body RoleAssignmentV3Edit
 	if err = ctx.ShouldBindJSON(&body); err != nil {
 		errors.AbortRequest(ctx, fmt.Errorf("(%s) request validation error: %w", errors.BadRequest, err))
+		return
+	}
+	if err = defaults.Set(&body); err != nil {
+		errors.AbortRequest(ctx, fmt.Errorf("error setting defaults: %w", err))
 		return
 	}
 

--- a/sherlock/internal/api/sherlock/role_assignments_v3_create_test.go
+++ b/sherlock/internal/api/sherlock/role_assignments_v3_create_test.go
@@ -1,0 +1,75 @@
+package sherlock
+
+import (
+	"github.com/broadinstitute/sherlock/go-shared/pkg/utils"
+	"github.com/broadinstitute/sherlock/sherlock/internal/errors"
+	"net/http"
+	"time"
+)
+
+func (s *handlerSuite) TestRoleAssignmentsV3Create_notFound() {
+	var got errors.ErrorResponse
+	code := s.HandleRequest(
+		s.NewRequest("POST", "/api/role-assignments/v3/does-not-exist/me@example.com", RoleAssignmentV3Edit{}),
+		&got)
+	s.Equal(http.StatusNotFound, code)
+	s.Equal(errors.NotFound, got.Type)
+}
+
+func (s *handlerSuite) TestRoleAssignmentsV3Create_badSelector() {
+	var got errors.ErrorResponse
+	code := s.HandleRequest(
+		s.NewRequest("POST", "/api/role-assignments/v3/!!!/!!!", RoleAssignmentV3Edit{}),
+		&got)
+	s.Equal(http.StatusBadRequest, code)
+	s.Equal(errors.BadRequest, got.Type)
+	s.Contains(got.Message, "selector")
+}
+
+func (s *handlerSuite) TestRoleAssignmentsV3Create_forbidden() {
+	user := s.TestData.User_NonSuitable()
+	role := s.TestData.Role_SherlockSuperAdmin()
+	var got errors.ErrorResponse
+	code := s.HandleRequest(
+		s.NewRequest("POST", "/api/role-assignments/v3/"+utils.UintToString(role.ID)+"/"+utils.UintToString(user.ID), RoleAssignmentV3Edit{}),
+		&got)
+	s.Equal(http.StatusForbidden, code)
+	s.Equal(errors.Forbidden, got.Type)
+}
+
+func (s *handlerSuite) TestRoleAssignmentsV3Create() {
+	user := s.TestData.User_NonSuitable()
+	role := s.TestData.Role_SherlockSuperAdmin()
+	var got RoleAssignmentV3
+	code := s.HandleRequest(
+		s.NewSuperAdminRequest("POST", "/api/role-assignments/v3/"+utils.UintToString(role.ID)+"/"+utils.UintToString(user.ID), RoleAssignmentV3Edit{}),
+		&got)
+	s.Equal(http.StatusCreated, code)
+	s.Equal(role.ID, got.RoleInfo.ID)
+	s.Equal(user.ID, got.UserInfo.ID)
+}
+
+func (s *handlerSuite) TestRoleAssignmentsV3Create_breakGlassForbidden() {
+	user := s.TestData.User_Suitable()
+	role := s.TestData.Role_TerraGlassBrokenAdmin()
+	var got errors.ErrorResponse
+	code := s.HandleRequest(
+		s.NewSuitableRequest("POST", "/api/role-assignments/v3/"+utils.UintToString(role.ID)+"/"+utils.UintToString(user.ID), RoleAssignmentV3Edit{}),
+		&got)
+	s.Equal(http.StatusForbidden, code)
+	s.Equal(errors.Forbidden, got.Type)
+}
+
+func (s *handlerSuite) TestRoleAssignmentsV3Create_breakGlassAllowed() {
+	user := s.TestData.User_Suitable()
+	role := s.TestData.Role_TerraGlassBrokenAdmin()
+	var got RoleAssignmentV3
+	code := s.HandleRequest(
+		s.NewSuitableRequest("POST", "/api/role-assignments/v3/"+utils.UintToString(role.ID)+"/"+utils.UintToString(user.ID), RoleAssignmentV3Edit{
+			ExpiresAt: utils.PointerTo(time.Now().Add(time.Hour)),
+		}),
+		&got)
+	s.Equal(http.StatusCreated, code)
+	s.Equal(role.ID, got.RoleInfo.ID)
+	s.Equal(user.ID, got.UserInfo.ID)
+}

--- a/sherlock/internal/api/sherlock/role_assignments_v3_delete_test.go
+++ b/sherlock/internal/api/sherlock/role_assignments_v3_delete_test.go
@@ -1,0 +1,47 @@
+package sherlock
+
+import (
+	"github.com/broadinstitute/sherlock/go-shared/pkg/utils"
+	"github.com/broadinstitute/sherlock/sherlock/internal/errors"
+	"net/http"
+)
+
+func (s *handlerSuite) TestRoleAssignmentsV3Delete_notFound() {
+	var got errors.ErrorResponse
+	code := s.HandleRequest(
+		s.NewRequest("DELETE", "/api/role-assignments/v3/does-not-exist/me@example.com", nil),
+		&got)
+	s.Equal(http.StatusNotFound, code)
+	s.Equal(errors.NotFound, got.Type)
+}
+
+func (s *handlerSuite) TestRoleAssignmentsV3Delete_badSelector() {
+	var got errors.ErrorResponse
+	code := s.HandleRequest(
+		s.NewRequest("DELETE", "/api/role-assignments/v3/!!!/!!!", nil),
+		&got)
+	s.Equal(http.StatusBadRequest, code)
+	s.Equal(errors.BadRequest, got.Type)
+	s.Contains(got.Message, "selector")
+}
+
+func (s *handlerSuite) TestRoleAssignmentsV3Delete_forbidden() {
+	roleAssignment := s.TestData.RoleAssignment_Suitable_TerraEngineer()
+	var got errors.ErrorResponse
+	code := s.HandleRequest(
+		s.NewRequest("DELETE", "/api/role-assignments/v3/"+utils.UintToString(roleAssignment.RoleID)+"/"+utils.UintToString(roleAssignment.UserID), nil),
+		&got)
+	s.Equal(http.StatusForbidden, code)
+	s.Equal(errors.Forbidden, got.Type)
+}
+
+func (s *handlerSuite) TestRoleAssignmentsV3Delete() {
+	roleAssignment := s.TestData.RoleAssignment_NonSuitable_TerraEngineer()
+	var got RoleAssignmentV3
+	code := s.HandleRequest(
+		s.NewSuperAdminRequest("DELETE", "/api/role-assignments/v3/"+utils.UintToString(roleAssignment.RoleID)+"/"+utils.UintToString(roleAssignment.UserID), nil),
+		&got)
+	s.Equal(http.StatusOK, code)
+	s.Equal(roleAssignment.RoleID, got.RoleInfo.ID)
+	s.Equal(roleAssignment.UserID, got.UserInfo.ID)
+}

--- a/sherlock/internal/api/sherlock/role_assignments_v3_edit.go
+++ b/sherlock/internal/api/sherlock/role_assignments_v3_edit.go
@@ -69,5 +69,5 @@ func roleAssignmentsV3Edit(ctx *gin.Context) {
 		return
 	}
 
-	ctx.JSON(http.StatusCreated, roleAssignmentFromModel(toEdit))
+	ctx.JSON(http.StatusOK, roleAssignmentFromModel(toEdit))
 }

--- a/sherlock/internal/api/sherlock/role_assignments_v3_edit_test.go
+++ b/sherlock/internal/api/sherlock/role_assignments_v3_edit_test.go
@@ -1,0 +1,66 @@
+package sherlock
+
+import (
+	"github.com/broadinstitute/sherlock/go-shared/pkg/utils"
+	"github.com/broadinstitute/sherlock/sherlock/internal/errors"
+	"github.com/gin-gonic/gin"
+	"net/http"
+)
+
+func (s *handlerSuite) TestRoleAssignmentsV3Edit_notFound() {
+	var got errors.ErrorResponse
+	code := s.HandleRequest(
+		s.NewRequest("PATCH", "/api/role-assignments/v3/does-not-exist/me@example.com", RoleAssignmentV3Edit{}),
+		&got)
+	s.Equal(http.StatusNotFound, code)
+	s.Equal(errors.NotFound, got.Type)
+}
+
+func (s *handlerSuite) TestRoleAssignmentsV3Edit_badSelector() {
+	var got errors.ErrorResponse
+	code := s.HandleRequest(
+		s.NewRequest("PATCH", "/api/role-assignments/v3/!!!/!!!", RoleAssignmentV3Edit{}),
+		&got)
+	s.Equal(http.StatusBadRequest, code)
+	s.Equal(errors.BadRequest, got.Type)
+	s.Contains(got.Message, "selector")
+}
+
+func (s *handlerSuite) TestRoleAssignmentsV3Edit_badBody() {
+	roleAssignment := s.TestData.RoleAssignment_Suitable_TerraEngineer()
+	var got errors.ErrorResponse
+	code := s.HandleRequest(
+		s.NewRequest("PATCH", "/api/role-assignments/v3/"+utils.UintToString(roleAssignment.RoleID)+"/"+utils.UintToString(roleAssignment.UserID), gin.H{
+			"suspended": "not-a-bool",
+		}),
+		&got)
+	s.Equal(http.StatusBadRequest, code)
+	s.Equal(errors.BadRequest, got.Type)
+	s.Contains(got.Message, "suspended")
+}
+
+func (s *handlerSuite) TestRoleAssignmentsV3Edit_forbidden() {
+	roleAssignment := s.TestData.RoleAssignment_Suitable_TerraEngineer()
+	var got errors.ErrorResponse
+	code := s.HandleRequest(
+		s.NewRequest("PATCH", "/api/role-assignments/v3/"+utils.UintToString(roleAssignment.RoleID)+"/"+utils.UintToString(roleAssignment.UserID), RoleAssignmentV3Edit{
+			Suspended: utils.PointerTo(true),
+		}),
+		&got)
+	s.Equal(http.StatusForbidden, code)
+	s.Equal(errors.Forbidden, got.Type)
+}
+
+func (s *handlerSuite) TestRoleAssignmentsV3Edit() {
+	roleAssignment := s.TestData.RoleAssignment_NonSuitable_TerraEngineer()
+	var got RoleAssignmentV3
+	code := s.HandleRequest(
+		s.NewSuperAdminRequest("PATCH", "/api/role-assignments/v3/"+utils.UintToString(roleAssignment.RoleID)+"/"+utils.UintToString(roleAssignment.UserID), RoleAssignmentV3Edit{
+			Suspended: utils.PointerTo(true),
+		}),
+		&got)
+	s.Equal(http.StatusOK, code)
+	s.Equal(roleAssignment.RoleID, got.RoleInfo.ID)
+	s.Equal(roleAssignment.UserID, got.UserInfo.ID)
+	s.True(*got.Suspended)
+}

--- a/sherlock/internal/api/sherlock/role_assignments_v3_get.go
+++ b/sherlock/internal/api/sherlock/role_assignments_v3_get.go
@@ -54,5 +54,5 @@ func roleAssignmentsV3Get(ctx *gin.Context) {
 		return
 	}
 
-	ctx.JSON(http.StatusCreated, roleAssignmentFromModel(result))
+	ctx.JSON(http.StatusOK, roleAssignmentFromModel(result))
 }

--- a/sherlock/internal/api/sherlock/role_assignments_v3_get_test.go
+++ b/sherlock/internal/api/sherlock/role_assignments_v3_get_test.go
@@ -1,0 +1,37 @@
+package sherlock
+
+import (
+	"github.com/broadinstitute/sherlock/go-shared/pkg/utils"
+	"github.com/broadinstitute/sherlock/sherlock/internal/errors"
+	"net/http"
+)
+
+func (s *handlerSuite) TestRoleAssignmentsV3Get_notFound() {
+	var got errors.ErrorResponse
+	code := s.HandleRequest(
+		s.NewRequest("GET", "/api/role-assignments/v3/does-not-exist/me@example.com", nil),
+		&got)
+	s.Equal(http.StatusNotFound, code)
+	s.Equal(errors.NotFound, got.Type)
+}
+
+func (s *handlerSuite) TestRoleAssignmentsV3Get_badSelector() {
+	var got errors.ErrorResponse
+	code := s.HandleRequest(
+		s.NewRequest("GET", "/api/role-assignments/v3/!!!/!!!", nil),
+		&got)
+	s.Equal(http.StatusBadRequest, code)
+	s.Equal(errors.BadRequest, got.Type)
+	s.Contains(got.Message, "selector")
+}
+
+func (s *handlerSuite) TestRoleAssignmentsV3Get() {
+	roleAssignment := s.TestData.RoleAssignment_NonSuitable_TerraEngineer()
+	var got RoleAssignmentV3
+	code := s.HandleRequest(
+		s.NewSuperAdminRequest("GET", "/api/role-assignments/v3/"+utils.UintToString(roleAssignment.RoleID)+"/"+utils.UintToString(roleAssignment.UserID), nil),
+		&got)
+	s.Equal(http.StatusOK, code)
+	s.Equal(roleAssignment.RoleID, got.RoleInfo.ID)
+	s.Equal(roleAssignment.UserID, got.UserInfo.ID)
+}

--- a/sherlock/internal/api/sherlock/role_assignments_v3_list.go
+++ b/sherlock/internal/api/sherlock/role_assignments_v3_list.go
@@ -45,7 +45,7 @@ func roleAssignmentsV3List(ctx *gin.Context) {
 		errors.AbortRequest(ctx, fmt.Errorf("(%s) %v", errors.BadRequest, err))
 		return
 	}
-	var results []models.Role
+	var results []models.RoleAssignment
 	chain := db.
 		Where(&modelFilter)
 	if limit > 0 {
@@ -61,5 +61,5 @@ func roleAssignmentsV3List(ctx *gin.Context) {
 		return
 	}
 
-	ctx.JSON(http.StatusOK, utils.Map(results, roleFromModel))
+	ctx.JSON(http.StatusOK, utils.Map(results, roleAssignmentFromModel))
 }

--- a/sherlock/internal/api/sherlock/role_assignments_v3_list_test.go
+++ b/sherlock/internal/api/sherlock/role_assignments_v3_list_test.go
@@ -1,0 +1,93 @@
+package sherlock
+
+import (
+	"github.com/broadinstitute/sherlock/go-shared/pkg/utils"
+	"github.com/broadinstitute/sherlock/sherlock/internal/errors"
+	"net/http"
+	"time"
+)
+
+func (s *handlerSuite) TestRoleAssignmentsV3List_none() {
+	var got []RoleAssignmentV3
+	code := s.HandleRequest(
+		s.NewRequest("GET", "/api/role-assignments/v3", nil),
+		&got)
+	s.Equal(http.StatusOK, code)
+	s.Len(got, 4) // 4 role assignments relied upon by base-level test users
+}
+
+func (s *handlerSuite) TestRoleAssignmentsV3List_badFilter() {
+	var got errors.ErrorResponse
+	code := s.HandleRequest(
+		s.NewRequest("GET", "/api/role-assignments/v3?suspended=foo", nil),
+		&got)
+	s.Equal(http.StatusBadRequest, code)
+	s.Equal(errors.BadRequest, got.Type)
+}
+
+func (s *handlerSuite) TestRoleAssignmentsV3List_badLimit() {
+	var got errors.ErrorResponse
+	code := s.HandleRequest(
+		s.NewRequest("GET", "/api/role-assignments/v3?limit=foo", nil),
+		&got)
+	s.Equal(http.StatusBadRequest, code)
+	s.Equal(errors.BadRequest, got.Type)
+}
+
+func (s *handlerSuite) TestRoleAssignmentsV3List_badOffset() {
+	var got errors.ErrorResponse
+	code := s.HandleRequest(
+		s.NewRequest("GET", "/api/role-assignments/v3?offset=foo", nil),
+		&got)
+	s.Equal(http.StatusBadRequest, code)
+	s.Equal(errors.BadRequest, got.Type)
+}
+
+func (s *handlerSuite) TestRoleAssignmentsV3List() {
+	s.TestData.RoleAssignment_SuperAdmin_SherlockSuperAdmin()
+	s.TestData.RoleAssignment_Suitable_TerraSuitableEngineer()
+	s.TestData.RoleAssignment_Suitable_TerraEngineer()
+	s.TestData.RoleAssignment_NonSuitable_TerraEngineer()
+
+	s.Run("all", func() {
+		var got []RoleAssignmentV3
+		code := s.HandleRequest(
+			s.NewRequest("GET", "/api/role-assignments/v3", nil),
+			&got)
+		s.Equal(http.StatusOK, code)
+		s.Len(got, 4)
+	})
+	s.Run("none", func() {
+		var got []RoleAssignmentV3
+		code := s.HandleRequest(
+			s.NewRequest("GET", "/api/role-assignments/v3?expiresAt="+time.Now().Format(time.RFC3339), nil),
+			&got)
+		s.Equal(http.StatusOK, code)
+		s.Len(got, 0)
+	})
+	s.Run("some", func() {
+		s.SetSelfSuperAdminForDB()
+		s.NoError(s.DB.Model(utils.PointerTo(s.TestData.RoleAssignment_Suitable_TerraEngineer())).Update("suspended", true).Error)
+		var got []RoleAssignmentV3
+		code := s.HandleRequest(
+			s.NewRequest("GET", "/api/role-assignments/v3?suspended=true", nil),
+			&got)
+		s.Equal(http.StatusOK, code)
+		s.Len(got, 1)
+	})
+	s.Run("limit and offset", func() {
+		var got1 []RoleAssignmentV3
+		code := s.HandleRequest(
+			s.NewRequest("GET", "/api/role-assignments/v3?limit=1", nil),
+			&got1)
+		s.Equal(http.StatusOK, code)
+		s.Len(got1, 1)
+		var got2 []RoleAssignmentV3
+		code = s.HandleRequest(
+			s.NewRequest("GET", "/api/role-assignments/v3?limit=1&offset=1", nil),
+			&got2)
+		s.Equal(http.StatusOK, code)
+		s.Len(got2, 1)
+		s.True(got1[0].RoleInfo.ID != got2[0].RoleInfo.ID || got1[0].UserInfo.ID != got2[0].UserInfo.ID)
+	})
+}

--- a/sherlock/internal/api/sherlock/role_assignments_v3_test.go
+++ b/sherlock/internal/api/sherlock/role_assignments_v3_test.go
@@ -1,0 +1,13 @@
+package sherlock
+
+func (s *handlerSuite) Test_roleAssignmentFromModel() {
+	model := s.TestData.RoleAssignment_Suitable_TerraSuitableEngineer()
+	expected := RoleAssignmentV3{
+		RoleAssignmentV3Edit: RoleAssignmentV3Edit{
+			Suspended: model.Suspended,
+			ExpiresAt: model.ExpiresAt,
+		},
+	}
+	roleAssignment := roleAssignmentFromModel(model)
+	s.Equalf(expected, roleAssignment, "roleAssignmentFromModel()")
+}

--- a/sherlock/internal/api/sherlock/roles_v3.go
+++ b/sherlock/internal/api/sherlock/roles_v3.go
@@ -8,7 +8,7 @@ import (
 
 type RoleV3 struct {
 	CommonFields
-	CanbeGlassBrokenByRoleInfo *RoleV3             `json:"canBeGlassBrokenByRoleInfo,omitempty" swaggertype:"object" form:"-"`
+	CanBeGlassBrokenByRoleInfo *RoleV3             `json:"canBeGlassBrokenByRoleInfo,omitempty" swaggertype:"object" form:"-"`
 	Assignments                []*RoleAssignmentV3 `json:"assignments,omitempty" form:"-"`
 	RoleV3Edit
 }
@@ -48,7 +48,7 @@ func (r RoleV3Edit) toModel() models.Role {
 func roleFromModel(model models.Role) RoleV3 {
 	ret := RoleV3{
 		CommonFields:               commonFieldsFromGormModel(model.Model),
-		CanbeGlassBrokenByRoleInfo: utils.NilOrCall(roleFromModel, model.CanBeGlassBrokenByRole),
+		CanBeGlassBrokenByRoleInfo: utils.NilOrCall(roleFromModel, model.CanBeGlassBrokenByRole),
 		RoleV3Edit: RoleV3Edit{
 			Name:                    model.Name,
 			SuspendNonSuitableUsers: model.SuspendNonSuitableUsers,

--- a/sherlock/internal/api/sherlock/roles_v3_create_test.go
+++ b/sherlock/internal/api/sherlock/roles_v3_create_test.go
@@ -1,0 +1,55 @@
+package sherlock
+
+import (
+	"github.com/broadinstitute/sherlock/go-shared/pkg/utils"
+	"github.com/broadinstitute/sherlock/sherlock/internal/errors"
+	"github.com/gin-gonic/gin"
+	"net/http"
+)
+
+func (s *handlerSuite) TestRolesV3Create_badBody() {
+	var got errors.ErrorResponse
+	code := s.HandleRequest(
+		s.NewRequest("POST", "/api/roles/v3", gin.H{
+			"name": 123,
+		}),
+		&got)
+	s.Equal(http.StatusBadRequest, code)
+	s.Equal(errors.BadRequest, got.Type)
+	s.Contains(got.Message, "name")
+}
+
+func (s *handlerSuite) TestRolesV3Create_forbidden() {
+	var got errors.ErrorResponse
+	code := s.HandleRequest(
+		s.NewRequest("POST", "/api/roles/v3", RoleV3Edit{
+			Name: utils.PointerTo("new-role"),
+		}),
+		&got)
+	s.Equal(http.StatusForbidden, code)
+	s.Equal(errors.Forbidden, got.Type)
+}
+
+func (s *handlerSuite) TestRolesV3Create_invalid() {
+	var got errors.ErrorResponse
+	code := s.HandleRequest(
+		s.NewSuperAdminRequest("POST", "/api/roles/v3", RoleV3Edit{
+			Name: utils.PointerTo("new role with a space"),
+		}),
+		&got)
+	s.Equal(http.StatusBadRequest, code)
+	s.Equal(errors.BadRequest, got.Type)
+}
+
+func (s *handlerSuite) TestRolesV3Create() {
+	var got RoleV3
+	code := s.HandleRequest(
+		s.NewSuperAdminRequest("POST", "/api/roles/v3", RoleV3Edit{
+			Name: utils.PointerTo("new-role"),
+		}),
+		&got)
+	s.Equal(http.StatusCreated, code)
+	if s.NotNil(got.Name) {
+		s.Equal("new-role", *got.Name)
+	}
+}

--- a/sherlock/internal/api/sherlock/roles_v3_delete_test.go
+++ b/sherlock/internal/api/sherlock/roles_v3_delete_test.go
@@ -1,0 +1,44 @@
+package sherlock
+
+import (
+	"github.com/broadinstitute/sherlock/sherlock/internal/errors"
+	"net/http"
+)
+
+func (s *handlerSuite) TestRolesV3Delete_notFound() {
+	var got errors.ErrorResponse
+	code := s.HandleRequest(
+		s.NewRequest("DELETE", "/api/roles/v3/does-not-exist", nil),
+		&got)
+	s.Equal(http.StatusNotFound, code)
+	s.Equal(errors.NotFound, got.Type)
+}
+
+func (s *handlerSuite) TestRolesV3Delete_badSelector() {
+	var got errors.ErrorResponse
+	code := s.HandleRequest(
+		s.NewRequest("DELETE", "/api/roles/v3/!!!", nil),
+		&got)
+	s.Equal(http.StatusBadRequest, code)
+	s.Equal(errors.BadRequest, got.Type)
+	s.Contains(got.Message, "selector")
+}
+
+func (s *handlerSuite) TestRolesV3Delete_forbidden() {
+	role := s.TestData.Role_TerraSuitableEngineer()
+	var got errors.ErrorResponse
+	code := s.HandleRequest(
+		s.NewRequest("DELETE", "/api/roles/v3/"+*role.Name, nil),
+		&got)
+	s.Equal(http.StatusForbidden, code)
+	s.Equal(errors.Forbidden, got.Type)
+}
+
+func (s *handlerSuite) TestRolesV3Delete() {
+	role := s.TestData.Role_TerraSuitableEngineer()
+	var got RoleV3
+	code := s.HandleRequest(
+		s.NewSuperAdminRequest("DELETE", "/api/roles/v3/"+*role.Name, nil),
+		&got)
+	s.Equal(http.StatusOK, code)
+}

--- a/sherlock/internal/api/sherlock/roles_v3_delete_test.go
+++ b/sherlock/internal/api/sherlock/roles_v3_delete_test.go
@@ -41,4 +41,5 @@ func (s *handlerSuite) TestRolesV3Delete() {
 		s.NewSuperAdminRequest("DELETE", "/api/roles/v3/"+*role.Name, nil),
 		&got)
 	s.Equal(http.StatusOK, code)
+	s.Equal(role.ID, got.ID)
 }

--- a/sherlock/internal/api/sherlock/roles_v3_edit_test.go
+++ b/sherlock/internal/api/sherlock/roles_v3_edit_test.go
@@ -1,0 +1,67 @@
+package sherlock
+
+import (
+	"github.com/broadinstitute/sherlock/go-shared/pkg/utils"
+	"github.com/broadinstitute/sherlock/sherlock/internal/errors"
+	"github.com/gin-gonic/gin"
+	"net/http"
+)
+
+func (s *handlerSuite) TestRolesV3Edit_notFound() {
+	var got errors.ErrorResponse
+	code := s.HandleRequest(
+		s.NewRequest("PATCH", "/api/roles/v3/does-not-exist", RoleV3Edit{
+			Name: utils.PointerTo("some-new-role-name"),
+		}),
+		&got)
+	s.Equal(http.StatusNotFound, code)
+	s.Equal(errors.NotFound, got.Type)
+}
+
+func (s *handlerSuite) TestRolesV3Edit_badBody() {
+	var got errors.ErrorResponse
+	code := s.HandleRequest(
+		s.NewRequest("PATCH", "/api/roles/v3/1", gin.H{
+			"name": 123,
+		}),
+		&got)
+	s.Equal(http.StatusBadRequest, code)
+	s.Equal(errors.BadRequest, got.Type)
+	s.Contains(got.Message, "name")
+}
+
+func (s *handlerSuite) TestRolesV3Edit_badSelector() {
+	var got errors.ErrorResponse
+	code := s.HandleRequest(
+		s.NewRequest("PATCH", "/api/roles/v3/!!!", RoleV3Edit{
+			Name: utils.PointerTo("some-new-role-name"),
+		}),
+		&got)
+	s.Equal(http.StatusBadRequest, code)
+	s.Equal(errors.BadRequest, got.Type)
+	s.Contains(got.Message, "selector")
+}
+
+func (s *handlerSuite) TestRolesV3Edit_forbidden() {
+	role := s.TestData.Role_TerraSuitableEngineer()
+	var got errors.ErrorResponse
+	code := s.HandleRequest(
+		s.NewRequest("PATCH", "/api/roles/v3/"+*role.Name, RoleV3Edit{
+			Name: utils.PointerTo("some-new-role-name"),
+		}),
+		&got)
+	s.Equal(http.StatusForbidden, code)
+	s.Equal(errors.Forbidden, got.Type)
+}
+
+func (s *handlerSuite) TestRolesV3Edit() {
+	role := s.TestData.Role_TerraSuitableEngineer()
+	var got RoleV3
+	code := s.HandleRequest(
+		s.NewSuperAdminRequest("PATCH", "/api/roles/v3/"+*role.Name, RoleV3Edit{
+			Name: utils.PointerTo("some-new-role-name"),
+		}),
+		&got)
+	s.Equal(http.StatusOK, code)
+	s.Equal("some-new-role-name", *got.Name)
+}

--- a/sherlock/internal/api/sherlock/roles_v3_get_test.go
+++ b/sherlock/internal/api/sherlock/roles_v3_get_test.go
@@ -1,0 +1,35 @@
+package sherlock
+
+import (
+	"github.com/broadinstitute/sherlock/sherlock/internal/errors"
+	"net/http"
+)
+
+func (s *handlerSuite) TestRolesV3Get_notFound() {
+	var got errors.ErrorResponse
+	code := s.HandleRequest(
+		s.NewRequest("GET", "/api/roles/v3/does-not-exist", nil),
+		&got)
+	s.Equal(http.StatusNotFound, code)
+	s.Equal(errors.NotFound, got.Type)
+}
+
+func (s *handlerSuite) TestRolesV3Get_badSelector() {
+	var got errors.ErrorResponse
+	code := s.HandleRequest(
+		s.NewRequest("GET", "/api/roles/v3/!!!", nil),
+		&got)
+	s.Equal(http.StatusBadRequest, code)
+	s.Equal(errors.BadRequest, got.Type)
+	s.Contains(got.Message, "selector")
+}
+
+func (s *handlerSuite) TestRolesV3Get() {
+	role := s.TestData.Role_TerraSuitableEngineer()
+	var got RoleV3
+	code := s.HandleRequest(
+		s.NewSuperAdminRequest("GET", "/api/roles/v3/"+*role.Name, nil),
+		&got)
+	s.Equal(http.StatusOK, code)
+	s.Equal(role.ID, got.ID)
+}

--- a/sherlock/internal/api/sherlock/roles_v3_list_test.go
+++ b/sherlock/internal/api/sherlock/roles_v3_list_test.go
@@ -1,0 +1,89 @@
+package sherlock
+
+import (
+	"github.com/broadinstitute/sherlock/sherlock/internal/errors"
+	"net/http"
+)
+
+func (s *handlerSuite) TestRolesV3List_none() {
+	var got []RoleV3
+	code := s.HandleRequest(
+		s.NewRequest("GET", "/api/roles/v3", nil),
+		&got)
+	s.Equal(http.StatusOK, code)
+	s.Len(got, 3) // 3 roles relied upon by base-level test users
+}
+
+func (s *handlerSuite) TestRolesV3List_badFilter() {
+	var got errors.ErrorResponse
+	code := s.HandleRequest(
+		s.NewRequest("GET", "/api/roles/v3?id=foo", nil),
+		&got)
+	s.Equal(http.StatusBadRequest, code)
+	s.Equal(errors.BadRequest, got.Type)
+}
+
+func (s *handlerSuite) TestRolesV3List_badLimit() {
+	var got errors.ErrorResponse
+	code := s.HandleRequest(
+		s.NewRequest("GET", "/api/roles/v3?limit=foo", nil),
+		&got)
+	s.Equal(http.StatusBadRequest, code)
+	s.Equal(errors.BadRequest, got.Type)
+}
+
+func (s *handlerSuite) TestRolesV3List_badOffset() {
+	var got errors.ErrorResponse
+	code := s.HandleRequest(
+		s.NewRequest("GET", "/api/roles/v3?offset=foo", nil),
+		&got)
+	s.Equal(http.StatusBadRequest, code)
+	s.Equal(errors.BadRequest, got.Type)
+}
+
+func (s *handlerSuite) TestRolesV3List() {
+	s.TestData.Role_SherlockSuperAdmin()
+	s.TestData.Role_TerraEngineer()
+	s.TestData.Role_TerraSuitableEngineer()
+	s.TestData.Role_TerraGlassBrokenAdmin()
+
+	s.Run("all", func() {
+		var got []RoleV3
+		code := s.HandleRequest(
+			s.NewRequest("GET", "/api/roles/v3", nil),
+			&got)
+		s.Equal(http.StatusOK, code)
+		s.Len(got, 4)
+	})
+	s.Run("none", func() {
+		var got []RoleV3
+		code := s.HandleRequest(
+			s.NewRequest("GET", "/api/roles/v3?name=foo", nil),
+			&got)
+		s.Equal(http.StatusOK, code)
+		s.Len(got, 0)
+	})
+	s.Run("some", func() {
+		var got []RoleV3
+		code := s.HandleRequest(
+			s.NewRequest("GET", "/api/roles/v3?name=terra-engineer", nil),
+			&got)
+		s.Equal(http.StatusOK, code)
+		s.Len(got, 1)
+	})
+	s.Run("limit and offset", func() {
+		var got1 []RoleV3
+		code := s.HandleRequest(
+			s.NewRequest("GET", "/api/roles/v3?limit=1", nil),
+			&got1)
+		s.Equal(http.StatusOK, code)
+		s.Len(got1, 1)
+		var got2 []RoleV3
+		code = s.HandleRequest(
+			s.NewRequest("GET", "/api/roles/v3?limit=1&offset=1", nil),
+			&got2)
+		s.Equal(http.StatusOK, code)
+		s.Len(got2, 1)
+		s.NotEqual(got1[0].ID, got2[0].ID)
+	})
+}

--- a/sherlock/internal/api/sherlock/roles_v3_test.go
+++ b/sherlock/internal/api/sherlock/roles_v3_test.go
@@ -1,0 +1,37 @@
+package sherlock
+
+import (
+	"github.com/broadinstitute/sherlock/go-shared/pkg/utils"
+	"github.com/broadinstitute/sherlock/sherlock/internal/models"
+	"time"
+)
+
+func (s *handlerSuite) Test_roleFromModel() {
+	model := s.TestData.Role_TerraSuitableEngineer()
+	expected := RoleV3{
+		CommonFields: CommonFields{
+			ID:        model.ID,
+			CreatedAt: model.CreatedAt,
+			UpdatedAt: model.UpdatedAt,
+		},
+		RoleV3Edit: RoleV3Edit{
+			Name:                      model.Name,
+			SuspendNonSuitableUsers:   model.SuspendNonSuitableUsers,
+			CanBeGlassBrokenByRole:    model.CanBeGlassBrokenByRoleID,
+			DefaultGlassBreakDuration: nil,
+			GrantsSherlockSuperAdmin:  model.GrantsSherlockSuperAdmin,
+			GrantsDevFirecloudGroup:   model.GrantsDevFirecloudGroup,
+			GrantsDevAzureGroup:       model.GrantsDevAzureGroup,
+		},
+	}
+	role := roleFromModel(model)
+	s.Equalf(expected, role, "roleFromModel()")
+}
+
+func (s *handlerSuite) Test_roleFromModel_duration() {
+	s.Equal(&Duration{time.Hour}, roleFromModel(models.Role{
+		RoleFields: models.RoleFields{
+			DefaultGlassBreakDuration: utils.PointerTo(time.Hour.Nanoseconds()),
+		},
+	}).DefaultGlassBreakDuration)
+}

--- a/sherlock/internal/api/sherlock/users_v3_list_test.go
+++ b/sherlock/internal/api/sherlock/users_v3_list_test.go
@@ -14,18 +14,21 @@ func (s *handlerSuite) TestUsersV3List_minimal() {
 		s.NewRequest("GET", "/api/users/v3", nil),
 		&got)
 	s.Equal(http.StatusOK, code)
-	s.Len(got, 3) // nonsuitable user + suitable user + self
+	s.Len(got, 4) // admin user + nonsuitable user + suitable user + self
 	// This'll never return 0 because the calling user will be upserted, but
 	// we can check that the only entries here are ourselves and the self
 	// user
 	s.Run("first alphabetical user is the nonsuitable user in the test data", func() {
 		s.Equal(s.TestData.User_NonSuitable().Email, got[0].Email)
 	})
-	s.Run("second alphabetical user is Sherlock's own self", func() {
-		s.Equal(self.Email, got[1].Email)
+	s.Run("second alphabetical user is the super admin user in the test data", func() {
+		s.Equal(s.TestData.User_SuperAdmin().Email, got[1].Email)
 	})
-	s.Run("third alphabetical user is the suitable user we made the request as", func() {
-		s.Equal(s.TestData.User_Suitable().Email, got[2].Email)
+	s.Run("third alphabetical user is Sherlock's own self", func() {
+		s.Equal(self.Email, got[2].Email)
+	})
+	s.Run("fourth alphabetical user is the suitable user we made the request as", func() {
+		s.Equal(s.TestData.User_Suitable().Email, got[3].Email)
 	})
 }
 
@@ -85,7 +88,7 @@ func (s *handlerSuite) TestUsersV3List() {
 			s.NewRequest("GET", "/api/users/v3", nil),
 			&got)
 		s.Equal(http.StatusOK, code)
-		s.Len(got, 6) // test suitable user + test nonsuitable user + self + 3
+		s.Len(got, 7) // test admin user + test suitable user + test nonsuitable user + self + 3
 		s.Run("each has suitability", func() {
 			for _, user := range got {
 				s.NotZero(user.Suitable)

--- a/sherlock/internal/authentication/middleware.go
+++ b/sherlock/internal/authentication/middleware.go
@@ -33,7 +33,7 @@ func Middleware(db *gorm.DB) gin.HandlersChain {
 // and references models.TestData's User_Suitable and User_NonSuitable instances of models.User.
 func TestMiddleware(db *gorm.DB, td models.TestData) gin.HandlersChain {
 	return gin.HandlersChain{
-		setUserWhoConnected(db, test_users.MakeHeaderParser(td.User_Suitable(), td.User_NonSuitable()), authentication_method.TEST),
+		setUserWhoConnected(db, test_users.MakeHeaderParser(td.User_SuperAdmin(), td.User_Suitable(), td.User_NonSuitable()), authentication_method.TEST),
 		setGithubClaimsAndEscalateUser(db),
 		setDatabaseWithUser(db),
 	}

--- a/sherlock/internal/authentication/test_users/parse_header_test.go
+++ b/sherlock/internal/authentication/test_users/parse_header_test.go
@@ -10,11 +10,17 @@ import (
 )
 
 func TestParseHeader(t *testing.T) {
+	superAdminTestUserEmail := "super admin test user email"
+	superAdminTestUserGoogleID := "super admin test user google id"
 	suitableTestUserEmail := "suitable test user email"
 	suitableTestUserGoogleID := "suitable test user google id"
 	nonSuitableTestUserEmail := "non-suitable test user email"
 	nonSuitableTestUserGoogleID := "non-suitable test user google id"
 	parseHeader := MakeHeaderParser(
+		models.User{
+			Email:    superAdminTestUserEmail,
+			GoogleID: superAdminTestUserGoogleID,
+		},
 		models.User{
 			Email:    suitableTestUserEmail,
 			GoogleID: suitableTestUserGoogleID,
@@ -27,6 +33,24 @@ func TestParseHeader(t *testing.T) {
 	t.Run("default", func(t *testing.T) {
 		req, err := http.NewRequest("GET", "/", nil)
 		assert.NoError(t, err)
+		email, googleID, err := parseHeader(&gin.Context{Request: req})
+		assert.NoError(t, err)
+		assert.Equal(t, suitableTestUserEmail, email)
+		assert.Equal(t, suitableTestUserGoogleID, googleID)
+	})
+	t.Run("explicitly super admin", func(t *testing.T) {
+		req, err := http.NewRequest("GET", "/", nil)
+		assert.NoError(t, err)
+		req.Header.Set(superAdminControlHeader, strconv.FormatBool(true))
+		email, googleID, err := parseHeader(&gin.Context{Request: req})
+		assert.NoError(t, err)
+		assert.Equal(t, superAdminTestUserEmail, email)
+		assert.Equal(t, superAdminTestUserGoogleID, googleID)
+	})
+	t.Run("explicitly non-super admin", func(t *testing.T) {
+		req, err := http.NewRequest("GET", "/", nil)
+		assert.NoError(t, err)
+		req.Header.Set(superAdminControlHeader, strconv.FormatBool(false))
 		email, googleID, err := parseHeader(&gin.Context{Request: req})
 		assert.NoError(t, err)
 		assert.Equal(t, suitableTestUserEmail, email)
@@ -50,11 +74,26 @@ func TestParseHeader(t *testing.T) {
 		assert.Equal(t, nonSuitableTestUserEmail, email)
 		assert.Equal(t, nonSuitableTestUserGoogleID, googleID)
 	})
+	t.Run("errors if can't parse superAdminControlHeader", func(t *testing.T) {
+		req, err := http.NewRequest("GET", "/", nil)
+		assert.NoError(t, err)
+		req.Header.Set(superAdminControlHeader, "something that isn't boolean")
+		_, _, err = parseHeader(&gin.Context{Request: req})
+		assert.ErrorContains(t, err, "failed to parse boolean")
+	})
 	t.Run("errors if can't parse suitableControlHeader", func(t *testing.T) {
 		req, err := http.NewRequest("GET", "/", nil)
 		assert.NoError(t, err)
 		req.Header.Set(suitableControlHeader, "something that isn't boolean")
 		_, _, err = parseHeader(&gin.Context{Request: req})
 		assert.ErrorContains(t, err, "failed to parse boolean")
+	})
+	t.Run("errors if super admin is asked to be non-suitable", func(t *testing.T) {
+		req, err := http.NewRequest("GET", "/", nil)
+		assert.NoError(t, err)
+		req.Header.Set(superAdminControlHeader, strconv.FormatBool(true))
+		req.Header.Set(suitableControlHeader, strconv.FormatBool(false))
+		_, _, err = parseHeader(&gin.Context{Request: req})
+		assert.ErrorContains(t, err, "super admin cannot be non-suitable")
 	})
 }

--- a/sherlock/internal/authentication/test_users/test_suite_helper.go
+++ b/sherlock/internal/authentication/test_users/test_suite_helper.go
@@ -13,16 +13,31 @@ import (
 // headers from tests)
 type TestUserHelper struct{}
 
-// UseSuitableUserFor sets suitableControlHeader such that ParseHeader will supply SuitableTestUserEmail.
-// This is ParseHeader's default behavior, but this function can be helpful for clarity or undoing
-// UseNonSuitableUserFor.
+// UseSuperAdminUserFor sets superAdminControlHeader such that ParseHeader will supply the email of a super admin user.
+func (h TestUserHelper) UseSuperAdminUserFor(req *http.Request) *http.Request {
+	return h.selectUserForRequestBySuperUser(req, true)
+}
+
+// UseNonSuperAdminUserFor sets superAdminControlHeader such that ParseHeader will supply the email of a non-super admin user.
+// This is ParseHeader's default behavior, but this function can be helpful for clarity or undoing UseSuperAdminUserFor.
+func (h TestUserHelper) UseNonSuperAdminUserFor(req *http.Request) *http.Request {
+	return h.selectUserForRequestBySuperUser(req, false)
+}
+
+// UseSuitableUserFor sets suitableControlHeader such that ParseHeader will supply the email of a suitable user.
+// This is ParseHeader's default behavior, but this function can be helpful for clarity or undoing UseNonSuitableUserFor.
 func (h TestUserHelper) UseSuitableUserFor(req *http.Request) *http.Request {
 	return h.selectUserForRequestBySuitability(req, true)
 }
 
-// UseNonSuitableUserFor sets suitableControlHeader such that ParseHeader will supply NonSuitableTestUserEmail.
+// UseNonSuitableUserFor sets suitableControlHeader such that ParseHeader will supply the email of a non-suitable user.
 func (h TestUserHelper) UseNonSuitableUserFor(req *http.Request) *http.Request {
 	return h.selectUserForRequestBySuitability(req, false)
+}
+
+func (_ TestUserHelper) selectUserForRequestBySuperUser(req *http.Request, superUser bool) *http.Request {
+	req.Header.Set(superAdminControlHeader, strconv.FormatBool(superUser))
+	return req
 }
 
 func (_ TestUserHelper) selectUserForRequestBySuitability(req *http.Request, suitable bool) *http.Request {

--- a/sherlock/internal/authentication/test_users/test_suite_helper_test.go
+++ b/sherlock/internal/authentication/test_users/test_suite_helper_test.go
@@ -7,6 +7,24 @@ import (
 	"testing"
 )
 
+func TestUseSuperAdminUserFor(t *testing.T) {
+	req, err := http.NewRequest("GET", "/", nil)
+	assert.NoError(t, err)
+	TestUserHelper{}.UseSuperAdminUserFor(req)
+	superAdmin, err := strconv.ParseBool(req.Header.Get(superAdminControlHeader))
+	assert.NoError(t, err)
+	assert.True(t, superAdmin)
+}
+
+func TestUseNonSuperAdminUserFor(t *testing.T) {
+	req, err := http.NewRequest("GET", "/", nil)
+	assert.NoError(t, err)
+	TestUserHelper{}.UseNonSuperAdminUserFor(req)
+	superAdmin, err := strconv.ParseBool(req.Header.Get(superAdminControlHeader))
+	assert.NoError(t, err)
+	assert.False(t, superAdmin)
+}
+
 func TestUseSuitableUserFor(t *testing.T) {
 	req, err := http.NewRequest("GET", "/", nil)
 	assert.NoError(t, err)

--- a/sherlock/internal/models/role_assignment.go
+++ b/sherlock/internal/models/role_assignment.go
@@ -90,6 +90,9 @@ func (ra *RoleAssignment) errorIfForbidden(tx *gorm.DB) error {
 					// If the expiry is too far in the future, bail
 					// (We fudge the timing by a second to account for the fact that the expiry is inclusive)
 					return fmt.Errorf("(%s) role %s (%d) can be glass-broken by the caller but the expiry on the break-glass assignment is too far in the future (must be within %s of now)", errors.Forbidden, *targetRole.Name, current.RoleID, time.Duration(*targetRole.DefaultGlassBreakDuration).String())
+				} else if current.Suspended != nil && *current.Suspended {
+					// If the assigment is suspended, bail, break-glass and suspensions don't mix
+					return fmt.Errorf("(%s) role %s (%d) can be glass-broken by the caller but the break-glass assignment is suspended (break-glass and suspensions don't mix)", errors.Forbidden, *targetRole.Name, current.RoleID)
 				} else {
 					// If we get all the way here, the operation is valid
 					return nil

--- a/sherlock/internal/models/role_assignment_test.go
+++ b/sherlock/internal/models/role_assignment_test.go
@@ -1,0 +1,274 @@
+package models
+
+import (
+	"github.com/broadinstitute/sherlock/go-shared/pkg/utils"
+	"github.com/broadinstitute/sherlock/sherlock/internal/errors"
+	"github.com/jinzhu/copier"
+	"time"
+)
+
+func (s *modelSuite) TestRoleAssignmentUnauthorizedCreate() {
+	roleAssignment := RoleAssignment{
+		RoleID: s.TestData.Role_TerraEngineer().ID,
+		UserID: s.TestData.User_NonSuitable().ID,
+		RoleAssignmentFields: RoleAssignmentFields{
+			Suspended: utils.PointerTo(false),
+		},
+	}
+	s.SetUserForDB(nil)
+	err := s.DB.Create(&roleAssignment).Error
+	s.ErrorContains(err, "database user was nil")
+}
+
+func (s *modelSuite) TestRoleAssignmentForbiddenCreate() {
+	roleAssignment := RoleAssignment{
+		RoleID: s.TestData.Role_TerraEngineer().ID,
+		UserID: s.TestData.User_NonSuitable().ID,
+		RoleAssignmentFields: RoleAssignmentFields{
+			Suspended: utils.PointerTo(false),
+		},
+	}
+	s.SetSuitableTestUserForDB()
+	err := s.DB.Create(&roleAssignment).Error
+	s.ErrorContains(err, errors.Forbidden)
+}
+
+func (s *modelSuite) TestRoleAssignmentAllowedCreate() {
+	roleAssignment := RoleAssignment{
+		RoleID: s.TestData.Role_TerraEngineer().ID,
+		UserID: s.TestData.User_NonSuitable().ID,
+		RoleAssignmentFields: RoleAssignmentFields{
+			Suspended: utils.PointerTo(false),
+		},
+	}
+	s.SetSelfSuperAdminForDB()
+	err := s.DB.Create(&roleAssignment).Error
+	s.NoError(err)
+	s.Run("journaled", func() {
+		var roleAssignmentOperation RoleAssignmentOperation
+		err := s.DB.Where(&RoleAssignmentOperation{
+			RoleID:    roleAssignment.RoleID,
+			UserID:    roleAssignment.UserID,
+			Operation: "create",
+		}).First(&roleAssignmentOperation).Error
+		s.NoError(err)
+		s.Equal(roleAssignment.RoleAssignmentFields, roleAssignmentOperation.To)
+	})
+}
+
+func (s *modelSuite) TestRoleAssignmentBreakGlassForbiddenLacksRole() {
+	breakGlassRoleAssignment := RoleAssignment{
+		RoleID: s.TestData.Role_TerraGlassBrokenAdmin().ID,
+		UserID: s.TestData.User_Suitable().ID,
+		RoleAssignmentFields: RoleAssignmentFields{
+			Suspended: utils.PointerTo(false),
+			ExpiresAt: utils.PointerTo(time.Now().Add(time.Hour)),
+		},
+	}
+	s.SetSuitableTestUserForDB()
+	err := s.DB.Create(&breakGlassRoleAssignment).Error
+	s.ErrorContains(err, errors.Forbidden)
+	s.ErrorContains(err, "caller has neither that role nor super-admin")
+}
+
+func (s *modelSuite) TestRoleAssignmentBreakGlassForbiddenIsSuspended() {
+	baseRoleAssignment := s.TestData.RoleAssignment_Suitable_TerraSuitableEngineer()
+	s.NoError(s.DB.
+		Model(&baseRoleAssignment).
+		Updates(&RoleAssignment{
+			RoleAssignmentFields: RoleAssignmentFields{
+				Suspended: utils.PointerTo(true),
+			},
+		}).Error)
+	breakGlassRoleAssignment := RoleAssignment{
+		RoleID: s.TestData.Role_TerraGlassBrokenAdmin().ID,
+		UserID: s.TestData.User_Suitable().ID,
+		RoleAssignmentFields: RoleAssignmentFields{
+			Suspended: utils.PointerTo(false),
+			ExpiresAt: utils.PointerTo(time.Now().Add(time.Hour)),
+		},
+	}
+	s.SetSuitableTestUserForDB(true)
+	err := s.DB.Create(&breakGlassRoleAssignment).Error
+	s.ErrorContains(err, errors.Forbidden)
+	s.ErrorContains(err, "caller has that role but their assignment is suspended")
+}
+
+func (s *modelSuite) TestRoleAssignmentBreakGlassForbiddenNoExpiry() {
+	s.TestData.RoleAssignment_Suitable_TerraSuitableEngineer()
+	breakGlassRoleAssignment := RoleAssignment{
+		RoleID: s.TestData.Role_TerraGlassBrokenAdmin().ID,
+		UserID: s.TestData.User_Suitable().ID,
+		RoleAssignmentFields: RoleAssignmentFields{
+			Suspended: utils.PointerTo(false),
+			ExpiresAt: nil,
+		},
+	}
+	s.SetSuitableTestUserForDB(true)
+	err := s.DB.Create(&breakGlassRoleAssignment).Error
+	s.ErrorContains(err, errors.Forbidden)
+	s.ErrorContains(err, "glass-break assignments require an expiry")
+}
+
+func (s *modelSuite) TestRoleAssignmentBreakGlassForbiddenExpiryBeforeNow() {
+	s.TestData.RoleAssignment_Suitable_TerraSuitableEngineer()
+	breakGlassRoleAssignment := RoleAssignment{
+		RoleID: s.TestData.Role_TerraGlassBrokenAdmin().ID,
+		UserID: s.TestData.User_Suitable().ID,
+		RoleAssignmentFields: RoleAssignmentFields{
+			Suspended: utils.PointerTo(false),
+			ExpiresAt: utils.PointerTo(time.Now().Add(-time.Hour)),
+		},
+	}
+	s.SetSuitableTestUserForDB(true)
+	err := s.DB.Create(&breakGlassRoleAssignment).Error
+	s.ErrorContains(err, errors.Forbidden)
+	s.ErrorContains(err, "the expiry on the break-glass assignment is in the past")
+}
+
+func (s *modelSuite) TestRoleAssignmentBreakGlassForbiddenExpiryTooFarFuture() {
+	s.TestData.RoleAssignment_Suitable_TerraSuitableEngineer()
+	breakGlassRoleAssignment := RoleAssignment{
+		RoleID: s.TestData.Role_TerraGlassBrokenAdmin().ID,
+		UserID: s.TestData.User_Suitable().ID,
+		RoleAssignmentFields: RoleAssignmentFields{
+			Suspended: utils.PointerTo(false),
+			ExpiresAt: utils.PointerTo(time.Now().Add(time.Duration(*s.TestData.Role_TerraGlassBrokenAdmin().DefaultGlassBreakDuration) * 2)),
+		},
+	}
+	s.SetSuitableTestUserForDB(true)
+	err := s.DB.Create(&breakGlassRoleAssignment).Error
+	s.ErrorContains(err, errors.Forbidden)
+	s.ErrorContains(err, "the expiry on the break-glass assignment is too far in the future")
+}
+
+func (s *modelSuite) TestRoleAssignmentBreakGlassAllowed() {
+	s.TestData.RoleAssignment_Suitable_TerraSuitableEngineer()
+	breakGlassRoleAssignment := RoleAssignment{
+		RoleID: s.TestData.Role_TerraGlassBrokenAdmin().ID,
+		UserID: s.TestData.User_Suitable().ID,
+		RoleAssignmentFields: RoleAssignmentFields{
+			Suspended: utils.PointerTo(false),
+			ExpiresAt: utils.PointerTo(time.Now().Add(time.Hour)),
+		},
+	}
+	s.SetSuitableTestUserForDB(true)
+	err := s.DB.Create(&breakGlassRoleAssignment).Error
+	s.NoError(err)
+}
+
+func (s *modelSuite) TestRoleAssignmentUnauthorizedEdit() {
+	roleAssignment := s.TestData.RoleAssignment_NonSuitable_TerraEngineer()
+	s.SetUserForDB(nil)
+	err := s.DB.Model(&roleAssignment).Updates(&RoleAssignment{
+		RoleAssignmentFields: RoleAssignmentFields{
+			Suspended: utils.PointerTo(true),
+		},
+	}).Error
+	s.ErrorContains(err, "database user was nil")
+}
+
+func (s *modelSuite) TestRoleAssignmentForbiddenEdit() {
+	roleAssignment := s.TestData.RoleAssignment_NonSuitable_TerraEngineer()
+	s.SetSuitableTestUserForDB()
+	err := s.DB.Model(&roleAssignment).Updates(&RoleAssignment{
+		RoleAssignmentFields: RoleAssignmentFields{
+			Suspended: utils.PointerTo(true),
+		},
+	}).Error
+	s.ErrorContains(err, errors.Forbidden)
+}
+
+func (s *modelSuite) TestRoleAssignmentAllowedEdit() {
+	roleAssignment := s.TestData.RoleAssignment_NonSuitable_TerraEngineer()
+	var before, after RoleAssignment
+	s.NoError(copier.CopyWithOption(&before, &roleAssignment, copier.Option{DeepCopy: true}))
+	s.SetSelfSuperAdminForDB()
+	err := s.DB.Model(&roleAssignment).Updates(&RoleAssignment{
+		RoleAssignmentFields: RoleAssignmentFields{
+			Suspended: utils.PointerTo(true),
+		},
+	}).Error
+	s.NoError(err)
+	s.NoError(s.DB.Where(&RoleAssignment{
+		RoleID: roleAssignment.RoleID,
+		UserID: roleAssignment.UserID,
+	}).First(&after).Error)
+	s.Run("journaled", func() {
+		var roleAssignmentOperation RoleAssignmentOperation
+		err := s.DB.Where(&RoleAssignmentOperation{
+			RoleID:    roleAssignment.RoleID,
+			UserID:    roleAssignment.UserID,
+			Operation: "update",
+		}).First(&roleAssignmentOperation).Error
+		s.NoError(err)
+		s.Equal(before.RoleAssignmentFields, roleAssignmentOperation.From)
+		s.Equal(after.RoleAssignmentFields, roleAssignmentOperation.To)
+	})
+}
+
+func (s *modelSuite) TestRoleAssignmentUnauthorizedDelete() {
+	roleAssignment := s.TestData.RoleAssignment_NonSuitable_TerraEngineer()
+	s.SetUserForDB(nil)
+	err := s.DB.Delete(&roleAssignment).Error
+	s.ErrorContains(err, "database user was nil")
+
+}
+
+func (s *modelSuite) TestRoleAssignmentForbiddenDelete() {
+	roleAssignment := s.TestData.RoleAssignment_NonSuitable_TerraEngineer()
+	s.SetSuitableTestUserForDB()
+	err := s.DB.Delete(&roleAssignment).Error
+	s.ErrorContains(err, errors.Forbidden)
+}
+
+func (s *modelSuite) TestRoleAssignmentAllowedDelete() {
+	roleAssignment := s.TestData.RoleAssignment_NonSuitable_TerraEngineer()
+	s.SetSelfSuperAdminForDB()
+	err := s.DB.Delete(&roleAssignment).Error
+	s.NoError(err)
+	s.Run("journaled", func() {
+		var roleAssignmentOperation RoleAssignmentOperation
+		err := s.DB.Where(&RoleAssignmentOperation{
+			RoleID:    roleAssignment.RoleID,
+			UserID:    roleAssignment.UserID,
+			Operation: "delete",
+		}).First(&roleAssignmentOperation).Error
+		s.NoError(err)
+		s.Equal(roleAssignment.RoleAssignmentFields, roleAssignmentOperation.From)
+	})
+}
+
+func (s *modelSuite) TestRoleAssignmentInvalidMissingRole() {
+	roleAssignment := RoleAssignment{
+		UserID: s.TestData.User_NonSuitable().ID,
+		RoleAssignmentFields: RoleAssignmentFields{
+			Suspended: utils.PointerTo(false),
+		},
+	}
+	s.SetSelfSuperAdminForDB()
+	err := s.DB.Create(&roleAssignment).Error
+	s.ErrorContains(err, "fk_role_assignments_role_id")
+}
+
+func (s *modelSuite) TestRoleAssignmentInvalidMissingUser() {
+	roleAssignment := RoleAssignment{
+		RoleID: s.TestData.Role_TerraEngineer().ID,
+		RoleAssignmentFields: RoleAssignmentFields{
+			Suspended: utils.PointerTo(false),
+		},
+	}
+	s.SetSelfSuperAdminForDB()
+	err := s.DB.Create(&roleAssignment).Error
+	s.ErrorContains(err, "fk_role_assignments_user_id")
+}
+
+func (s *modelSuite) TestRoleAssignmentInvalidMissingSuspended() {
+	roleAssignment := RoleAssignment{
+		RoleID: s.TestData.Role_TerraEngineer().ID,
+		UserID: s.TestData.User_NonSuitable().ID,
+	}
+	s.SetSelfSuperAdminForDB()
+	err := s.DB.Create(&roleAssignment).Error
+	s.ErrorContains(err, "suspended")
+}

--- a/sherlock/internal/models/role_assignment_test.go
+++ b/sherlock/internal/models/role_assignment_test.go
@@ -9,7 +9,7 @@ import (
 
 func (s *modelSuite) TestRoleAssignmentUnauthorizedCreate() {
 	roleAssignment := RoleAssignment{
-		RoleID: s.TestData.Role_TerraEngineer().ID,
+		RoleID: s.TestData.Role_SherlockSuperAdmin().ID,
 		UserID: s.TestData.User_NonSuitable().ID,
 		RoleAssignmentFields: RoleAssignmentFields{
 			Suspended: utils.PointerTo(false),
@@ -22,7 +22,7 @@ func (s *modelSuite) TestRoleAssignmentUnauthorizedCreate() {
 
 func (s *modelSuite) TestRoleAssignmentForbiddenCreate() {
 	roleAssignment := RoleAssignment{
-		RoleID: s.TestData.Role_TerraEngineer().ID,
+		RoleID: s.TestData.Role_SherlockSuperAdmin().ID,
 		UserID: s.TestData.User_NonSuitable().ID,
 		RoleAssignmentFields: RoleAssignmentFields{
 			Suspended: utils.PointerTo(false),
@@ -34,16 +34,7 @@ func (s *modelSuite) TestRoleAssignmentForbiddenCreate() {
 }
 
 func (s *modelSuite) TestRoleAssignmentAllowedCreate() {
-	roleAssignment := RoleAssignment{
-		RoleID: s.TestData.Role_TerraEngineer().ID,
-		UserID: s.TestData.User_NonSuitable().ID,
-		RoleAssignmentFields: RoleAssignmentFields{
-			Suspended: utils.PointerTo(false),
-		},
-	}
-	s.SetSelfSuperAdminForDB()
-	err := s.DB.Create(&roleAssignment).Error
-	s.NoError(err)
+	roleAssignment := s.TestData.RoleAssignment_NonSuitable_TerraEngineer()
 	s.Run("journaled", func() {
 		var roleAssignmentOperation RoleAssignmentOperation
 		err := s.DB.Where(&RoleAssignmentOperation{
@@ -59,13 +50,13 @@ func (s *modelSuite) TestRoleAssignmentAllowedCreate() {
 func (s *modelSuite) TestRoleAssignmentBreakGlassForbiddenLacksRole() {
 	breakGlassRoleAssignment := RoleAssignment{
 		RoleID: s.TestData.Role_TerraGlassBrokenAdmin().ID,
-		UserID: s.TestData.User_Suitable().ID,
+		UserID: s.TestData.User_NonSuitable().ID,
 		RoleAssignmentFields: RoleAssignmentFields{
 			Suspended: utils.PointerTo(false),
 			ExpiresAt: utils.PointerTo(time.Now().Add(time.Hour)),
 		},
 	}
-	s.SetSuitableTestUserForDB()
+	s.SetNonSuitableTestUserForDB()
 	err := s.DB.Create(&breakGlassRoleAssignment).Error
 	s.ErrorContains(err, errors.Forbidden)
 	s.ErrorContains(err, "caller has neither that role nor super-admin")

--- a/sherlock/internal/models/role_assignment_test.go
+++ b/sherlock/internal/models/role_assignment_test.go
@@ -133,6 +133,22 @@ func (s *modelSuite) TestRoleAssignmentBreakGlassForbiddenExpiryTooFarFuture() {
 	s.ErrorContains(err, "the expiry on the break-glass assignment is too far in the future")
 }
 
+func (s *modelSuite) TestRoleAssignmentBreakGlassForbiddenSuspended() {
+	s.TestData.RoleAssignment_Suitable_TerraSuitableEngineer()
+	breakGlassRoleAssignment := RoleAssignment{
+		RoleID: s.TestData.Role_TerraGlassBrokenAdmin().ID,
+		UserID: s.TestData.User_Suitable().ID,
+		RoleAssignmentFields: RoleAssignmentFields{
+			Suspended: utils.PointerTo(true),
+			ExpiresAt: utils.PointerTo(time.Now().Add(time.Hour)),
+		},
+	}
+	s.SetSuitableTestUserForDB(true)
+	err := s.DB.Create(&breakGlassRoleAssignment).Error
+	s.ErrorContains(err, errors.Forbidden)
+	s.ErrorContains(err, "the break-glass assignment is suspended (break-glass and suspensions don't mix)")
+}
+
 func (s *modelSuite) TestRoleAssignmentBreakGlassAllowed() {
 	s.TestData.RoleAssignment_Suitable_TerraSuitableEngineer()
 	breakGlassRoleAssignment := RoleAssignment{

--- a/sherlock/internal/models/role_test.go
+++ b/sherlock/internal/models/role_test.go
@@ -1,0 +1,168 @@
+package models
+
+import (
+	"github.com/broadinstitute/sherlock/go-shared/pkg/utils"
+	"github.com/broadinstitute/sherlock/sherlock/internal/errors"
+	"github.com/jinzhu/copier"
+)
+
+func (s *modelSuite) TestRoleUnauthorizedCreate() {
+	role := Role{
+		RoleFields: RoleFields{
+			Name: utils.PointerTo("name"),
+		},
+	}
+	s.SetUserForDB(nil)
+	err := s.DB.Create(&role).Error
+	s.ErrorContains(err, "database user was nil")
+
+}
+
+func (s *modelSuite) TestRoleForbiddenCreate() {
+	s.SetSuitableTestUserForDB()
+	role := Role{
+		RoleFields: RoleFields{
+			Name: utils.PointerTo("name"),
+		},
+	}
+	err := s.DB.Create(&role).Error
+	s.ErrorContains(err, errors.Forbidden)
+}
+
+func (s *modelSuite) TestRoleAllowedCreate() {
+	s.SetSelfSuperAdminForDB()
+	role := Role{
+		RoleFields: RoleFields{
+			Name: utils.PointerTo("name"),
+		},
+	}
+	err := s.DB.Create(&role).Error
+	s.NoError(err)
+	s.Run("journaled", func() {
+		var roleOperation RoleOperation
+		err := s.DB.First(&roleOperation, "role_id = ? and operation = 'create'", role.ID).Error
+		s.NoError(err)
+		s.Equal(role.RoleFields, roleOperation.To)
+	})
+}
+
+func (s *modelSuite) TestRoleUnauthorizedEdit() {
+	role := s.TestData.Role_TerraEngineer()
+	s.SetUserForDB(nil)
+	err := s.DB.Model(&role).Updates(&Role{
+		RoleFields: RoleFields{
+			Name: utils.PointerTo("different-name"),
+		},
+	}).Error
+	s.ErrorContains(err, "database user was nil")
+}
+
+func (s *modelSuite) TestRoleForbiddenEdit() {
+	role := s.TestData.Role_TerraEngineer()
+	s.SetSuitableTestUserForDB()
+	err := s.DB.Model(&role).Updates(&Role{
+		RoleFields: RoleFields{
+			Name: utils.PointerTo("different-name"),
+		},
+	}).Error
+	s.ErrorContains(err, errors.Forbidden)
+}
+
+func (s *modelSuite) TestRoleAllowedEdit() {
+	role := s.TestData.Role_TerraEngineer()
+	var before, after Role
+	s.NoError(copier.CopyWithOption(&before, &role, copier.Option{DeepCopy: true}))
+	s.SetSelfSuperAdminForDB()
+	err := s.DB.Model(&role).Updates(&Role{
+		RoleFields: RoleFields{
+			Name: utils.PointerTo("different-name"),
+		},
+	}).Error
+	s.NoError(err)
+	s.NoError(s.DB.First(&after, role.ID).Error)
+	s.Run("journaled", func() {
+		var roleOperation RoleOperation
+		err := s.DB.First(&roleOperation, "role_id = ? and operation = 'update'", role.ID).Error
+		s.NoError(err)
+		s.Equal(before.RoleFields, roleOperation.From)
+		s.Equal(after.RoleFields, roleOperation.To)
+	})
+}
+
+func (s *modelSuite) TestRoleUnauthorizedDelete() {
+	role := s.TestData.Role_TerraEngineer()
+	s.SetUserForDB(nil)
+	err := s.DB.Delete(&role).Error
+	s.ErrorContains(err, "database user was nil")
+}
+
+func (s *modelSuite) TestRoleForbiddenDelete() {
+	role := s.TestData.Role_TerraEngineer()
+	s.SetSuitableTestUserForDB()
+	err := s.DB.Delete(&role).Error
+	s.ErrorContains(err, errors.Forbidden)
+}
+
+func (s *modelSuite) TestRoleAllowedDelete() {
+	role := s.TestData.Role_TerraEngineer()
+	s.SetSelfSuperAdminForDB()
+	err := s.DB.Delete(&role).Error
+	s.NoError(err)
+	s.Run("journaled", func() {
+		var roleOperation RoleOperation
+		err := s.DB.First(&roleOperation, "role_id = ? and operation = 'delete'", role.ID).Error
+		s.NoError(err)
+		s.Equal(role.RoleFields, roleOperation.From)
+	})
+}
+
+func (s *modelSuite) TestRoleInvalidName() {
+	s.SetSelfSuperAdminForDB()
+	role := Role{
+		RoleFields: RoleFields{
+			Name: utils.PointerTo(""),
+		},
+	}
+	err := s.DB.Create(&role).Error
+	s.ErrorContains(err, "name_valid")
+}
+
+func (s *modelSuite) TestRoleUniqueName() {
+	s.SetSelfSuperAdminForDB()
+	a := s.TestData.Role_TerraSuitableEngineer()
+	b := s.TestData.Role_TerraEngineer()
+	b.Name = a.Name
+	err := s.DB.Save(&b).Error
+	s.ErrorContains(err, "name")
+	s.ErrorContains(err, "violates unique constraint")
+}
+
+func (s *modelSuite) TestRoleUniqueGrantsSherlockSuperAdmin() {
+	s.SetSelfSuperAdminForDB()
+	a := s.TestData.Role_SherlockSuperAdmin()
+	b := s.TestData.Role_TerraEngineer()
+	b.GrantsSherlockSuperAdmin = a.GrantsSherlockSuperAdmin
+	err := s.DB.Save(&b).Error
+	s.ErrorContains(err, "grants_sherlock_super_admin")
+	s.ErrorContains(err, "violates unique constraint")
+}
+
+func (s *modelSuite) TestRoleUniqueGrantsDevFirecloudGroup() {
+	s.SetSelfSuperAdminForDB()
+	a := s.TestData.Role_TerraSuitableEngineer()
+	b := s.TestData.Role_TerraEngineer()
+	b.GrantsDevFirecloudGroup = a.GrantsDevFirecloudGroup
+	err := s.DB.Save(&b).Error
+	s.ErrorContains(err, "grants_dev_firecloud_group")
+	s.ErrorContains(err, "violates unique constraint")
+}
+
+func (s *modelSuite) TestRoleUniqueGrantsDevAzureGroup() {
+	s.SetSelfSuperAdminForDB()
+	a := s.TestData.Role_TerraSuitableEngineer()
+	b := s.TestData.Role_TerraEngineer()
+	b.GrantsDevAzureGroup = a.GrantsDevAzureGroup
+	err := s.DB.Save(&b).Error
+	s.ErrorContains(err, "grants_dev_azure_group")
+	s.ErrorContains(err, "violates unique constraint")
+}

--- a/sherlock/internal/models/test_data.go
+++ b/sherlock/internal/models/test_data.go
@@ -16,14 +16,16 @@ import (
 //  2. These methods cache within the context of a test function. Subsequent
 //     calls to a method will not contact the database.
 type TestData interface {
+	User_SuperAdmin() User
 	User_Suitable() User
 	User_NonSuitable() User
 
+	Role_SherlockSuperAdmin() Role
 	Role_TerraEngineer() Role
 	Role_TerraSuitableEngineer() Role
 	Role_TerraGlassBrokenAdmin() Role
-	Role_SherlockSuperAdmin() Role
 
+	RoleAssignment_SuperAdmin_SherlockSuperAdmin() RoleAssignment
 	RoleAssignment_Suitable_TerraSuitableEngineer() RoleAssignment
 	RoleAssignment_Suitable_TerraEngineer() RoleAssignment
 	RoleAssignment_NonSuitable_TerraEngineer() RoleAssignment
@@ -130,14 +132,16 @@ type TestData interface {
 type testDataImpl struct {
 	h *TestSuiteHelper
 
+	user_superAdmin  User
 	user_suitable    User
 	user_nonSuitable User
 
+	role_sherlockSuperAdmin    Role
 	role_terraEngineer         Role
 	role_terraSuitableEngineer Role
 	role_terraGlassBrokenAdmin Role
-	role_sherlockSuperAdmin    Role
 
+	roleAssignment_superAdmin_sherlockSuperAdmin  RoleAssignment
 	roleAssignment_suitable_terraSuitableEngineer RoleAssignment
 	roleAssignment_suitable_terraEngineer         RoleAssignment
 	roleAssignment_nonSuitable_terraEngineer      RoleAssignment
@@ -242,8 +246,32 @@ func (td *testDataImpl) create(pointer any) {
 	}
 }
 
-// User_Suitable abstracts over the complexity of creating a general Terra-suitable user
-// for use in tests. It creates the user
+func (td *testDataImpl) User_SuperAdmin() User {
+	if td.user_superAdmin.ID == 0 {
+		td.user_superAdmin = User{
+			Email:    "sherlock-super-admin-test-email@broadinstitute.org",
+			GoogleID: "999000999",
+		}
+		td.create(&td.user_superAdmin)
+
+		// Assume super-admin to set suitability
+		td.h.SetSelfSuperAdminForDB()
+		td.create(&Suitability{
+			Email:       &td.user_superAdmin.Email,
+			Suitable:    utils.PointerTo(false),
+			Description: utils.PointerTo("TestData.User_SuperAdmin() is inherently suitable"),
+		})
+
+		td.RoleAssignment_SuperAdmin_SherlockSuperAdmin()
+
+		// Reload user from the database so we get suitability and other records
+		if err := td.h.DB.Scopes(ReadUserScope).Take(&td.user_superAdmin, td.user_superAdmin.ID).Error; err != nil {
+			panic(err)
+		}
+	}
+	return td.user_superAdmin
+}
+
 func (td *testDataImpl) User_Suitable() User {
 	if td.user_suitable.ID == 0 {
 		td.user_suitable = User{
@@ -260,6 +288,9 @@ func (td *testDataImpl) User_Suitable() User {
 			Description: utils.PointerTo("TestData.User_Suitable() is inherently suitable"),
 		})
 
+		td.RoleAssignment_Suitable_TerraEngineer()
+		td.RoleAssignment_Suitable_TerraSuitableEngineer()
+
 		// Reload user from the database so we get suitability and other records
 		if err := td.h.DB.Scopes(ReadUserScope).Take(&td.user_suitable, td.user_suitable.ID).Error; err != nil {
 			panic(err)
@@ -268,7 +299,6 @@ func (td *testDataImpl) User_Suitable() User {
 	return td.user_suitable
 }
 
-// User_NonSuitable is like User_Suitable but for a non-suitable User
 func (td *testDataImpl) User_NonSuitable() User {
 	if td.user_nonSuitable.ID == 0 {
 		td.user_nonSuitable = User{
@@ -285,12 +315,29 @@ func (td *testDataImpl) User_NonSuitable() User {
 			Description: utils.PointerTo("TestData.User_NonSuitable() is inherently non-suitable"),
 		})
 
+		td.RoleAssignment_NonSuitable_TerraEngineer()
+
 		// Reload user from the database so we get suitability and other records
 		if err := td.h.DB.Scopes(ReadUserScope).Take(&td.user_nonSuitable, td.user_nonSuitable.ID).Error; err != nil {
 			panic(err)
 		}
 	}
 	return td.user_nonSuitable
+}
+
+func (td *testDataImpl) Role_SherlockSuperAdmin() Role {
+	if td.role_sherlockSuperAdmin.ID == 0 {
+		td.role_sherlockSuperAdmin = Role{
+			RoleFields: RoleFields{
+				Name:                     utils.PointerTo("sherlock-super-admin"),
+				SuspendNonSuitableUsers:  utils.PointerTo(true),
+				GrantsSherlockSuperAdmin: utils.PointerTo(true),
+			},
+		}
+		td.h.SetSelfSuperAdminForDB()
+		td.create(&td.role_sherlockSuperAdmin)
+	}
+	return td.role_sherlockSuperAdmin
 }
 
 func (td *testDataImpl) Role_TerraEngineer() Role {
@@ -338,19 +385,19 @@ func (td *testDataImpl) Role_TerraGlassBrokenAdmin() Role {
 	return td.role_terraGlassBrokenAdmin
 }
 
-func (td *testDataImpl) Role_SherlockSuperAdmin() Role {
-	if td.role_sherlockSuperAdmin.ID == 0 {
-		td.role_sherlockSuperAdmin = Role{
-			RoleFields: RoleFields{
-				Name:                     utils.PointerTo("sherlock-super-admin"),
-				SuspendNonSuitableUsers:  utils.PointerTo(true),
-				GrantsSherlockSuperAdmin: utils.PointerTo(true),
+func (td *testDataImpl) RoleAssignment_SuperAdmin_SherlockSuperAdmin() RoleAssignment {
+	if td.roleAssignment_superAdmin_sherlockSuperAdmin.RoleID == 0 && td.roleAssignment_superAdmin_sherlockSuperAdmin.UserID == 0 {
+		td.roleAssignment_superAdmin_sherlockSuperAdmin = RoleAssignment{
+			UserID: td.User_SuperAdmin().ID,
+			RoleID: td.Role_SherlockSuperAdmin().ID,
+			RoleAssignmentFields: RoleAssignmentFields{
+				Suspended: utils.PointerTo(false),
 			},
 		}
 		td.h.SetSelfSuperAdminForDB()
-		td.create(&td.role_sherlockSuperAdmin)
+		td.create(&td.roleAssignment_superAdmin_sherlockSuperAdmin)
 	}
-	return td.role_sherlockSuperAdmin
+	return td.roleAssignment_superAdmin_sherlockSuperAdmin
 }
 
 func (td *testDataImpl) RoleAssignment_Suitable_TerraSuitableEngineer() RoleAssignment {

--- a/sherlock/internal/models/test_data.go
+++ b/sherlock/internal/models/test_data.go
@@ -19,6 +19,15 @@ type TestData interface {
 	User_Suitable() User
 	User_NonSuitable() User
 
+	Role_TerraEngineer() Role
+	Role_TerraSuitableEngineer() Role
+	Role_TerraGlassBrokenAdmin() Role
+	Role_SherlockSuperAdmin() Role
+
+	RoleAssignment_Suitable_TerraSuitableEngineer() RoleAssignment
+	RoleAssignment_Suitable_TerraEngineer() RoleAssignment
+	RoleAssignment_NonSuitable_TerraEngineer() RoleAssignment
+
 	PagerdutyIntegration_ManuallyTriggeredTerraIncident() PagerdutyIntegration
 
 	Chart_Leonardo() Chart
@@ -123,6 +132,15 @@ type testDataImpl struct {
 
 	user_suitable    User
 	user_nonSuitable User
+
+	role_terraEngineer         Role
+	role_terraSuitableEngineer Role
+	role_terraGlassBrokenAdmin Role
+	role_sherlockSuperAdmin    Role
+
+	roleAssignment_suitable_terraSuitableEngineer RoleAssignment
+	roleAssignment_suitable_terraEngineer         RoleAssignment
+	roleAssignment_nonSuitable_terraEngineer      RoleAssignment
 
 	pagerdutyIntegration_manuallyTriggeredTerraIncident PagerdutyIntegration
 
@@ -273,6 +291,111 @@ func (td *testDataImpl) User_NonSuitable() User {
 		}
 	}
 	return td.user_nonSuitable
+}
+
+func (td *testDataImpl) Role_TerraEngineer() Role {
+	if td.role_terraEngineer.ID == 0 {
+		td.role_terraEngineer = Role{
+			RoleFields: RoleFields{
+				Name: utils.PointerTo("terra-engineer"),
+			},
+		}
+		td.h.SetSelfSuperAdminForDB()
+		td.create(&td.role_terraEngineer)
+	}
+	return td.role_terraEngineer
+}
+
+func (td *testDataImpl) Role_TerraSuitableEngineer() Role {
+	if td.role_terraSuitableEngineer.ID == 0 {
+		td.role_terraSuitableEngineer = Role{
+			RoleFields: RoleFields{
+				Name:                    utils.PointerTo("terra-suitable-engineer"),
+				SuspendNonSuitableUsers: utils.PointerTo(true),
+				GrantsDevFirecloudGroup: utils.PointerTo("terra-suitable-engineer"),
+				GrantsDevAzureGroup:     utils.PointerTo("terra-suitable-engineer"),
+			},
+		}
+		td.h.SetSelfSuperAdminForDB()
+		td.create(&td.role_terraSuitableEngineer)
+	}
+	return td.role_terraSuitableEngineer
+}
+
+func (td *testDataImpl) Role_TerraGlassBrokenAdmin() Role {
+	if td.role_terraGlassBrokenAdmin.ID == 0 {
+		td.role_terraGlassBrokenAdmin = Role{
+			RoleFields: RoleFields{
+				Name:                      utils.PointerTo("terra-glass-broken-admin"),
+				SuspendNonSuitableUsers:   utils.PointerTo(true),
+				CanBeGlassBrokenByRoleID:  utils.PointerTo(td.Role_TerraSuitableEngineer().ID),
+				DefaultGlassBreakDuration: utils.PointerTo((time.Hour * 8).Nanoseconds()),
+			},
+		}
+		td.h.SetSelfSuperAdminForDB()
+		td.create(&td.role_terraGlassBrokenAdmin)
+	}
+	return td.role_terraGlassBrokenAdmin
+}
+
+func (td *testDataImpl) Role_SherlockSuperAdmin() Role {
+	if td.role_sherlockSuperAdmin.ID == 0 {
+		td.role_sherlockSuperAdmin = Role{
+			RoleFields: RoleFields{
+				Name:                     utils.PointerTo("sherlock-super-admin"),
+				SuspendNonSuitableUsers:  utils.PointerTo(true),
+				GrantsSherlockSuperAdmin: utils.PointerTo(true),
+			},
+		}
+		td.h.SetSelfSuperAdminForDB()
+		td.create(&td.role_sherlockSuperAdmin)
+	}
+	return td.role_sherlockSuperAdmin
+}
+
+func (td *testDataImpl) RoleAssignment_Suitable_TerraSuitableEngineer() RoleAssignment {
+	if td.roleAssignment_suitable_terraSuitableEngineer.RoleID == 0 && td.roleAssignment_suitable_terraSuitableEngineer.UserID == 0 {
+		td.roleAssignment_suitable_terraSuitableEngineer = RoleAssignment{
+			UserID: td.User_Suitable().ID,
+			RoleID: td.Role_TerraSuitableEngineer().ID,
+			RoleAssignmentFields: RoleAssignmentFields{
+				Suspended: utils.PointerTo(false),
+			},
+		}
+		td.h.SetSelfSuperAdminForDB()
+		td.create(&td.roleAssignment_suitable_terraSuitableEngineer)
+	}
+	return td.roleAssignment_suitable_terraSuitableEngineer
+}
+
+func (td *testDataImpl) RoleAssignment_Suitable_TerraEngineer() RoleAssignment {
+	if td.roleAssignment_suitable_terraEngineer.RoleID == 0 && td.roleAssignment_suitable_terraEngineer.UserID == 0 {
+		td.roleAssignment_suitable_terraEngineer = RoleAssignment{
+			UserID: td.User_Suitable().ID,
+			RoleID: td.Role_TerraEngineer().ID,
+			RoleAssignmentFields: RoleAssignmentFields{
+				Suspended: utils.PointerTo(false),
+			},
+		}
+		td.h.SetSelfSuperAdminForDB()
+		td.create(&td.roleAssignment_suitable_terraEngineer)
+	}
+	return td.roleAssignment_suitable_terraEngineer
+}
+
+func (td *testDataImpl) RoleAssignment_NonSuitable_TerraEngineer() RoleAssignment {
+	if td.roleAssignment_nonSuitable_terraEngineer.RoleID == 0 && td.roleAssignment_nonSuitable_terraEngineer.UserID == 0 {
+		td.roleAssignment_nonSuitable_terraEngineer = RoleAssignment{
+			UserID: td.User_NonSuitable().ID,
+			RoleID: td.Role_TerraEngineer().ID,
+			RoleAssignmentFields: RoleAssignmentFields{
+				Suspended: utils.PointerTo(false),
+			},
+		}
+		td.h.SetSelfSuperAdminForDB()
+		td.create(&td.roleAssignment_nonSuitable_terraEngineer)
+	}
+	return td.roleAssignment_nonSuitable_terraEngineer
 }
 
 func (td *testDataImpl) PagerdutyIntegration_ManuallyTriggeredTerraIncident() PagerdutyIntegration {


### PR DESCRIPTION
A laundry list of fixes and full test coverage for the Role and RoleAssignment APIs.

Fixes include:
- Fix return code for RoleAssignment GET/PATCH, should be 200 instead of 201
- Include default for "suspended: false" for RoleAssignment POST
- Fix data types used in RoleAssignment list GET
- Fix column types for journal tables
- Prevent break-glass and suspended role assignments from being mixed because that's just confusing for no reason
- Correctly populate journal tables (the previous strategy wasn't working for some cases)

There's some small improvements to the test harnesses here, to help test super-admin access from the API level.

## Testing

Yes (just joking but that's sorta the whole PR here)

## Risk

No (just joking but these APIs aren't used outside of Chelsea's new code, risk very low)