### PR TITLE
[DDO-3772] Add automatic suspension

### DIFF
--- a/sherlock/config/default_config.yaml
+++ b/sherlock/config/default_config.yaml
@@ -351,3 +351,6 @@ suitabilitySynchronization:
       extraPermissions:
         #- email: example@dsp-tools-k8s.iam.gserviceaccount.com
         #  suitable: false
+    suspendRoleAssignments:
+      enable: true
+      interval: 1m

--- a/sherlock/config/default_config.yaml
+++ b/sherlock/config/default_config.yaml
@@ -70,26 +70,10 @@ db:
     level: warn
 
 auth:
-  updateIntervalMinutes: 15
-  broadinstitute:
-    domain: broadinstitute.org
-  firecloud:
-    domain: firecloud.org
-    groups:
-      fcAdmins: fc-admins@firecloud.org
-      firecloudProjectOwners: firecloud-project-owners@firecloud.org
   githubActionsOIDC:
     issuer: https://token.actions.githubusercontent.com
     allowedOrganizations:
       - broadinstitute
-
-  # extraPermissions can be used to grant an exact email address access to "suitable" actions inside Sherlock,
-  # regardless of that email correlating to a Firecloud account. This functionality should only be used for
-  # service accounts, and the justification for this functionality existing is that adding a service account
-  # here is better than actually giving the service account any actual permissions inside the Firecloud org.
-  extraPermissions:
-    #- email: example@dsp-tools-k8s.iam.gserviceaccount.com
-    #  suitable: false
 
 hooks:
   # If Sherlock should act on CiRun state transitions. Hooks are still subject
@@ -344,3 +328,26 @@ rolePropagation:
       # Sherlock users to Azure Entra ID users.
       userEmailSuffixesToReplace:
         - "@broadinstitute.org"
+
+suitabilitySynchronization:
+  enable: true
+  behaviors:
+    loadIntoDB:
+      enable: true
+      interval: 60m
+      firecloud:
+        domain: firecloud.org
+        groups:
+          fcAdmins: fc-admins@firecloud.org
+          firecloudProjectOwners: firecloud-project-owners@firecloud.org
+      # extraPermissions can be used to grant an exact email address access to "suitable" actions inside Sherlock,
+      # regardless of that email correlating to a Firecloud account. This functionality should only be used for
+      # service accounts, and the justification for this functionality existing is that adding a service account
+      # here is better than actually giving the service account any actual permissions inside the Firecloud org.
+      #
+      # This is almost always unnecessary, because a caller's suitability will be evaluated even from GitHub
+      # Actions. Great care needs to be taken using this capability, as access to the service account needs to
+      # otherwise be limited to only suitable individuals.
+      extraPermissions:
+        #- email: example@dsp-tools-k8s.iam.gserviceaccount.com
+        #  suitable: false

--- a/sherlock/config/test_config.yaml
+++ b/sherlock/config/test_config.yaml
@@ -19,14 +19,6 @@ db:
   ssl: disable
   init: true
 
-auth:
-  # These are for testing our handling of this config; tests run fully off-line
-  extraPermissions:
-    - email: has-extra-permissions-suitable@example.com
-      suitable: true
-    - email: has-extra-permissions-non-suitable@example.com
-      suitable: false
-
 hooks:
   asynchronous: false
 
@@ -80,3 +72,13 @@ rolePropagation:
         - broadinstitute.org
       toleratedUsers:
         - email: tolerated@test.firecloud.org
+
+suitabilitySynchronization:
+  behaviors:
+    loadIntoDB:
+      # These are for testing our handling of this config; tests run fully off-line
+      extraPermissions:
+        - email: has-extra-permissions-suitable@example.com
+          suitable: true
+        - email: has-extra-permissions-non-suitable@example.com
+          suitable: false

--- a/sherlock/internal/api/sherlock/role_assignments_v3.go
+++ b/sherlock/internal/api/sherlock/role_assignments_v3.go
@@ -15,7 +15,7 @@ type RoleAssignmentV3 struct {
 }
 
 type RoleAssignmentV3Edit struct {
-	Suspended *bool      `json:"suspended,omitempty" form:"suspended" default:"false"`
+	Suspended *bool      `json:"suspended,omitempty" form:"suspended"` // If the assignment should be active. This field is only mutable through the API if the role doesn't automatically suspend non-suitable users
 	ExpiresAt *time.Time `json:"expiresAt,omitempty" form:"expiresAt" format:"date-time"`
 	ExpiresIn *string    `json:"expiresIn,omitempty" form:"expiresIn"` // A Go time.Duration string that will be added to the current time to attempt to set expiresAt (this may be more convenient than setting expiresAt directly)
 }

--- a/sherlock/internal/api/sherlock/role_assignments_v3_create_test.go
+++ b/sherlock/internal/api/sherlock/role_assignments_v3_create_test.go
@@ -5,6 +5,7 @@ import (
 	"github.com/broadinstitute/sherlock/sherlock/internal/clients/slack"
 	"github.com/broadinstitute/sherlock/sherlock/internal/clients/slack/slack_mocks"
 	"github.com/broadinstitute/sherlock/sherlock/internal/errors"
+	"github.com/broadinstitute/sherlock/sherlock/internal/models"
 	"github.com/stretchr/testify/mock"
 	"net/http"
 	"time"
@@ -118,4 +119,138 @@ func (s *handlerSuite) TestRoleAssignmentsV3Create_alert() {
 		s.Equal(role.ID, got.RoleInfo.ID)
 		s.Equal(user.ID, got.UserInfo.ID)
 	})
+}
+
+func (s *handlerSuite) TestRoleAssignmentsV3Create_calculateDefaultSuspendedTrue() {
+	s.SetSelfSuperAdminForDB()
+	user := models.User{Email: "user1@example.com", GoogleID: "accounts.google.com:user1"}
+	s.NoError(s.DB.Create(&user).Error)
+	suitability := models.Suitability{Email: &user.Email, Suitable: utils.PointerTo(false), Description: utils.PointerTo("test")}
+	s.NoError(s.DB.Create(&suitability).Error)
+	role := models.Role{RoleFields: models.RoleFields{Name: utils.PointerTo("test-role"), SuspendNonSuitableUsers: utils.PointerTo(true)}}
+	s.NoError(s.DB.Create(&role).Error)
+	var got RoleAssignmentV3
+	code := s.HandleRequest(
+		s.NewSuperAdminRequest("POST", "/api/role-assignments/v3/"+utils.UintToString(role.ID)+"/"+utils.UintToString(user.ID), RoleAssignmentV3Edit{}),
+		&got)
+	s.Equal(http.StatusCreated, code)
+	s.True(*got.Suspended)
+}
+
+func (s *handlerSuite) TestRoleAssignmentsV3Create_calculateAgreeSuspendedTrue() {
+	s.SetSelfSuperAdminForDB()
+	user := models.User{Email: "user1@example.com", GoogleID: "accounts.google.com:user1"}
+	s.NoError(s.DB.Create(&user).Error)
+	suitability := models.Suitability{Email: &user.Email, Suitable: utils.PointerTo(false), Description: utils.PointerTo("test")}
+	s.NoError(s.DB.Create(&suitability).Error)
+	role := models.Role{RoleFields: models.RoleFields{Name: utils.PointerTo("test-role"), SuspendNonSuitableUsers: utils.PointerTo(true)}}
+	s.NoError(s.DB.Create(&role).Error)
+	var got RoleAssignmentV3
+	code := s.HandleRequest(
+		s.NewSuperAdminRequest("POST", "/api/role-assignments/v3/"+utils.UintToString(role.ID)+"/"+utils.UintToString(user.ID), RoleAssignmentV3Edit{
+			Suspended: utils.PointerTo(true),
+		}),
+		&got)
+	s.Equal(http.StatusCreated, code)
+	s.True(*got.Suspended)
+}
+
+func (s *handlerSuite) TestRoleAssignmentsV3Create_calculateDisagreeSuspendedTrue() {
+	s.SetSelfSuperAdminForDB()
+	user := models.User{Email: "user1@example.com", GoogleID: "accounts.google.com:user1"}
+	s.NoError(s.DB.Create(&user).Error)
+	suitability := models.Suitability{Email: &user.Email, Suitable: utils.PointerTo(false), Description: utils.PointerTo("test")}
+	s.NoError(s.DB.Create(&suitability).Error)
+	role := models.Role{RoleFields: models.RoleFields{Name: utils.PointerTo("test-role"), SuspendNonSuitableUsers: utils.PointerTo(true)}}
+	s.NoError(s.DB.Create(&role).Error)
+	var got errors.ErrorResponse
+	code := s.HandleRequest(
+		s.NewSuperAdminRequest("POST", "/api/role-assignments/v3/"+utils.UintToString(role.ID)+"/"+utils.UintToString(user.ID), RoleAssignmentV3Edit{
+			Suspended: utils.PointerTo(false),
+		}),
+		&got)
+	s.Equal(http.StatusBadRequest, code)
+	s.Contains(got.Message, "it's a computed field and is expected to be")
+}
+
+func (s *handlerSuite) TestRoleAssignmentsV3Create_calculateDefaultSuspendedFalse() {
+	s.SetSelfSuperAdminForDB()
+	user := models.User{Email: "user1@example.com", GoogleID: "accounts.google.com:user1"}
+	s.NoError(s.DB.Create(&user).Error)
+	suitability := models.Suitability{Email: &user.Email, Suitable: utils.PointerTo(true), Description: utils.PointerTo("test")}
+	s.NoError(s.DB.Create(&suitability).Error)
+	role := models.Role{RoleFields: models.RoleFields{Name: utils.PointerTo("test-role"), SuspendNonSuitableUsers: utils.PointerTo(true)}}
+	s.NoError(s.DB.Create(&role).Error)
+	var got RoleAssignmentV3
+	code := s.HandleRequest(
+		s.NewSuperAdminRequest("POST", "/api/role-assignments/v3/"+utils.UintToString(role.ID)+"/"+utils.UintToString(user.ID), RoleAssignmentV3Edit{}),
+		&got)
+	s.Equal(http.StatusCreated, code)
+	s.False(*got.Suspended)
+}
+
+func (s *handlerSuite) TestRoleAssignmentsV3Create_calculateAgreeSuspendedFalse() {
+	s.SetSelfSuperAdminForDB()
+	user := models.User{Email: "user1@example.com", GoogleID: "accounts.google.com:user1"}
+	s.NoError(s.DB.Create(&user).Error)
+	suitability := models.Suitability{Email: &user.Email, Suitable: utils.PointerTo(true), Description: utils.PointerTo("test")}
+	s.NoError(s.DB.Create(&suitability).Error)
+	role := models.Role{RoleFields: models.RoleFields{Name: utils.PointerTo("test-role"), SuspendNonSuitableUsers: utils.PointerTo(true)}}
+	s.NoError(s.DB.Create(&role).Error)
+	var got RoleAssignmentV3
+	code := s.HandleRequest(
+		s.NewSuperAdminRequest("POST", "/api/role-assignments/v3/"+utils.UintToString(role.ID)+"/"+utils.UintToString(user.ID), RoleAssignmentV3Edit{
+			Suspended: utils.PointerTo(false),
+		}),
+		&got)
+	s.Equal(http.StatusCreated, code)
+	s.False(*got.Suspended)
+}
+
+func (s *handlerSuite) TestRoleAssignmentsV3Create_calculateDisagreeSuspendedFalse() {
+	s.SetSelfSuperAdminForDB()
+	user := models.User{Email: "user1@example.com", GoogleID: "accounts.google.com:user1"}
+	s.NoError(s.DB.Create(&user).Error)
+	suitability := models.Suitability{Email: &user.Email, Suitable: utils.PointerTo(true), Description: utils.PointerTo("test")}
+	s.NoError(s.DB.Create(&suitability).Error)
+	role := models.Role{RoleFields: models.RoleFields{Name: utils.PointerTo("test-role"), SuspendNonSuitableUsers: utils.PointerTo(true)}}
+	s.NoError(s.DB.Create(&role).Error)
+	var got errors.ErrorResponse
+	code := s.HandleRequest(
+		s.NewSuperAdminRequest("POST", "/api/role-assignments/v3/"+utils.UintToString(role.ID)+"/"+utils.UintToString(user.ID), RoleAssignmentV3Edit{
+			Suspended: utils.PointerTo(true),
+		}),
+		&got)
+	s.Equal(http.StatusBadRequest, code)
+	s.Contains(got.Message, "it's a computed field and is expected to be")
+}
+
+func (s *handlerSuite) TestRoleAssignmentsV3Create_defaultFalse() {
+	s.SetSelfSuperAdminForDB()
+	user := models.User{Email: "user1@example.com", GoogleID: "accounts.google.com:user1"}
+	s.NoError(s.DB.Create(&user).Error)
+	suitability := models.Suitability{Email: &user.Email, Suitable: utils.PointerTo(false), Description: utils.PointerTo("test")}
+	s.NoError(s.DB.Create(&suitability).Error)
+	role := models.Role{RoleFields: models.RoleFields{Name: utils.PointerTo("test-role"), SuspendNonSuitableUsers: utils.PointerTo(false)}}
+	s.NoError(s.DB.Create(&role).Error)
+	var got RoleAssignmentV3
+	code := s.HandleRequest(
+		s.NewSuperAdminRequest("POST", "/api/role-assignments/v3/"+utils.UintToString(role.ID)+"/"+utils.UintToString(user.ID), nil),
+		&got)
+	s.Equal(http.StatusCreated, code)
+	s.False(*got.Suspended)
+}
+
+func (s *handlerSuite) TestRoleAssignmentsV3Create_defaultFalseNoSuitability() {
+	s.SetSelfSuperAdminForDB()
+	user := models.User{Email: "user1@example.com", GoogleID: "accounts.google.com:user1"}
+	s.NoError(s.DB.Create(&user).Error)
+	role := models.Role{RoleFields: models.RoleFields{Name: utils.PointerTo("test-role"), SuspendNonSuitableUsers: utils.PointerTo(false)}}
+	s.NoError(s.DB.Create(&role).Error)
+	var got RoleAssignmentV3
+	code := s.HandleRequest(
+		s.NewSuperAdminRequest("POST", "/api/role-assignments/v3/"+utils.UintToString(role.ID)+"/"+utils.UintToString(user.ID), nil),
+		&got)
+	s.Equal(http.StatusCreated, code)
+	s.False(*got.Suspended)
 }

--- a/sherlock/internal/api/sherlock/roles_v3.go
+++ b/sherlock/internal/api/sherlock/roles_v3.go
@@ -15,7 +15,7 @@ type RoleV3 struct {
 
 type RoleV3Edit struct {
 	Name                      *string   `json:"name" form:"name"`
-	SuspendNonSuitableUsers   *bool     `json:"suspendNonSuitableUsers,omitempty" form:"suspendNonSuitableUsers"`
+	SuspendNonSuitableUsers   *bool     `json:"suspendNonSuitableUsers,omitempty" form:"suspendNonSuitableUsers"` // When true, the "suspended" field on role assignments will be computed by Sherlock based on suitability instead of being a mutable API field
 	CanBeGlassBrokenByRole    *uint     `json:"canBeGlassBrokenByRole,omitempty" form:"canBeGlassBrokenByRole"`
 	DefaultGlassBreakDuration *Duration `json:"defaultGlassBreakDuration,omitempty" swaggertype:"string" form:"defaultGlassBreakDuration"`
 	GrantsSherlockSuperAdmin  *bool     `json:"grantsSherlockSuperAdmin,omitempty" form:"grantsSherlockSuperAdmin"`

--- a/sherlock/internal/boot/application.go
+++ b/sherlock/internal/boot/application.go
@@ -13,7 +13,7 @@ import (
 	"github.com/broadinstitute/sherlock/sherlock/internal/middleware/authentication/gha_oidc"
 	"github.com/broadinstitute/sherlock/sherlock/internal/models"
 	"github.com/broadinstitute/sherlock/sherlock/internal/role_propagation"
-	"github.com/broadinstitute/sherlock/sherlock/internal/suitability_loader"
+	"github.com/broadinstitute/sherlock/sherlock/internal/suitability_synchronization"
 	"github.com/gin-gonic/gin"
 	"github.com/rs/zerolog/log"
 	"gorm.io/gorm"
@@ -81,10 +81,10 @@ func (a *Application) Start() {
 
 	if config.Config.MustString("mode") != "debug" {
 		log.Info().Msgf("BOOT | caching Firecloud accounts and config-based suitability...")
-		if err = suitability_loader.SyncSuitabilitiesToDB(ctx, a.gormDB); err != nil {
-			log.Fatal().Err(err).Msgf("suitabilityloader.SyncSuitabilitiesToDB() error")
+		if err = suitability_synchronization.LoadIntoDB(ctx, a.gormDB); err != nil {
+			log.Fatal().Err(err).Msgf("suitability_synchronization.LoadIntoDB() error")
 		}
-		go suitability_loader.KeepSuitabilitiesInDBUpdated(ctx, a.gormDB)
+		go suitability_synchronization.KeepLoadingIntoDB(ctx, a.gormDB)
 	}
 
 	log.Info().Msgf("BOOT | initializing GitHub Actions OIDC token verification...")

--- a/sherlock/internal/models/role.go
+++ b/sherlock/internal/models/role.go
@@ -16,6 +16,9 @@ type RoleFields struct {
 
 	// SuspendNonSuitableUsers instructs that any RoleAssignment between this Role and a User who is not suitable
 	// should be marked as suspended (and any of this Role's grants should be suspended accordingly).
+	//
+	// When this field is true, RoleAssignmentFields.Suspended becomes effectively a computed field that can't
+	// be set directly from the API.
 	SuspendNonSuitableUsers *bool
 
 	// CanBeGlassBrokenByRole indicates that any User with a RoleAssignment to the given Role can temporarily give

--- a/sherlock/internal/models/role_assignment.go
+++ b/sherlock/internal/models/role_assignment.go
@@ -12,6 +12,23 @@ import (
 )
 
 type RoleAssignmentFields struct {
+	// Suspended represents whether the RoleAssignment is active or not.
+	//
+	// This field is closely related to RoleFields.SuspendNonSuitableUsers. When that field is true,
+	// this field effectively becomes a computed field, managed entirely by Sherlock based on the
+	// Suitability of each User. This accomplishes effectively revoking a User's permissions when
+	// they become non-suitable.
+	//
+	// Why have a concept of suspension vs. just deleting the RoleAssignment? There's two reasons:
+	// 1. Some role grants, like a Firecloud.org account, actually have a concept of suspension.
+	//    When this is available, it's extremely useful: e.g. we can create and delete Firecloud.org
+	//    accounts based on presence of a RoleAssignment, and as suitability fluctuates we just
+	//    suspend it. If we deleted it, the Google subject ID would change, and people would need
+	//    to set their password and two-factor.
+	// 2. It allows the super-admins to manage role membership independent of suitability. We don't
+	//    need to wait for a new employee to actually become suitable before adding them to a bunch
+	//    of roles: the roles will just automatically not grant permissions until the user becomes
+	//    suitable.
 	Suspended *bool
 	ExpiresAt *time.Time
 }

--- a/sherlock/internal/suitability_synchronization/load_from_config.go
+++ b/sherlock/internal/suitability_synchronization/load_from_config.go
@@ -1,4 +1,4 @@
-package suitability_loader
+package suitability_synchronization
 
 import (
 	"fmt"
@@ -9,14 +9,14 @@ import (
 
 func fromConfig() ([]models.Suitability, error) {
 	var result []models.Suitability
-	for index, entry := range config.Config.Slices("auth.extraPermissions") {
+	for index, entry := range config.Config.Slices("suitabilitySynchronization.behaviors.loadIntoDB.extraPermissions") {
 		email := entry.String("email")
 		if email == "" {
-			return nil, fmt.Errorf("auth.extraPermissions[%d].email is required", index)
+			return nil, fmt.Errorf("suitabilitySynchronization.behaviors.loadIntoDB.extraPermissions.extraPermissions[%d].email is required", index)
 		}
 		result = append(result, models.Suitability{
 			Email:       &email,
-			Suitable:    utils.PointerTo(true),
+			Suitable:    utils.PointerTo(entry.Bool("suitable")),
 			Description: utils.PointerTo("suitability set via Sherlock configuration"),
 		})
 	}

--- a/sherlock/internal/suitability_synchronization/load_from_config_test.go
+++ b/sherlock/internal/suitability_synchronization/load_from_config_test.go
@@ -1,0 +1,27 @@
+package suitability_synchronization
+
+import (
+	"github.com/broadinstitute/sherlock/go-shared/pkg/utils"
+	"github.com/broadinstitute/sherlock/sherlock/internal/config"
+	"github.com/broadinstitute/sherlock/sherlock/internal/models"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func Test_fromConfig(t *testing.T) {
+	config.LoadTestConfig()
+	results, err := fromConfig()
+	assert.NoError(t, err)
+	assert.Equal(t, []models.Suitability{
+		{
+			Email:       utils.PointerTo("has-extra-permissions-suitable@example.com"),
+			Suitable:    utils.PointerTo(true),
+			Description: utils.PointerTo("suitability set via Sherlock configuration"),
+		},
+		{
+			Email:       utils.PointerTo("has-extra-permissions-non-suitable@example.com"),
+			Suitable:    utils.PointerTo(false),
+			Description: utils.PointerTo("suitability set via Sherlock configuration"),
+		},
+	}, results)
+}

--- a/sherlock/internal/suitability_synchronization/load_from_firecloud.go
+++ b/sherlock/internal/suitability_synchronization/load_from_firecloud.go
@@ -1,4 +1,4 @@
-package suitability_loader
+package suitability_synchronization
 
 import (
 	"context"
@@ -19,13 +19,15 @@ func fromFirecloud(ctx context.Context) ([]models.Suitability, error) {
 	}
 
 	var fcAdminsGroupEmails []string
-	err = adminService.Members.List(config.Config.MustString("auth.firecloud.groups.fcAdmins")).Pages(ctx, func(members *admin.Members) error {
+	err = adminService.Members.List(config.Config.MustString("suitabilitySynchronization.behaviors.loadIntoDB.firecloud.groups.fcAdmins")).Pages(ctx, func(members *admin.Members) error {
 		if members == nil {
-			return fmt.Errorf("cacheFirecloudSuitability got a nil %s member page from Google", config.Config.MustString("auth.firecloud.groups.fcAdmins"))
+			return fmt.Errorf("suitability synchronization got a nil %s member page from Google",
+				config.Config.MustString("suitabilitySynchronization.behaviors.loadIntoDB.firecloud.groups.fcAdmins"))
 		} else {
 			for _, member := range members.Members {
 				if member == nil {
-					return fmt.Errorf("cacheFirecloudSuitability got a nil %s member from Google", config.Config.MustString("auth.firecloud.groups.fcAdmins"))
+					return fmt.Errorf("suitability synchronization got a nil %s member from Google",
+						config.Config.MustString("suitabilitySynchronization.behaviors.loadIntoDB.firecloud.groups.fcAdmins"))
 				} else {
 					fcAdminsGroupEmails = append(fcAdminsGroupEmails, member.Email)
 				}
@@ -38,13 +40,15 @@ func fromFirecloud(ctx context.Context) ([]models.Suitability, error) {
 	}
 
 	var firecloudProjectOwnersGroupEmails []string
-	err = adminService.Members.List(config.Config.MustString("auth.firecloud.groups.firecloudProjectOwners")).Pages(ctx, func(members *admin.Members) error {
+	err = adminService.Members.List(config.Config.MustString("suitabilitySynchronization.behaviors.loadIntoDB.firecloud.groups.firecloudProjectOwners")).Pages(ctx, func(members *admin.Members) error {
 		if members == nil {
-			return fmt.Errorf("cacheFirecloudSuitability got a nil %s member page from Google", config.Config.MustString("auth.firecloud.groups.fcAdmins"))
+			return fmt.Errorf("suitability synchronization got a nil %s member page from Google",
+				config.Config.MustString("suitabilitySynchronization.behaviors.loadIntoDB.firecloud.groups.fcAdmins"))
 		} else {
 			for _, member := range members.Members {
 				if member == nil {
-					return fmt.Errorf("cacheFirecloudSuitability got a nil %s member from Google", config.Config.MustString("auth.firecloud.groups.fcAdmins"))
+					return fmt.Errorf("suitability synchronization got a nil %s member from Google",
+						config.Config.MustString("suitabilitySynchronization.behaviors.loadIntoDB.firecloud.groups.fcAdmins"))
 				} else {
 					firecloudProjectOwnersGroupEmails = append(firecloudProjectOwnersGroupEmails, member.Email)
 				}
@@ -57,13 +61,13 @@ func fromFirecloud(ctx context.Context) ([]models.Suitability, error) {
 	}
 
 	resultSet := make(map[string]models.Suitability)
-	err = adminService.Users.List().Domain(config.Config.MustString("auth.firecloud.domain")).Pages(ctx, func(workspaceUsers *admin.Users) error {
+	err = adminService.Users.List().Domain(config.Config.MustString("suitabilitySynchronization.behaviors.loadIntoDB.firecloud.domain")).Pages(ctx, func(workspaceUsers *admin.Users) error {
 		if workspaceUsers == nil {
-			return fmt.Errorf("cacheFirecloudSuitability got a nil user page from Google")
+			return fmt.Errorf("suitability synchronization got a nil user page from Google")
 		} else {
 			for _, workspaceUser := range workspaceUsers.Users {
 				if workspaceUser == nil {
-					return fmt.Errorf("cacheFirecloudSuitability got a nil user from Google")
+					return fmt.Errorf("suitability synchronization got a nil user from Google")
 				} else {
 					suitable, description := parseFirecloudUser(workspaceUser, fcAdminsGroupEmails, firecloudProjectOwnersGroupEmails)
 					if workspaceUser.PrimaryEmail != "" {
@@ -135,20 +139,20 @@ func parseFirecloudUser(workspaceUser *admin.User, fcAdminsGroupEmails []string,
 		return false, "firecloud user doesn't appear to have a primary email? something's amiss, marking as not suitable"
 	} else if !workspaceUser.AgreedToTerms {
 		return false, fmt.Sprintf("firecloud user hasn't accepted Google Workspace terms (suggesting they've never logged in; they'll need to wait %d minutes after first login for Sherlock to pick it up)",
-			config.Config.MustInt("auth.updateIntervalMinutes"))
+			config.Config.Duration("suitabilitySynchronization.behaviors.loadIntoDB.interval"))
 	} else if !workspaceUser.IsEnrolledIn2Sv {
 		return false, "firecloud user hasn't enrolled in two-factor authentication"
 	} else if workspaceUser.Suspended {
 		return false, fmt.Sprintf("firecloud user is suspended, probably due to inactivity (reach out to #dsp-devops-champions for help; they'll need to wait %d minutes after reactivation for Sherlock to pick it up)",
-			config.Config.MustInt("auth.updateIntervalMinutes"))
+			config.Config.Duration("suitabilitySynchronization.behaviors.loadIntoDB.interval"))
 	} else if workspaceUser.Archived {
 		return false, "firecloud user is archived"
 	} else if !utils.Contains(fcAdminsGroupEmails, workspaceUser.PrimaryEmail) {
 		return false, fmt.Sprintf("firecloud user isn't in fc-admins group (reach out to #dsp-devops-champions for help; they'll need to wait %d minutes after being added for Sherlock to pick it up)",
-			config.Config.MustInt("auth.updateIntervalMinutes"))
+			config.Config.Duration("suitabilitySynchronization.behaviors.loadIntoDB.interval"))
 	} else if !utils.Contains(firecloudProjectOwnersGroupEmails, workspaceUser.PrimaryEmail) {
 		return false, fmt.Sprintf("firecloud user isn't in firecloud-project-owners group (reach out to #dsp-devops-champions for help; they'll need to wait %d minutes after being added for Sherlock to pick it up)",
-			config.Config.MustInt("auth.updateIntervalMinutes"))
+			config.Config.Duration("suitabilitySynchronization.behaviors.loadIntoDB.interval"))
 	} else {
 		return true, "firecloud user is suitable"
 	}

--- a/sherlock/internal/suitability_synchronization/suspend_role_assignments.go
+++ b/sherlock/internal/suitability_synchronization/suspend_role_assignments.go
@@ -1,0 +1,111 @@
+package suitability_synchronization
+
+import (
+	"context"
+	"fmt"
+	"github.com/broadinstitute/sherlock/go-shared/pkg/utils"
+	"github.com/broadinstitute/sherlock/sherlock/internal/clients/slack"
+	"github.com/broadinstitute/sherlock/sherlock/internal/config"
+	"github.com/broadinstitute/sherlock/sherlock/internal/models"
+	"github.com/broadinstitute/sherlock/sherlock/internal/role_propagation"
+	"github.com/rs/zerolog/log"
+	"gorm.io/gorm"
+	"time"
+)
+
+func KeepSuspendingRoleAssignments(ctx context.Context, db *gorm.DB) {
+	if config.Config.Bool("suitabilitySynchronization.enable") && config.Config.Bool("suitabilitySynchronization.behaviors.suspendRoleAssignments.enable") {
+		interval := config.Config.MustDuration("suitabilitySynchronization.behaviors.suspendRoleAssignments.interval")
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+				if err := suspendRoleAssignments(ctx, db); err != nil {
+					log.Warn().Err(err).Msgf("failed to suspend role assignments: %v", err)
+				}
+			}
+			time.Sleep(interval)
+		}
+	}
+}
+
+func suspendRoleAssignments(ctx context.Context, db *gorm.DB) error {
+	var roleIDsToSuspendAssignmentsFor []uint
+	if err := db.Model(&models.Role{}).Where(&models.Role{
+		RoleFields: models.RoleFields{
+			SuspendNonSuitableUsers: utils.PointerTo(true),
+		},
+	}).Pluck("id", &roleIDsToSuspendAssignmentsFor).Error; err != nil {
+		return fmt.Errorf("failed to get roles to suspend assignments for: %w", err)
+	}
+	if len(roleIDsToSuspendAssignmentsFor) == 0 {
+		return nil
+	}
+	// Assume super-user privileges for this operation (required to edit RoleAssignments)
+	superUserDB := models.SetCurrentUserForDB(db, models.SelfUser)
+	roleIDsRequiringPropagation := make(map[uint]struct{})
+	var summaries []string
+	var errors []error
+	for _, roleID := range roleIDsToSuspendAssignmentsFor {
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
+			var role models.Role
+			if err := db.
+				Preload("Assignments").
+				Preload("Assignments.User").
+				Preload("Assignments.User.Suitability").
+				Take(&role, roleID).Error; err != nil {
+				return fmt.Errorf("failed to get role %d: %w", roleID, err)
+			}
+			for _, assignment := range role.Assignments {
+				if assignment.User == nil {
+					errors = append(errors, fmt.Errorf("skipping evaluating assignment for %s because user was nil", *role.Name))
+					continue
+				}
+				suitable := assignment.User.Suitability != nil && assignment.User.Suitability.Suitable != nil && *assignment.User.Suitability.Suitable
+				if suitable && (assignment.Suspended == nil || *assignment.Suspended) {
+					roleIDsRequiringPropagation[roleID] = struct{}{}
+					if err := superUserDB.Model(&assignment).Updates(&models.RoleAssignment{
+						RoleAssignmentFields: models.RoleAssignmentFields{
+							Suspended: utils.PointerTo(false),
+						},
+					}).Error; err != nil {
+						errors = append(errors, fmt.Errorf("failed to un-suspend %s's assignment for %s: %w", assignment.User.NameOrEmailHandle(), *role.Name, err))
+					} else {
+						summaries = append(summaries, fmt.Sprintf("un-suspended %s's assignment for %s", assignment.User.NameOrEmailHandle(), *role.Name))
+					}
+				} else if !suitable && (assignment.Suspended == nil || !*assignment.Suspended) {
+					roleIDsRequiringPropagation[roleID] = struct{}{}
+					if err := superUserDB.Model(&assignment).Updates(&models.RoleAssignment{
+						RoleAssignmentFields: models.RoleAssignmentFields{
+							Suspended: utils.PointerTo(true),
+						},
+					}).Error; err != nil {
+						errors = append(errors, fmt.Errorf("failed to suspend %s's assignment for %s: %w", assignment.User.NameOrEmailHandle(), *role.Name, err))
+					} else {
+						summaries = append(summaries, fmt.Sprintf("suspended %s's assignment for %s", assignment.User.NameOrEmailHandle(), *role.Name))
+					}
+				}
+			}
+		}
+	}
+	if len(summaries) > 0 {
+		slack.SendPermissionChangeNotification(ctx, models.SelfUser.SlackReference(true), slack.PermissionChangeNotificationInputs{
+			Summary: "modified role assignments based on suitability",
+			Results: summaries,
+			Errors:  errors,
+		})
+	}
+	for roleID := range roleIDsRequiringPropagation {
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
+			role_propagation.DoOnDemandPropagation(ctx, db, roleID)
+		}
+	}
+	return nil
+}

--- a/sherlock/internal/suitability_synchronization/suspend_role_assignments_test.go
+++ b/sherlock/internal/suitability_synchronization/suspend_role_assignments_test.go
@@ -1,0 +1,94 @@
+package suitability_synchronization
+
+import (
+	"github.com/broadinstitute/sherlock/go-shared/pkg/utils"
+	"github.com/broadinstitute/sherlock/sherlock/internal/clients/slack"
+	"github.com/broadinstitute/sherlock/sherlock/internal/clients/slack/slack_mocks"
+	"github.com/broadinstitute/sherlock/sherlock/internal/models"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type suspendRoleAssignmentsSuite struct {
+	suite.Suite
+	models.TestSuiteHelper
+}
+
+func TestSuspendRoleAssignmentsSuite(t *testing.T) {
+	suite.Run(t, new(suspendRoleAssignmentsSuite))
+}
+
+func (s *suspendRoleAssignmentsSuite) Test_suspendRoleAssignments_none() {
+	slack.UseMockedClient(s.T(), func(c *slack_mocks.MockMockableClient) {}, func() {
+		s.NoError(suspendRoleAssignments(s.DB.Statement.Context, s.DB))
+	})
+}
+
+func (s *suspendRoleAssignmentsSuite) Test_suspendRoleAssignments() {
+	s.SetSelfSuperAdminForDB()
+	user1 := models.User{Email: "user1@example.com", GoogleID: "accounts.google.com:user1"}
+	user2 := models.User{Email: "user2@example.com", GoogleID: "accounts.google.com:user2"}
+	user3 := models.User{Email: "user3@example.com", GoogleID: "accounts.google.com:user3"}
+	user4 := models.User{Email: "user4@example.com", GoogleID: "accounts.google.com:user4"}
+	user5 := models.User{Email: "user5@example.com", GoogleID: "accounts.google.com:user5"}
+	s.NoError(s.DB.Create(&user1).Error)
+	s.NoError(s.DB.Create(&user2).Error)
+	s.NoError(s.DB.Create(&user3).Error)
+	s.NoError(s.DB.Create(&user4).Error)
+	s.NoError(s.DB.Create(&user5).Error)
+	suitability1 := models.Suitability{Email: &user1.Email, Suitable: utils.PointerTo(true), Description: utils.PointerTo("test")}
+	suitability2 := models.Suitability{Email: &user2.Email, Suitable: utils.PointerTo(true), Description: utils.PointerTo("test")}
+	suitability3 := models.Suitability{Email: &user3.Email, Suitable: utils.PointerTo(false), Description: utils.PointerTo("test")}
+	suitability4 := models.Suitability{Email: &user4.Email, Suitable: utils.PointerTo(false), Description: utils.PointerTo("test")}
+	// no suitability record for user 5
+	s.NoError(s.DB.Create(&suitability1).Error)
+	s.NoError(s.DB.Create(&suitability2).Error)
+	s.NoError(s.DB.Create(&suitability3).Error)
+	s.NoError(s.DB.Create(&suitability4).Error)
+	role := models.Role{RoleFields: models.RoleFields{Name: utils.PointerTo("test-role"), SuspendNonSuitableUsers: utils.PointerTo(true)}}
+	s.NoError(s.DB.Create(&role).Error)
+	assignment1 := models.RoleAssignment{RoleID: role.ID, UserID: user1.ID, RoleAssignmentFields: models.RoleAssignmentFields{Suspended: utils.PointerTo(false)}}
+	assignment2 := models.RoleAssignment{RoleID: role.ID, UserID: user2.ID, RoleAssignmentFields: models.RoleAssignmentFields{Suspended: utils.PointerTo(true)}}
+	assignment3 := models.RoleAssignment{RoleID: role.ID, UserID: user3.ID, RoleAssignmentFields: models.RoleAssignmentFields{Suspended: utils.PointerTo(true)}}
+	assignment4 := models.RoleAssignment{RoleID: role.ID, UserID: user4.ID, RoleAssignmentFields: models.RoleAssignmentFields{Suspended: utils.PointerTo(false)}}
+	assignment5 := models.RoleAssignment{RoleID: role.ID, UserID: user5.ID, RoleAssignmentFields: models.RoleAssignmentFields{Suspended: utils.PointerTo(false)}}
+	s.NoError(s.DB.Create(&assignment1).Error)
+	s.NoError(s.DB.Create(&assignment2).Error)
+	s.NoError(s.DB.Create(&assignment3).Error)
+	s.NoError(s.DB.Create(&assignment4).Error)
+	s.NoError(s.DB.Create(&assignment5).Error)
+
+	slack.UseMockedClient(s.T(), func(c *slack_mocks.MockMockableClient) {
+		c.EXPECT().SendMessageContext(mock.Anything, "#notification-channel", mock.Anything).Return("", "", "", nil)
+		c.EXPECT().SendMessageContext(mock.Anything, "#permission-change-channel", mock.Anything).Return("", "", "", nil)
+	}, func() {
+		s.NoError(suspendRoleAssignments(s.DB.Statement.Context, s.DB))
+	})
+
+	s.Run("user 1 should still be active", func() {
+		var assignment models.RoleAssignment
+		s.NoError(s.DB.Where(&models.RoleAssignment{RoleID: role.ID, UserID: user1.ID}).Take(&assignment).Error)
+		s.False(*assignment.Suspended)
+	})
+	s.Run("user 2 should have been made active", func() {
+		var assignment models.RoleAssignment
+		s.NoError(s.DB.Where(&models.RoleAssignment{RoleID: role.ID, UserID: user2.ID}).Take(&assignment).Error)
+		s.False(*assignment.Suspended)
+	})
+	s.Run("user 3 should still be suspended", func() {
+		var assignment models.RoleAssignment
+		s.NoError(s.DB.Where(&models.RoleAssignment{RoleID: role.ID, UserID: user3.ID}).Take(&assignment).Error)
+		s.True(*assignment.Suspended)
+	})
+	s.Run("user 4 should have been suspended", func() {
+		var assignment models.RoleAssignment
+		s.NoError(s.DB.Where(&models.RoleAssignment{RoleID: role.ID, UserID: user4.ID}).Take(&assignment).Error)
+		s.True(*assignment.Suspended)
+	})
+	s.Run("user 5 should have been suspended as handling for the suitability record not existing", func() {
+		var assignment models.RoleAssignment
+		s.NoError(s.DB.Where(&models.RoleAssignment{RoleID: role.ID, UserID: user5.ID}).Take(&assignment).Error)
+		s.True(*assignment.Suspended)
+	})
+}


### PR DESCRIPTION
Three steps:
1. Refactors existing suitability loading to be in a suitability synchronization package
2. Adds a cronjob-type-thing to automatically suspend role assignments that should be suspended
3. Adjusts API to enforce the "calculated field" of role assignment suspension

## Tests

The usual test coverage. Went a little bit overboard with some of the API level tests

## Risk

Low