### PR TITLE
[DDO-3748] Document two reviewer rule

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,3 +29,5 @@ Sherlock is a multi-replica system, so we can't make database changes that would
 ## Submitting Changes
 
 PRs require a ticket in the title with CLIA risk and security impact description filled. The description must include a summary of the changes, an explanation of what testing was done (screenshots recommended), and a note on the risk of the change.
+
+PRs require two approvals. Dependabot PRs will be automatically approved and merged without human intervention (assuming tests succeed).


### PR DESCRIPTION
The GHA and branch protections are already in place, just documenting so I can link to this from the prod readiness checklist.