### PR TITLE
[DDO-3763] Do CORS from Sherlock

### DIFF
--- a/sherlock/config/default_config.yaml
+++ b/sherlock/config/default_config.yaml
@@ -20,6 +20,9 @@ log:
   caller: false
   level: debug
 
+cors:
+  allowOrigins: []
+
 db:
   # Can be "pgx" or "cloudsql-postgres". "cloudsql-postgres" won't work in debug mode.
   driver: pgx

--- a/sherlock/config/default_config.yaml
+++ b/sherlock/config/default_config.yaml
@@ -5,13 +5,11 @@
 #   It will use mock authentication and authorization.
 mode: debug
 
-hooks:
-  # If Sherlock should act on CiRun state transitions. Hooks are still subject
-  # to the third-party-specific flags elsewhere in this file.
-  enable: true
-  # If true, hooks will be run asynchronously after the initial call into the
-  # hooks package.
-  asynchronous: true
+# Origins is the list of allowed origins for requests (used for CORS and CSRF protection).
+# Each entry should include the scheme, like "https://example.com".
+# When empty, all origins will be allowed, which is only suitable for local development where
+# cross-origin requests with credentials aren't required.
+origins: []
 
 log:
   # Always true when mode="release"
@@ -19,9 +17,6 @@ log:
   # Always true when mode="release"
   caller: false
   level: debug
-
-cors:
-  allowOrigins: []
 
 db:
   # Can be "pgx" or "cloudsql-postgres". "cloudsql-postgres" won't work in debug mode.
@@ -95,6 +90,14 @@ auth:
   extraPermissions:
     #- email: example@dsp-tools-k8s.iam.gserviceaccount.com
     #  suitable: false
+
+hooks:
+  # If Sherlock should act on CiRun state transitions. Hooks are still subject
+  # to the third-party-specific flags elsewhere in this file.
+  enable: true
+  # If true, hooks will be run asynchronously after the initial call into the
+  # hooks package.
+  asynchronous: true
 
 metrics:
   v2:

--- a/sherlock/config/test_config.yaml
+++ b/sherlock/config/test_config.yaml
@@ -3,8 +3,8 @@
 
 mode: debug
 
-hooks:
-  asynchronous: false
+origins:
+  - http://localhost:8080
 
 log:
   level: warn
@@ -26,6 +26,9 @@ auth:
       suitable: true
     - email: has-extra-permissions-non-suitable@example.com
       suitable: false
+
+hooks:
+  asynchronous: false
 
 pagerduty:
   enable: false

--- a/sherlock/go.mod
+++ b/sherlock/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/coreos/go-oidc v2.2.1+incompatible
 	github.com/creasty/defaults v1.7.0
 	github.com/dustinkirkland/golang-petname v0.0.0-20230626224747-e794b9370d49
+	github.com/gin-contrib/cors v1.7.2
 	github.com/gin-gonic/gin v1.10.0
 	github.com/golang-migrate/migrate/v4 v4.17.1
 	github.com/google/go-cmp v0.6.0
@@ -60,7 +61,6 @@ require (
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.3 // indirect
-	github.com/gin-contrib/cors v1.7.2 // indirect
 	github.com/gin-contrib/sse v0.1.0 // indirect
 	github.com/go-kit/log v0.2.1 // indirect
 	github.com/go-logfmt/logfmt v0.5.1 // indirect

--- a/sherlock/go.mod
+++ b/sherlock/go.mod
@@ -60,6 +60,7 @@ require (
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.3 // indirect
+	github.com/gin-contrib/cors v1.7.2 // indirect
 	github.com/gin-contrib/sse v0.1.0 // indirect
 	github.com/go-kit/log v0.2.1 // indirect
 	github.com/go-logfmt/logfmt v0.5.1 // indirect

--- a/sherlock/go.sum
+++ b/sherlock/go.sum
@@ -150,6 +150,8 @@ github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbS
 github.com/gabriel-vasile/mimetype v1.4.3 h1:in2uUcidCuFcDKtdcBxlR0rJ1+fsokWf+uqxgUFjbI0=
 github.com/gabriel-vasile/mimetype v1.4.3/go.mod h1:d8uq/6HKRL6CGdk+aubisF/M5GcPfT7nKyLpA0lbSSk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
+github.com/gin-contrib/cors v1.7.2 h1:oLDHxdg8W/XDoN/8zamqk/Drgt4oVZDvaV0YmvVICQw=
+github.com/gin-contrib/cors v1.7.2/go.mod h1:SUJVARKgQ40dmrzgXEVxj2m7Ig1v1qIboQkPDTQ9t2E=
 github.com/gin-contrib/gzip v0.0.6 h1:NjcunTcGAj5CO1gn4N8jHOSIeRFHIbn51z6K+xaN4d4=
 github.com/gin-contrib/gzip v0.0.6/go.mod h1:QOJlmV2xmayAjkNS2Y8NQsMneuRShOU/kjovCXNuzzk=
 github.com/gin-contrib/sse v0.1.0 h1:Y/yl/+YNO8GZSjAhjMsSuLt29uWRFHdHYUb5lYOV9qE=

--- a/sherlock/internal/boot/router.go
+++ b/sherlock/internal/boot/router.go
@@ -55,7 +55,6 @@ func BuildRouter(ctx context.Context, db *gorm.DB) *gin.Engine {
 		gin.Recovery(),
 		logger.Logger(),
 		cors.Cors(),
-		csrf_protection.CsrfProtection(),
 		headers.Headers())
 
 	// Replace Gin's standard fallback responses with our standard error format for friendlier client behavior
@@ -82,7 +81,9 @@ func BuildRouter(ctx context.Context, db *gorm.DB) *gin.Engine {
 	router.GET("", func(ctx *gin.Context) { ctx.Redirect(http.StatusMovedPermanently, "/swagger/index.html") })
 
 	// routes under /api require authentication and may use the database
-	apiRouter := router.Group("api", authentication.Middleware(db)...)
+	apiRouter := router.Group("api")
+	apiRouter.Use(csrf_protection.CsrfProtection())
+	apiRouter.Use(authentication.Middleware(db)...)
 
 	// refactored sherlock API, under /api/{type}/v3
 	sherlock.ConfigureRoutes(apiRouter)

--- a/sherlock/internal/boot/router.go
+++ b/sherlock/internal/boot/router.go
@@ -13,6 +13,7 @@ import (
 	"github.com/broadinstitute/sherlock/sherlock/internal/metrics"
 	"github.com/broadinstitute/sherlock/sherlock/internal/middleware/authentication"
 	"github.com/broadinstitute/sherlock/sherlock/internal/middleware/cors"
+	"github.com/broadinstitute/sherlock/sherlock/internal/middleware/csrf_protection"
 	"github.com/broadinstitute/sherlock/sherlock/internal/middleware/headers"
 	"github.com/broadinstitute/sherlock/sherlock/internal/middleware/logger"
 	"github.com/gin-gonic/gin"
@@ -54,6 +55,7 @@ func BuildRouter(ctx context.Context, db *gorm.DB) *gin.Engine {
 		gin.Recovery(),
 		logger.Logger(),
 		cors.Cors(),
+		csrf_protection.CsrfProtection(),
 		headers.Headers())
 
 	// Replace Gin's standard fallback responses with our standard error format for friendlier client behavior

--- a/sherlock/internal/boot/router.go
+++ b/sherlock/internal/boot/router.go
@@ -12,6 +12,7 @@ import (
 	"github.com/broadinstitute/sherlock/sherlock/internal/errors"
 	"github.com/broadinstitute/sherlock/sherlock/internal/metrics"
 	"github.com/broadinstitute/sherlock/sherlock/internal/middleware/authentication"
+	"github.com/broadinstitute/sherlock/sherlock/internal/middleware/cors"
 	"github.com/broadinstitute/sherlock/sherlock/internal/middleware/headers"
 	"github.com/broadinstitute/sherlock/sherlock/internal/middleware/logger"
 	"github.com/gin-gonic/gin"
@@ -52,6 +53,7 @@ func BuildRouter(ctx context.Context, db *gorm.DB) *gin.Engine {
 	router.Use(
 		gin.Recovery(),
 		logger.Logger(),
+		cors.Cors(),
 		headers.Headers())
 
 	// Replace Gin's standard fallback responses with our standard error format for friendlier client behavior

--- a/sherlock/internal/middleware/cors/middleware.go
+++ b/sherlock/internal/middleware/cors/middleware.go
@@ -19,7 +19,7 @@ func Cors() gin.HandlerFunc {
 		// AJAX nature of the request so it can return a 401 rather than a 302.
 		// https://cloud.google.com/iap/docs/sessions-howto#understanding_the_response
 		"X-Requested-With")
-	if origins := config.Config.Strings("cors.allowOrigins"); len(origins) > 0 {
+	if origins := config.Config.Strings("origins"); len(origins) > 0 {
 		c.AllowCredentials = true
 		c.AllowOrigins = origins
 	} else {

--- a/sherlock/internal/middleware/cors/middleware.go
+++ b/sherlock/internal/middleware/cors/middleware.go
@@ -1,0 +1,30 @@
+package cors
+
+import (
+	"github.com/broadinstitute/sherlock/sherlock/internal/config"
+	"github.com/gin-contrib/cors"
+	"github.com/gin-gonic/gin"
+)
+
+// Cors does the CORS thing. IAP requires its cookie to be sent cross-origin, so origins must be
+// specifically enumerated for cross-origin AJAX to work.
+//
+// If no origins are specified, this middleware will allow all origins since that's at least
+// useful for local development where credentials aren't in play (browsers require origins to be
+// enumerated to send credentials, so operation behind IAP should enumerate origins).
+func Cors() gin.HandlerFunc {
+	c := cors.DefaultConfig()
+	c.AllowHeaders = append(c.AllowHeaders,
+		// "X-Requested-With" being set to "XMLHttpRequest" helps IAP understand the
+		// AJAX nature of the request so it can return a 401 rather than a 302.
+		// https://cloud.google.com/iap/docs/sessions-howto#understanding_the_response
+		"X-Requested-With")
+	if origins := config.Config.Strings("cors.allowOrigins"); len(origins) > 0 {
+		c.AllowCredentials = true
+		c.AllowOrigins = origins
+	} else {
+		c.AllowCredentials = false
+		c.AllowAllOrigins = true
+	}
+	return cors.New(c)
+}

--- a/sherlock/internal/middleware/cors/middleware_test.go
+++ b/sherlock/internal/middleware/cors/middleware_test.go
@@ -1,0 +1,56 @@
+package cors
+
+import (
+	"github.com/broadinstitute/sherlock/sherlock/internal/config"
+	"github.com/gin-gonic/gin"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHeaders(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	config.LoadTestConfig()
+	zerolog.SetGlobalLevel(zerolog.Disabled)
+	router := gin.New()
+	router.Use(Cors())
+	router.DELETE("/", func(ctx *gin.Context) {
+		ctx.JSON(200, gin.H{})
+	})
+	t.Run("successful preflight", func(t *testing.T) {
+		recorder := httptest.NewRecorder()
+		request := httptest.NewRequest("OPTIONS", "/", nil)
+		request.Header.Set("Access-Control-Request-Method", "DELETE")
+		request.Header.Set("Access-Control-Request-Headers", "X-Requested-With")
+		request.Header.Set("Origin", "http://localhost:8080")
+		router.ServeHTTP(recorder, request)
+
+		assert.Equal(t, 204, recorder.Code)
+		assert.Equal(t, "http://localhost:8080", recorder.Header().Get("Access-Control-Allow-Origin"))
+		assert.Equal(t, "true", recorder.Header().Get("Access-Control-Allow-Credentials"))
+		assert.Contains(t, recorder.Header().Get("Access-Control-Allow-Headers"), "X-Requested-With")
+		assert.Contains(t, recorder.Header().Get("Access-Control-Allow-Methods"), "DELETE")
+	})
+	t.Run("failed origin preflight", func(t *testing.T) {
+		recorder := httptest.NewRecorder()
+		request := httptest.NewRequest("OPTIONS", "/", nil)
+		request.Header.Set("Access-Control-Request-Method", "DELETE")
+		request.Header.Set("Access-Control-Request-Headers", "X-Requested-With")
+		request.Header.Set("Origin", "https://example.com")
+		router.ServeHTTP(recorder, request)
+
+		assert.Equal(t, 404, recorder.Code)
+		assert.Empty(t, recorder.Header().Get("Access-Control-Allow-Origin"))
+		assert.Empty(t, recorder.Header().Get("Access-Control-Allow-Credentials"))
+		assert.Empty(t, recorder.Header().Get("Access-Control-Allow-Headers"))
+		assert.Empty(t, recorder.Header().Get("Access-Control-Allow-Methods"))
+	})
+	t.Run("successful request", func(t *testing.T) {
+		recorder := httptest.NewRecorder()
+		request := httptest.NewRequest("DELETE", "/", nil)
+		router.ServeHTTP(recorder, request)
+
+		assert.Equal(t, 200, recorder.Code)
+	})
+}

--- a/sherlock/internal/middleware/csrf_protection/middleware.go
+++ b/sherlock/internal/middleware/csrf_protection/middleware.go
@@ -1,0 +1,47 @@
+package csrf_protection
+
+import (
+	"fmt"
+	"github.com/broadinstitute/sherlock/go-shared/pkg/utils"
+	"github.com/broadinstitute/sherlock/sherlock/internal/config"
+	"github.com/broadinstitute/sherlock/sherlock/internal/errors"
+	"github.com/gin-gonic/gin"
+	"github.com/rs/zerolog/log"
+)
+
+// CsrfProtection is a layer of defense against Cross-Site-Request-Forgery attacks.
+//
+// It checks three things:
+//  1. The content type of the request is application/json or not passed at all. HTML forms are a common
+//     vector for CSRF attacks, and they won't ever be application/json without JavaScript being involved
+//     in sending the request.
+//  2. The Origin header is in the list of allowed origins or not passed at all. Assuming JavaScript is
+//     involved in sending the request, we're in the land of JavaScript's same-origin-policy, so we can
+//     filter based on this header. An attacker won't be able to convince a modern browser *not* to send
+//     this header cross-origin.
+//  3. We do the same check for the Referer header as we do for the Origin header too. It's less reliable
+//     than the Origin header but it has older support.
+//
+// This isn't perfect -- it's not bulletproof like a double-submit cookie can be -- but for an API
+// it's fairly strong.
+func CsrfProtection() gin.HandlerFunc {
+	origins := config.Config.Strings("origins")
+	return func(ctx *gin.Context) {
+		if ct := ctx.ContentType(); ct != "" && ct != "application/json" {
+			log.Warn().Str("content-type", ct).Msgf("unsupported content type %s observed, rejecting request for CSRF protection", ct)
+			errors.AbortRequest(ctx, fmt.Errorf("(%s) unsupported content type; see logs for more details", errors.BadRequest))
+			return
+		} else if len(origins) > 0 {
+			if origin := ctx.GetHeader("Origin"); origin != "" && !utils.Contains(origins, origin) {
+				log.Warn().Str("origin", origin).Msgf("origin %s not allowed, rejecting request for CSRF protection", origin)
+				errors.AbortRequest(ctx, fmt.Errorf("(%s) origin not allowed; see logs for more details", errors.Forbidden))
+				return
+			}
+			if referer := ctx.GetHeader("Referer"); referer != "" && !utils.Contains(origins, referer) {
+				log.Warn().Str("referer", referer).Msgf("referer %s not allowed, rejecting request for CSRF protection", referer)
+				errors.AbortRequest(ctx, fmt.Errorf("(%s) referer not allowed; see logs for more details", errors.Forbidden))
+				return
+			}
+		}
+	}
+}

--- a/sherlock/internal/middleware/csrf_protection/middleware_test.go
+++ b/sherlock/internal/middleware/csrf_protection/middleware_test.go
@@ -65,10 +65,26 @@ func TestHeaders(t *testing.T) {
 
 		assert.Equal(t, 200, recorder.Code)
 	})
+	t.Run("accepted referer on another url", func(t *testing.T) {
+		recorder := httptest.NewRecorder()
+		request := httptest.NewRequest("DELETE", "/", nil)
+		request.Header.Set("Referer", "http://localhost:8080/blah/blah")
+		router.ServeHTTP(recorder, request)
+
+		assert.Equal(t, 200, recorder.Code)
+	})
 	t.Run("rejected referer", func(t *testing.T) {
 		recorder := httptest.NewRecorder()
 		request := httptest.NewRequest("DELETE", "/", nil)
 		request.Header.Set("Referer", "https://example.com")
+		router.ServeHTTP(recorder, request)
+
+		assert.Equal(t, 403, recorder.Code)
+	})
+	t.Run("rejected referer on another url", func(t *testing.T) {
+		recorder := httptest.NewRecorder()
+		request := httptest.NewRequest("DELETE", "/", nil)
+		request.Header.Set("Referer", "https://example.com/blah/blah")
 		router.ServeHTTP(recorder, request)
 
 		assert.Equal(t, 403, recorder.Code)

--- a/sherlock/internal/middleware/csrf_protection/middleware_test.go
+++ b/sherlock/internal/middleware/csrf_protection/middleware_test.go
@@ -1,0 +1,76 @@
+package csrf_protection
+
+import (
+	"github.com/broadinstitute/sherlock/sherlock/internal/config"
+	"github.com/gin-gonic/gin"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHeaders(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	config.LoadTestConfig()
+	zerolog.SetGlobalLevel(zerolog.Disabled)
+	router := gin.New()
+	router.Use(CsrfProtection())
+	router.DELETE("/", func(ctx *gin.Context) {
+		ctx.JSON(200, gin.H{})
+	})
+	t.Run("no content type", func(t *testing.T) {
+		recorder := httptest.NewRecorder()
+		request := httptest.NewRequest("DELETE", "/", nil)
+		router.ServeHTTP(recorder, request)
+
+		assert.Equal(t, 200, recorder.Code)
+	})
+	t.Run("accepted content type", func(t *testing.T) {
+		recorder := httptest.NewRecorder()
+		request := httptest.NewRequest("DELETE", "/", nil)
+		request.Header.Set("Content-Type", "application/json")
+		router.ServeHTTP(recorder, request)
+
+		assert.Equal(t, 200, recorder.Code)
+	})
+	t.Run("rejected content type", func(t *testing.T) {
+		recorder := httptest.NewRecorder()
+		request := httptest.NewRequest("DELETE", "/", nil)
+		request.Header.Set("Content-Type", "text/html")
+		router.ServeHTTP(recorder, request)
+
+		assert.Equal(t, 400, recorder.Code)
+	})
+	t.Run("accepted origin", func(t *testing.T) {
+		recorder := httptest.NewRecorder()
+		request := httptest.NewRequest("DELETE", "/", nil)
+		request.Header.Set("Origin", "http://localhost:8080")
+		router.ServeHTTP(recorder, request)
+
+		assert.Equal(t, 200, recorder.Code)
+	})
+	t.Run("rejected origin", func(t *testing.T) {
+		recorder := httptest.NewRecorder()
+		request := httptest.NewRequest("DELETE", "/", nil)
+		request.Header.Set("Origin", "https://example.com")
+		router.ServeHTTP(recorder, request)
+
+		assert.Equal(t, 403, recorder.Code)
+	})
+	t.Run("accepted referer", func(t *testing.T) {
+		recorder := httptest.NewRecorder()
+		request := httptest.NewRequest("DELETE", "/", nil)
+		request.Header.Set("Referer", "http://localhost:8080")
+		router.ServeHTTP(recorder, request)
+
+		assert.Equal(t, 200, recorder.Code)
+	})
+	t.Run("rejected referer", func(t *testing.T) {
+		recorder := httptest.NewRecorder()
+		request := httptest.NewRequest("DELETE", "/", nil)
+		request.Header.Set("Referer", "https://example.com")
+		router.ServeHTTP(recorder, request)
+
+		assert.Equal(t, 403, recorder.Code)
+	})
+}

--- a/sherlock/internal/middleware/headers/middleware_test.go
+++ b/sherlock/internal/middleware/headers/middleware_test.go
@@ -1,0 +1,28 @@
+package headers
+
+import (
+	"github.com/broadinstitute/sherlock/sherlock/internal/config"
+	"github.com/gin-gonic/gin"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHeaders(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	config.LoadTestConfig()
+	zerolog.SetGlobalLevel(zerolog.Disabled)
+	router := gin.New()
+	router.Use(Headers())
+	router.GET("/", func(ctx *gin.Context) {
+		ctx.JSON(200, gin.H{})
+	})
+	t.Run("headers", func(t *testing.T) {
+		recorder := httptest.NewRecorder()
+		request := httptest.NewRequest("GET", "/", nil)
+		router.ServeHTTP(recorder, request)
+
+		assert.Equal(t, "no-store", recorder.Header().Get("Cache-Control"))
+	})
+}


### PR DESCRIPTION
[Details in the ticket.](https://broadworkbench.atlassian.net/browse/DDO-3763)

This does the CORS thing that we've been having [the proxy do so far.](https://github.com/broadinstitute/terra-helmfile/blob/master/charts/sherlock/templates/configMap.yaml#L34-L40) Benefit now is that we can actually just pass the list of origins and it filters based on them, without treating them like a vulnerable regex like Apache does. Argument for this approach is that it's simpler.

We also move the CSRF mitigations from the proxy into Sherlock for the same reasons.

Two chart changes are required for this to work: we'll need to pass the origins into Sherlock's config and we'll need to configure the proxy to not mutate the Host/Origin headers so that this new middleware can see the real values.

## Testing

Via unit test, my own manual testing, and most importantly, Sarah Gibson's testing from her pentest tools

## Risk

Low