### PR TITLE
[DDO-3769] Fix Google Subject ID inconsistency

### DIFF
--- a/sherlock/config/default_config.yaml
+++ b/sherlock/config/default_config.yaml
@@ -262,6 +262,7 @@ beehive:
 # useful for testing or offline development to skip using ADC.
 self:
     overrideEmail:
+    # The subject ID should be prefixed with the standard "accounts.google.com:" prefix.
     overrideSubjectID:
 
 rolePropagation:

--- a/sherlock/config/test_config.yaml
+++ b/sherlock/config/test_config.yaml
@@ -59,7 +59,7 @@ model:
 
 self:
   overrideEmail: sherlock-test@broadinstitute.org
-  overrideSubjectID: sherlock-test
+  overrideSubjectID: accounts.google.com:sherlock-test
 
 rolePropagation:
   asynchronous: false

--- a/sherlock/db/migrations/000091_fix_self_google_id.down.sql
+++ b/sherlock/db/migrations/000091_fix_self_google_id.down.sql
@@ -1,0 +1,3 @@
+-- There's no backwards migration here because at the migration stage we're not sure who the self user is.
+-- Sherlock would error during startup and a human would need to manually remove the accounts.google.com: prefix
+-- from the self user's google_id in the database.

--- a/sherlock/db/migrations/000091_fix_self_google_id.up.sql
+++ b/sherlock/db/migrations/000091_fix_self_google_id.up.sql
@@ -1,0 +1,11 @@
+-- See DDO-3769, ticket description follows:
+--
+-- Recently, we began having Sherlock represent itself inside its database with a User record. The problem is that
+-- because we create that record from Google’s UserInfo endpoint rather than IAP, we inherited an inconsistency in how
+-- Google represents IDs: UserInfo omits the `accounts.google.com:` prefix that IAP provides.
+--
+-- Since every single other user is guaranteed to be from IAP… we can actually just push through a code change and
+-- migration to fix this. We wouldn’t be able to cleanly revert that one migration without manual intervention, but I
+-- think that’s okay given the alternative of leaving the inconsistency forever or having to represent the migration in
+-- Sherlock’s application code forever.
+UPDATE users SET google_id = concat('accounts.google.com:', google_id) WHERE google_id NOT LIKE 'accounts.google.com:%';

--- a/sherlock/internal/models/self/self.go
+++ b/sherlock/internal/models/self/self.go
@@ -26,7 +26,7 @@ var (
 	Email = "sherlock-uninitialized@broadinstitute.org"
 	// GoogleID is Sherlock's own subject ID. This variable shouldn't be
 	// accessed until Load has been called.
-	GoogleID = "sherlock-uninitialized"
+	GoogleID = "accounts.google.com:sherlock-uninitialized"
 )
 
 func Load(ctx context.Context) error {
@@ -58,6 +58,10 @@ func Load(ctx context.Context) error {
 		return fmt.Errorf("failed to get self userinfo: %w", err)
 	}
 	Email = userinfo.Email
-	GoogleID = userinfo.Id
+	// Sherlock stores Google Subject IDs the way it observes them from IAP, which means with the leading
+	// "accounts.google.com:" prefix. There's no way to get that full prefixed ID from the userinfo endpoint,
+	// so we add it ourselves for consistency. Maybe a decade down the road Google will add other possible
+	// prefixes, but presumably they won't change the meaning of this field of this endpoint.
+	GoogleID = "accounts.google.com:" + userinfo.Id
 	return nil
 }


### PR DESCRIPTION
From the ticket:

Recently, we began having Sherlock represent itself inside its database with a User record. The problem is that because we create that record from Google’s UserInfo endpoint rather than IAP, we inherited an inconsistency in how Google represents IDs: UserInfo omits the accounts.google.com: prefix that IAP provides.

Since every single other user is guaranteed to be from IAP… we can actually just push through a code change and migration to fix this. We wouldn’t be able to cleanly revert that one migration without manual intervention, but I think that’s okay given the alternative of leaving the inconsistency forever or having to represent the migration in Sherlock’s application code forever.

## Testing

Manual since we're really just doing a database migration 🤷 tested fresh startup and migration cases

## Risk

Low