### PR TITLE
[DDO-3767] Check RoleAssignment mismatch

### DIFF
--- a/sherlock/Dockerfile
+++ b/sherlock/Dockerfile
@@ -1,7 +1,7 @@
 ARG GO_VERSION='1.21'
 ARG ALPINE_VERSION='3.19'
 
-FROM golang:${GO_VERSION}-alpine${ALPINE_VERSION} as build
+FROM golang:${GO_VERSION}-alpine${ALPINE_VERSION} AS build
 ARG BUILD_VERSION='development'
 WORKDIR /build/sherlock
 ENV CGO_ENABLED=0
@@ -15,7 +15,7 @@ COPY sherlock ./
 RUN go build -buildvcs=false -ldflags="-X 'github.com/broadinstitute/sherlock/go-shared/pkg/version.BuildVersion=${BUILD_VERSION}'" -o /bin/sherlock ./cmd/...
 
 # FROM alpine:${ALPINE_VERSION} as runtime <-- use this if you hit issues
-FROM gcr.io/distroless/static:nonroot as runtime
+FROM gcr.io/distroless/static:nonroot AS runtime
 
 COPY --from=build /bin/sherlock /bin/sherlock
 ENTRYPOINT [ "/bin/sherlock" ]

--- a/sherlock/internal/api/sherlock/role_assignments_v3_create_test.go
+++ b/sherlock/internal/api/sherlock/role_assignments_v3_create_test.go
@@ -75,6 +75,20 @@ func (s *handlerSuite) TestRoleAssignmentsV3Create_breakGlassForbidden() {
 	s.Equal(errors.Forbidden, got.Type)
 }
 
+func (s *handlerSuite) TestRoleAssignmentsV3Create_breakGlassForbiddenMismatch() {
+	// Not the user we're making the request with!
+	user := s.TestData.User_NonSuitable()
+	role := s.TestData.Role_TerraGlassBrokenAdmin() // Suitable can break-glass non-suitable can't
+	var got errors.ErrorResponse
+	code := s.HandleRequest(
+		s.NewSuitableRequest("POST", "/api/role-assignments/v3/"+utils.UintToString(role.ID)+"/"+utils.UintToString(user.ID), RoleAssignmentV3Edit{
+			ExpiresAt: utils.PointerTo(time.Now().Add(time.Hour)),
+		}),
+		&got)
+	s.Equal(http.StatusForbidden, code)
+	s.Equal(errors.Forbidden, got.Type)
+}
+
 func (s *handlerSuite) TestRoleAssignmentsV3Create_breakGlassAllowed() {
 	user := s.TestData.User_Suitable()
 	role := s.TestData.Role_TerraGlassBrokenAdmin()

--- a/sherlock/internal/models/role_assignment.go
+++ b/sherlock/internal/models/role_assignment.go
@@ -105,6 +105,8 @@ func (ra *RoleAssignment) errorIfForbidden(tx *gorm.DB) error {
 	}
 	if targetRole.CanBeGlassBrokenByRoleID == nil {
 		return fmt.Errorf("(%s) role %s (%d) cannot be glass-broken and the caller is not a super-admin who can make non-glass-break assignments", errors.Forbidden, *targetRole.Name, current.RoleID)
+	} else if ra.UserID != user.ID {
+		return fmt.Errorf("(%s) a caller may only make break-glass assignments for themselves", errors.Forbidden)
 	} else if targetRole.DefaultGlassBreakDuration == nil {
 		return fmt.Errorf("role %s (%d) is misconfigured: it declares that it can be glass-broken but defines no default duration", *targetRole.Name, current.RoleID)
 	} else {

--- a/sherlock/internal/models/role_assignment_test.go
+++ b/sherlock/internal/models/role_assignment_test.go
@@ -152,6 +152,22 @@ func (s *modelSuite) TestRoleAssignmentBreakGlassForbiddenSuspended() {
 	s.ErrorContains(err, "the break-glass assignment is suspended (break-glass and suspensions don't mix)")
 }
 
+func (s *modelSuite) TestRoleAssignmentBreakGlassForbiddenMismatch() {
+	s.TestData.RoleAssignment_Suitable_TerraSuitableEngineer()
+	breakGlassRoleAssignment := RoleAssignment{
+		RoleID: s.TestData.Role_TerraGlassBrokenAdmin().ID,
+		UserID: s.TestData.User_NonSuitable().ID,
+		RoleAssignmentFields: RoleAssignmentFields{
+			Suspended: utils.PointerTo(false),
+			ExpiresAt: utils.PointerTo(time.Now().Add(time.Hour)),
+		},
+	}
+	s.SetSuitableTestUserForDB(true)
+	err := s.DB.Create(&breakGlassRoleAssignment).Error
+	s.ErrorContains(err, errors.Forbidden)
+	s.ErrorContains(err, "a caller may only make break-glass assignments for themselves")
+}
+
 func (s *modelSuite) TestRoleAssignmentBreakGlassAllowed() {
 	s.TestData.RoleAssignment_Suitable_TerraSuitableEngineer()
 	breakGlassRoleAssignment := RoleAssignment{


### PR DESCRIPTION
Sarah Gibson found that it was possible for a user who could break-glass to break-glass for someone else who could not (because the permission function wasn't checking that the IDs matched).

## Testing

Added a test for this exact mismatch case. Sarah confirmed that this resolved the issue.

## Risk

Low