### PR TITLE
[DDO-3714] RoleAssignment expiresIn

### DIFF
--- a/sherlock/internal/api/sherlock/role_assignments_v3.go
+++ b/sherlock/internal/api/sherlock/role_assignments_v3.go
@@ -1,7 +1,9 @@
 package sherlock
 
 import (
+	"fmt"
 	"github.com/broadinstitute/sherlock/go-shared/pkg/utils"
+	"github.com/broadinstitute/sherlock/sherlock/internal/errors"
 	"github.com/broadinstitute/sherlock/sherlock/internal/models"
 	"time"
 )
@@ -15,23 +17,33 @@ type RoleAssignmentV3 struct {
 type RoleAssignmentV3Edit struct {
 	Suspended *bool      `json:"suspended,omitempty" form:"suspended" default:"false"`
 	ExpiresAt *time.Time `json:"expiresAt,omitempty" form:"expiresAt" format:"date-time"`
+	ExpiresIn *string    `json:"expiresIn,omitempty" form:"expiresIn"` // A Go time.Duration string that will be added to the current time to attempt to set expiresAt (this may be more convenient than setting expiresAt directly)
 }
 
-func (ra RoleAssignmentV3) toModel() models.RoleAssignment {
-	return models.RoleAssignment{
+func (ra RoleAssignmentV3) toModel() (models.RoleAssignment, error) {
+	ret := models.RoleAssignment{
 		RoleAssignmentFields: models.RoleAssignmentFields{
 			Suspended: ra.Suspended,
 			ExpiresAt: ra.ExpiresAt,
 		},
 	}
+	if ret.ExpiresAt == nil && ra.ExpiresIn != nil {
+		if duration, err := time.ParseDuration(*ra.ExpiresIn); err != nil {
+			return ret, fmt.Errorf("(%s) failed to parse '%s' to expiresIn: %w", errors.BadRequest, *ra.ExpiresIn, err)
+		} else {
+			expiresAt := time.Now().Add(duration)
+			ret.ExpiresAt = &expiresAt
+		}
+	}
+	return ret, nil
 }
 
-func (ra RoleAssignmentV3Edit) toModel() models.RoleAssignment {
+func (ra RoleAssignmentV3Edit) toModel() (models.RoleAssignment, error) {
 	return RoleAssignmentV3{RoleAssignmentV3Edit: ra}.toModel()
 }
 
 func roleAssignmentFromModel(model models.RoleAssignment) RoleAssignmentV3 {
-	return RoleAssignmentV3{
+	ret := RoleAssignmentV3{
 		RoleInfo: utils.NilOrCall(roleFromModel, model.Role),
 		UserInfo: utils.NilOrCall(userFromModel, model.User),
 		RoleAssignmentV3Edit: RoleAssignmentV3Edit{
@@ -39,4 +51,9 @@ func roleAssignmentFromModel(model models.RoleAssignment) RoleAssignmentV3 {
 			ExpiresAt: model.ExpiresAt,
 		},
 	}
+	if ret.ExpiresAt != nil {
+		expiresIn := ret.ExpiresAt.Sub(time.Now()).String()
+		ret.ExpiresIn = &expiresIn
+	}
+	return ret
 }

--- a/sherlock/internal/api/sherlock/role_assignments_v3.go
+++ b/sherlock/internal/api/sherlock/role_assignments_v3.go
@@ -52,7 +52,7 @@ func roleAssignmentFromModel(model models.RoleAssignment) RoleAssignmentV3 {
 		},
 	}
 	if ret.ExpiresAt != nil {
-		expiresIn := ret.ExpiresAt.Sub(time.Now()).String()
+		expiresIn := time.Until(*ret.ExpiresAt).String()
 		ret.ExpiresIn = &expiresIn
 	}
 	return ret

--- a/sherlock/internal/api/sherlock/role_assignments_v3_create.go
+++ b/sherlock/internal/api/sherlock/role_assignments_v3_create.go
@@ -40,7 +40,11 @@ func roleAssignmentsV3Create(ctx *gin.Context) {
 		return
 	}
 
-	toCreate := body.toModel()
+	toCreate, err := body.toModel()
+	if err != nil {
+		errors.AbortRequest(ctx, err)
+		return
+	}
 	roleQuery, err := roleModelFromSelector(canonicalizeSelector(ctx.Param("role-selector")))
 	if err != nil {
 		errors.AbortRequest(ctx, err)

--- a/sherlock/internal/api/sherlock/role_assignments_v3_edit.go
+++ b/sherlock/internal/api/sherlock/role_assignments_v3_edit.go
@@ -34,7 +34,11 @@ func roleAssignmentsV3Edit(ctx *gin.Context) {
 		errors.AbortRequest(ctx, fmt.Errorf("(%s) request validation error: %w", errors.BadRequest, err))
 		return
 	}
-	edits := body.toModel()
+	edits, err := body.toModel()
+	if err != nil {
+		errors.AbortRequest(ctx, err)
+		return
+	}
 
 	roleQuery, err := roleModelFromSelector(canonicalizeSelector(ctx.Param("role-selector")))
 	if err != nil {

--- a/sherlock/internal/api/sherlock/role_assignments_v3_list.go
+++ b/sherlock/internal/api/sherlock/role_assignments_v3_list.go
@@ -33,7 +33,11 @@ func roleAssignmentsV3List(ctx *gin.Context) {
 		errors.AbortRequest(ctx, err)
 		return
 	}
-	modelFilter := filter.toModel()
+	modelFilter, err := filter.toModel()
+	if err != nil {
+		errors.AbortRequest(ctx, err)
+		return
+	}
 
 	limit, err := utils.ParseInt(ctx.DefaultQuery("limit", "0"))
 	if err != nil {

--- a/sherlock/internal/api/sherlock/role_assignments_v3_list_test.go
+++ b/sherlock/internal/api/sherlock/role_assignments_v3_list_test.go
@@ -25,6 +25,16 @@ func (s *handlerSuite) TestRoleAssignmentsV3List_badFilter() {
 	s.Equal(errors.BadRequest, got.Type)
 }
 
+func (s *handlerSuite) TestRoleAssignmentsV3List_badFilter_expiresIn() {
+	var got errors.ErrorResponse
+	code := s.HandleRequest(
+		s.NewRequest("GET", "/api/role-assignments/v3?expiresIn=bad", nil),
+		&got)
+	s.Equal(http.StatusBadRequest, code)
+	s.Equal(errors.BadRequest, got.Type)
+	s.Contains(got.Message, "expiresIn")
+}
+
 func (s *handlerSuite) TestRoleAssignmentsV3List_badLimit() {
 	var got errors.ErrorResponse
 	code := s.HandleRequest(


### PR DESCRIPTION
@choover-broad pointed out that the timestamp API field was pretty difficult to work with from non-Go, because the duration is stored on the role as a Go duration (so other languages would need to emulate adding that duration to the current ISO-8601 time the way that Go can). Solution: add a calculated field at the API layer that just does that part. 

# Tests

Added tests for the success and error cases of the new field

# Risk

Low