### PR TITLE
[DDO-3776] Check role membership

### DIFF
--- a/sherlock/db/migrations/000062_environment_v3.up.sql
+++ b/sherlock/db/migrations/000062_environment_v3.up.sql
@@ -9,7 +9,8 @@ alter table environments
 
 alter table environments
     add constraint lifecycle_valid
-        check ((lifecycle = 'template' and template_environment_id is null) or
+        check ((lifecycle = 'template' and
+                template_environment_id is null) or
                (lifecycle = 'dynamic' and
                 template_environment_id is not null and
                 base is not null and base != '' and

--- a/sherlock/db/migrations/000092_required_role.down.sql
+++ b/sherlock/db/migrations/000092_required_role.down.sql
@@ -1,0 +1,37 @@
+alter table clusters
+    alter column requires_suitability set not null;
+
+alter table environments
+    drop constraint if exists fk_environments_required_role;
+
+alter table environments
+    drop column if exists required_role_id;
+
+alter table environments
+    add constraint lifecycle_valid_temp
+        check ((lifecycle = 'template' and
+                template_environment_id is null) or
+               (lifecycle = 'dynamic' and
+                template_environment_id is not null and
+                base is not null and base != '' and
+                default_cluster_id is not null and
+                requires_suitability is not null) or
+               (lifecycle = 'static' and
+                base is not null and base != '' and
+                default_cluster_id is not null and
+                requires_suitability is not null));
+
+alter table environments
+    validate constraint lifecycle_valid_temp;
+
+alter table environments
+    drop constraint lifecycle_valid;
+
+alter table environments
+    rename constraint lifecycle_valid_temp to lifecycle_valid;
+
+alter table clusters
+    drop constraint if exists fk_clusters_required_role;
+
+alter table clusters
+    drop column if exists required_role_id;

--- a/sherlock/db/migrations/000092_required_role.up.sql
+++ b/sherlock/db/migrations/000092_required_role.up.sql
@@ -1,0 +1,43 @@
+alter table clusters
+    add column required_role_id bigint;
+
+alter table clusters
+    add constraint fk_clusters_required_role
+        foreign key (required_role_id) references roles;
+
+-- Now formally allow nulls in requires_suitability column to match with the semantics of required_role_id
+alter table clusters
+    alter column requires_suitability drop not null;
+
+alter table environments
+    add column required_role_id bigint;
+
+alter table environments
+    add constraint fk_environments_required_role
+        foreign key (required_role_id) references roles;
+
+-- The not null requirement on requires_suitability here is lifecycle-dependent, see 000062_environment_v3.up.sql,
+-- so we need to drop the not null constraint here to match the semantics of required_role_id.
+-- We do this by adding a new constraint as not valid, so that it commits instantly, and then validate it.
+-- This requires much, much less locking than a normal add constraint.
+-- https://www.postgresql.org/docs/current/sql-altertable.html#SQL-ALTERTABLE-NOTES
+alter table environments
+    add constraint lifecycle_valid_temp
+        check ((lifecycle = 'template' and
+                template_environment_id is null) or
+               (lifecycle = 'dynamic' and
+                template_environment_id is not null and
+                base is not null and base != '' and
+                default_cluster_id is not null) or
+               (lifecycle = 'static' and
+                base is not null and base != '' and
+                default_cluster_id is not null)) not valid;
+
+alter table environments
+    validate constraint lifecycle_valid_temp;
+
+alter table environments
+    drop constraint lifecycle_valid;
+
+alter table environments
+    rename constraint lifecycle_valid_temp to lifecycle_valid;

--- a/sherlock/internal/api/sherlock/clusters_v3_create.go
+++ b/sherlock/internal/api/sherlock/clusters_v3_create.go
@@ -39,7 +39,11 @@ func clustersV3Create(ctx *gin.Context) {
 		return
 	}
 
-	toCreate := body.toModel()
+	toCreate, err := body.toModel(db)
+	if err != nil {
+		errors.AbortRequest(ctx, err)
+		return
+	}
 	if err = db.Create(&toCreate).Error; err != nil {
 		errors.AbortRequest(ctx, err)
 		return

--- a/sherlock/internal/api/sherlock/clusters_v3_create_test.go
+++ b/sherlock/internal/api/sherlock/clusters_v3_create_test.go
@@ -44,9 +44,6 @@ func (s *handlerSuite) TestClustersV3Create_defaults() {
 	s.Equal(http.StatusCreated, code)
 	s.Equal("cluster-name", got.Name)
 	s.Equal("us-central1-a", got.Location)
-	if s.NotNil(got.RequiresSuitability) {
-		s.False(*got.RequiresSuitability)
-	}
 	if s.NotNil(got.HelmfileRef) {
 		s.Equal("HEAD", *got.HelmfileRef)
 	}

--- a/sherlock/internal/api/sherlock/clusters_v3_edit.go
+++ b/sherlock/internal/api/sherlock/clusters_v3_edit.go
@@ -38,7 +38,11 @@ func clustersV3Edit(ctx *gin.Context) {
 		return
 	}
 
-	edits := body.toModel()
+	edits, err := body.toModel(db)
+	if err != nil {
+		errors.AbortRequest(ctx, err)
+		return
+	}
 
 	var toEdit models.Cluster
 	if err = db.Preload(clause.Associations).Where(&query).First(&toEdit).Error; err != nil {

--- a/sherlock/internal/api/sherlock/clusters_v3_list.go
+++ b/sherlock/internal/api/sherlock/clusters_v3_list.go
@@ -33,7 +33,11 @@ func clustersV3List(ctx *gin.Context) {
 		errors.AbortRequest(ctx, err)
 		return
 	}
-	modelFilter := filter.toModel()
+	modelFilter, err := filter.toModel(db)
+	if err != nil {
+		errors.AbortRequest(ctx, err)
+		return
+	}
 
 	limit, err := utils.ParseInt(ctx.DefaultQuery("limit", "0"))
 	if err != nil {

--- a/sherlock/internal/api/sherlock/environments_v3_test.go
+++ b/sherlock/internal/api/sherlock/environments_v3_test.go
@@ -158,6 +158,7 @@ func (s *handlerSuite) TestEnvironmentV3_toModel() {
 						DefaultCluster:              utils.PointerTo(defaultCluster.Name),
 						Owner:                       utils.PointerTo(owner.Email),
 						RequiresSuitability:         utils.PointerTo(true),
+						RequiredRole:                s.TestData.Role_TerraSuitableEngineer().Name,
 						BaseDomain:                  utils.PointerTo("base-domain"),
 						NamePrefixesDomain:          utils.PointerTo(true),
 						HelmfileRef:                 utils.PointerTo("HEAD"),
@@ -193,6 +194,7 @@ func (s *handlerSuite) TestEnvironmentV3_toModel() {
 				DefaultClusterID:          &defaultCluster.ID,
 				OwnerID:                   &owner.ID,
 				RequiresSuitability:       utils.PointerTo(true),
+				RequiredRoleID:            utils.PointerTo(s.TestData.Role_TerraSuitableEngineer().ID),
 				BaseDomain:                utils.PointerTo("base-domain"),
 				NamePrefixesDomain:        utils.PointerTo(true),
 				HelmfileRef:               utils.PointerTo("HEAD"),
@@ -345,6 +347,8 @@ func Test_environmentFromModel(t *testing.T) {
 				Owner:                     &models.User{Model: gorm.Model{ID: 5}, Email: "example@example.com"},
 				OwnerID:                   utils.PointerTo[uint](5),
 				RequiresSuitability:       utils.PointerTo(true),
+				RequiredRole:              &models.Role{Model: gorm.Model{ID: 999}, RoleFields: models.RoleFields{Name: utils.PointerTo("role-name")}},
+				RequiredRoleID:            utils.PointerTo[uint](999),
 				BaseDomain:                utils.PointerTo("base-domain"),
 				NamePrefixesDomain:        utils.PointerTo(true),
 				HelmfileRef:               utils.PointerTo("HEAD"),
@@ -376,6 +380,7 @@ func Test_environmentFromModel(t *testing.T) {
 				PagerdutyIntegrationInfo: &PagerdutyIntegrationV3{CommonFields: CommonFields{ID: 6}, PagerdutyID: "blah"},
 				OwnerInfo: &UserV3{CommonFields: CommonFields{ID: 5}, Email: "example@example.com", Suitable: utils.PointerTo(false),
 					SuitabilityDescription: utils.PointerTo("no matching suitability record found or loaded; assuming unsuitable")},
+				RequiredRoleInfo: &RoleV3{CommonFields: CommonFields{ID: 999}, RoleV3Edit: RoleV3Edit{Name: utils.PointerTo("role-name")}},
 				EnvironmentV3Create: EnvironmentV3Create{
 					Base:                      "base",
 					AutoPopulateChartReleases: utils.PointerTo(true),
@@ -389,6 +394,7 @@ func Test_environmentFromModel(t *testing.T) {
 						DefaultCluster:              utils.PointerTo("name-4"),
 						Owner:                       utils.PointerTo("example@example.com"),
 						RequiresSuitability:         utils.PointerTo(true),
+						RequiredRole:                utils.PointerTo("role-name"),
 						BaseDomain:                  utils.PointerTo("base-domain"),
 						NamePrefixesDomain:          utils.PointerTo(true),
 						HelmfileRef:                 utils.PointerTo("HEAD"),
@@ -416,6 +422,19 @@ func Test_environmentFromModel(t *testing.T) {
 				EnvironmentV3Create: EnvironmentV3Create{
 					EnvironmentV3Edit: EnvironmentV3Edit{
 						PagerdutyIntegration: utils.PointerTo("6"),
+					},
+				},
+			},
+		},
+		{
+			name: "role ID case",
+			args: args{model: models.Environment{
+				RequiredRoleID: utils.PointerTo[uint](999),
+			}},
+			want: EnvironmentV3{
+				EnvironmentV3Create: EnvironmentV3Create{
+					EnvironmentV3Edit: EnvironmentV3Edit{
+						RequiredRole: utils.PointerTo("999"),
 					},
 				},
 			},

--- a/sherlock/internal/api/sherlock/pagerduty_integrations_v3_create_test.go
+++ b/sherlock/internal/api/sherlock/pagerduty_integrations_v3_create_test.go
@@ -10,7 +10,7 @@ import (
 func (s *handlerSuite) TestPagerdutyIntegrationsV3Create_badBody() {
 	var got errors.ErrorResponse
 	code := s.HandleRequest(
-		s.NewRequest("POST", "/api/pagerduty-integrations/v3", gin.H{
+		s.NewSuperAdminRequest("POST", "/api/pagerduty-integrations/v3", gin.H{
 			"pagerdutyID": 123,
 		}),
 		&got)
@@ -22,7 +22,7 @@ func (s *handlerSuite) TestPagerdutyIntegrationsV3Create_badBody() {
 func (s *handlerSuite) TestPagerdutyIntegrationsV3Create_sqlValidation() {
 	var got errors.ErrorResponse
 	code := s.HandleRequest(
-		s.NewRequest("POST", "/api/pagerduty-integrations/v3", PagerdutyIntegrationV3Create{}),
+		s.NewSuperAdminRequest("POST", "/api/pagerduty-integrations/v3", PagerdutyIntegrationV3Create{}),
 		&got)
 	s.Equal(http.StatusBadRequest, code)
 	s.Equal(errors.BadRequest, got.Type)
@@ -47,7 +47,7 @@ func (s *handlerSuite) TestPagerdutyIntegrationsV3Create_suitability() {
 func (s *handlerSuite) TestPagerdutyIntegrationsV3Create() {
 	var got PagerdutyIntegrationV3
 	code := s.HandleRequest(
-		s.NewSuitableRequest("POST", "/api/pagerduty-integrations/v3", PagerdutyIntegrationV3Create{
+		s.NewSuperAdminRequest("POST", "/api/pagerduty-integrations/v3", PagerdutyIntegrationV3Create{
 			PagerdutyID: "pagerduty-id",
 			PagerdutyIntegrationV3Edit: PagerdutyIntegrationV3Edit{
 				Name: utils.PointerTo("pagerduty-integration-name"),
@@ -67,7 +67,7 @@ func (s *handlerSuite) TestPagerdutyIntegrationsV3Create_duplicate() {
 	pdi := s.TestData.PagerdutyIntegration_ManuallyTriggeredTerraIncident()
 	var got PagerdutyIntegrationV3
 	code := s.HandleRequest(
-		s.NewSuitableRequest("POST", "/api/pagerduty-integrations/v3", PagerdutyIntegrationV3Create{
+		s.NewSuperAdminRequest("POST", "/api/pagerduty-integrations/v3", PagerdutyIntegrationV3Create{
 			PagerdutyID: pdi.PagerdutyID,
 			PagerdutyIntegrationV3Edit: PagerdutyIntegrationV3Edit{
 				Name: utils.PointerTo("pagerduty-integration-name"),

--- a/sherlock/internal/api/sherlock/pagerduty_integrations_v3_delete_test.go
+++ b/sherlock/internal/api/sherlock/pagerduty_integrations_v3_delete_test.go
@@ -9,7 +9,7 @@ import (
 func (s *handlerSuite) TestPagerdutyIntegrationV3Delete_badSelector() {
 	var got errors.ErrorResponse
 	code := s.HandleRequest(
-		s.NewRequest("DELETE", "/api/pagerduty-integrations/v3/something/with/slashes", nil),
+		s.NewSuperAdminRequest("DELETE", "/api/pagerduty-integrations/v3/something/with/slashes", nil),
 		&got)
 	s.Equal(http.StatusBadRequest, code)
 	s.Equal(errors.BadRequest, got.Type)
@@ -18,7 +18,7 @@ func (s *handlerSuite) TestPagerdutyIntegrationV3Delete_badSelector() {
 func (s *handlerSuite) TestPagerdutyIntegrationV3Delete_notFound() {
 	var got errors.ErrorResponse
 	code := s.HandleRequest(
-		s.NewRequest("DELETE", "/api/pagerduty-integrations/v3/pd-id/blahblahblah", nil),
+		s.NewSuperAdminRequest("DELETE", "/api/pagerduty-integrations/v3/pd-id/blahblahblah", nil),
 		&got)
 	s.Equal(http.StatusNotFound, code)
 	s.Equal(errors.NotFound, got.Type)
@@ -38,7 +38,7 @@ func (s *handlerSuite) TestPagerdutyIntegrationV3Delete() {
 	pdi := s.TestData.PagerdutyIntegration_ManuallyTriggeredTerraIncident()
 	var got PagerdutyIntegrationV3
 	code := s.HandleRequest(
-		s.NewSuitableRequest("DELETE", fmt.Sprintf("/api/pagerduty-integrations/v3/%d", pdi.ID), nil),
+		s.NewSuperAdminRequest("DELETE", fmt.Sprintf("/api/pagerduty-integrations/v3/%d", pdi.ID), nil),
 		&got)
 	s.Equal(http.StatusOK, code)
 	s.Equal(pdi.ID, got.ID)

--- a/sherlock/internal/api/sherlock/pagerduty_integrations_v3_edit_test.go
+++ b/sherlock/internal/api/sherlock/pagerduty_integrations_v3_edit_test.go
@@ -11,7 +11,7 @@ import (
 func (s *handlerSuite) TestPagerdutyIntegrationV3Edit_badSelector() {
 	var got errors.ErrorResponse
 	code := s.HandleRequest(
-		s.NewRequest("PATCH", "/api/pagerduty-integrations/v3/something/with/slashes", nil),
+		s.NewSuperAdminRequest("PATCH", "/api/pagerduty-integrations/v3/something/with/slashes", nil),
 		&got)
 	s.Equal(http.StatusBadRequest, code)
 	s.Equal(errors.BadRequest, got.Type)
@@ -20,7 +20,7 @@ func (s *handlerSuite) TestPagerdutyIntegrationV3Edit_badSelector() {
 func (s *handlerSuite) TestPagerdutyIntegrationV3Edit_badBody() {
 	var got errors.ErrorResponse
 	code := s.HandleRequest(
-		s.NewRequest("PATCH", "/api/pagerduty-integrations/v3/123", gin.H{
+		s.NewSuperAdminRequest("PATCH", "/api/pagerduty-integrations/v3/123", gin.H{
 			"key": 123,
 		}),
 		&got)
@@ -31,7 +31,7 @@ func (s *handlerSuite) TestPagerdutyIntegrationV3Edit_badBody() {
 func (s *handlerSuite) TestPagerdutyIntegrationV3Edit_notFound() {
 	var got errors.ErrorResponse
 	code := s.HandleRequest(
-		s.NewRequest("PATCH", "/api/pagerduty-integrations/v3/pd-id/blahblahblah", PagerdutyIntegrationV3Edit{
+		s.NewSuperAdminRequest("PATCH", "/api/pagerduty-integrations/v3/pd-id/blahblahblah", PagerdutyIntegrationV3Edit{
 			Key: utils.PointerTo("pagerduty-integration-key"),
 		}),
 		&got)
@@ -43,7 +43,7 @@ func (s *handlerSuite) TestPagerdutyIntegrationV3Edit_sqlValidation() {
 	pdi := s.TestData.PagerdutyIntegration_ManuallyTriggeredTerraIncident()
 	var got errors.ErrorResponse
 	code := s.HandleRequest(
-		s.NewRequest("PATCH", fmt.Sprintf("/api/pagerduty-integrations/v3/%d", pdi.ID), PagerdutyIntegrationV3Edit{
+		s.NewSuperAdminRequest("PATCH", fmt.Sprintf("/api/pagerduty-integrations/v3/%d", pdi.ID), PagerdutyIntegrationV3Edit{
 			Key: utils.PointerTo(""),
 		}),
 		&got)
@@ -68,7 +68,7 @@ func (s *handlerSuite) TestPagerdutyIntegrationV3Edit() {
 	pdi := s.TestData.PagerdutyIntegration_ManuallyTriggeredTerraIncident()
 	var got PagerdutyIntegrationV3
 	code := s.HandleRequest(
-		s.NewSuitableRequest("PATCH", fmt.Sprintf("/api/pagerduty-integrations/v3/%d", pdi.ID), PagerdutyIntegrationV3Edit{
+		s.NewSuperAdminRequest("PATCH", fmt.Sprintf("/api/pagerduty-integrations/v3/%d", pdi.ID), PagerdutyIntegrationV3Edit{
 			Key:  utils.PointerTo("a key"),
 			Name: utils.PointerTo("a name"),
 		}),

--- a/sherlock/internal/api/sherlock/pagerduty_integrations_v3_list_test.go
+++ b/sherlock/internal/api/sherlock/pagerduty_integrations_v3_list_test.go
@@ -44,7 +44,7 @@ func (s *handlerSuite) TestPagerdutyIntegrationsV3List_badOffset() {
 }
 
 func (s *handlerSuite) TestPagerdutyIntegrationsV3List() {
-	s.SetSuitableTestUserForDB()
+	s.SetSelfSuperAdminForDB()
 	pdi1 := models.PagerdutyIntegration{
 		PagerdutyID: "some-pd-id-1",
 		Name:        utils.PointerTo("some-name-1"),

--- a/sherlock/internal/models/cluster.go
+++ b/sherlock/internal/models/cluster.go
@@ -18,6 +18,8 @@ type Cluster struct {
 	Base                *string
 	Address             *string
 	RequiresSuitability *bool
+	RequiredRole        *Role
+	RequiredRoleID      *uint
 	HelmfileRef         *string
 }
 
@@ -32,6 +34,9 @@ func (c *Cluster) GetCiIdentifier() CiIdentifier {
 func (c *Cluster) errorIfForbidden(tx *gorm.DB) error {
 	user, err := GetCurrentUserForDB(tx)
 	if err != nil {
+		return err
+	}
+	if err = user.ErrIfNotActiveInRole(tx, c.RequiredRoleID); err != nil {
 		return err
 	}
 	if c.RequiresSuitability == nil || *c.RequiresSuitability {

--- a/sherlock/internal/models/cluster_test.go
+++ b/sherlock/internal/models/cluster_test.go
@@ -140,21 +140,6 @@ func (s *modelSuite) TestClusterLocationValidationSqlMissing() {
 	s.ErrorContains(err, "location")
 }
 
-func (s *modelSuite) TestClusterRequiresSuitabilityValidationSqlMissing() {
-	s.SetSuitableTestUserForDB() // To actually prompt the SQL error we have to be suitable to get past the permissions
-	err := s.DB.Create(&Cluster{
-		Name:              "some-name",
-		Provider:          "google",
-		GoogleProject:     "some-project",
-		AzureSubscription: "some-subscription",
-		Location:          "some-location",
-		Base:              utils.PointerTo("some-base"),
-		Address:           utils.PointerTo("0.0.0.0"),
-		HelmfileRef:       utils.PointerTo("HEAD"),
-	}).Error
-	s.ErrorContains(err, "requires_suitability")
-}
-
 func (s *modelSuite) TestClusterHelmfileRefValidationSqlMissing() {
 	s.SetNonSuitableTestUserForDB()
 	err := s.DB.Create(&Cluster{

--- a/sherlock/internal/models/environment.go
+++ b/sherlock/internal/models/environment.go
@@ -35,6 +35,8 @@ type Environment struct {
 	OwnerID                     *uint
 	LegacyOwner                 *string
 	RequiresSuitability         *bool
+	RequiredRole                *Role
+	RequiredRoleID              *uint
 	BaseDomain                  *string
 	NamePrefixesDomain          *bool
 	HelmfileRef                 *string
@@ -63,6 +65,9 @@ func (e *Environment) GetCiIdentifier() CiIdentifier {
 func (e *Environment) errorIfForbidden(tx *gorm.DB) error {
 	user, err := GetCurrentUserForDB(tx)
 	if err != nil {
+		return err
+	}
+	if err = user.ErrIfNotActiveInRole(tx, e.RequiredRoleID); err != nil {
 		return err
 	}
 	if e.RequiresSuitability == nil || *e.RequiresSuitability {

--- a/sherlock/internal/models/environment_test.go
+++ b/sherlock/internal/models/environment_test.go
@@ -280,13 +280,6 @@ func (s *modelSuite) TestEnvironmentValidationSqlDynamicLifecycleDefaultClusterI
 	s.ErrorContains(err, "violates check constraint \"lifecycle_valid\"")
 }
 
-func (s *modelSuite) TestEnvironmentValidationSqlDynamicLifecycleRequiresSuitability() {
-	s.SetSuitableTestUserForDB()
-	staticEnv := s.TestData.Environment_Swatomation_TestBee()
-	err := s.DB.Model(&staticEnv).Select("RequiresSuitability").Updates(&Environment{RequiresSuitability: nil}).Error
-	s.ErrorContains(err, "violates check constraint \"lifecycle_valid\"")
-}
-
 func (s *modelSuite) TestEnvironmentValidationSqlStaticLifecycleBase() {
 	s.SetSuitableTestUserForDB()
 	staticEnv := s.TestData.Environment_Prod()
@@ -298,13 +291,6 @@ func (s *modelSuite) TestEnvironmentValidationSqlStaticLifecycleDefaultClusterID
 	s.SetSuitableTestUserForDB()
 	staticEnv := s.TestData.Environment_Prod()
 	err := s.DB.Model(&staticEnv).Select("DefaultClusterID").Updates(&Environment{DefaultClusterID: nil}).Error
-	s.ErrorContains(err, "violates check constraint \"lifecycle_valid\"")
-}
-
-func (s *modelSuite) TestEnvironmentValidationSqlStaticLifecycleRequiresSuitability() {
-	s.SetSuitableTestUserForDB()
-	staticEnv := s.TestData.Environment_Prod()
-	err := s.DB.Model(&staticEnv).Select("RequiresSuitability").Updates(&Environment{RequiresSuitability: nil}).Error
 	s.ErrorContains(err, "violates check constraint \"lifecycle_valid\"")
 }
 

--- a/sherlock/internal/models/pagerduty_integration.go
+++ b/sherlock/internal/models/pagerduty_integration.go
@@ -18,8 +18,8 @@ type PagerdutyIntegration struct {
 func (p *PagerdutyIntegration) errorIfForbidden(tx *gorm.DB) error {
 	if user, err := GetCurrentUserForDB(tx); err != nil {
 		return err
-	} else if err = user.ErrIfNotSuitable(); err != nil {
-		return fmt.Errorf("(%s) suitability required: %w", errors.Forbidden, err)
+	} else if err = user.ErrIfNotSuperAdmin(); err != nil {
+		return fmt.Errorf("(%s) super-admin required: %w", errors.Forbidden, err)
 	} else {
 		return nil
 	}

--- a/sherlock/internal/models/pagerduty_integration_test.go
+++ b/sherlock/internal/models/pagerduty_integration_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func (s *modelSuite) TestPagerdutyIntegrationPagerdutyIDValidationSql() {
-	s.SetSuitableTestUserForDB()
+	s.SetSelfSuperAdminForDB()
 	err := s.DB.Create(&PagerdutyIntegration{
 		Name: utils.PointerTo("some-name"),
 		Key:  utils.PointerTo("some-key"),
@@ -16,7 +16,7 @@ func (s *modelSuite) TestPagerdutyIntegrationPagerdutyIDValidationSql() {
 }
 
 func (s *modelSuite) TestPagerdutyIntegrationNameValidationSql() {
-	s.SetSuitableTestUserForDB()
+	s.SetSelfSuperAdminForDB()
 	err := s.DB.Create(&PagerdutyIntegration{
 		PagerdutyID: "some-pagerduty-id",
 		Key:         utils.PointerTo("some-key"),
@@ -26,7 +26,7 @@ func (s *modelSuite) TestPagerdutyIntegrationNameValidationSql() {
 }
 
 func (s *modelSuite) TestPagerdutyIntegrationKeyValidationSql() {
-	s.SetSuitableTestUserForDB()
+	s.SetSelfSuperAdminForDB()
 	err := s.DB.Create(&PagerdutyIntegration{
 		PagerdutyID: "some-pagerduty-id",
 		Name:        utils.PointerTo("some-name"),
@@ -36,7 +36,7 @@ func (s *modelSuite) TestPagerdutyIntegrationKeyValidationSql() {
 }
 
 func (s *modelSuite) TestPagerdutyIntegrationTypeValidationSql() {
-	s.SetSuitableTestUserForDB()
+	s.SetSelfSuperAdminForDB()
 	err := s.DB.Create(&PagerdutyIntegration{
 		PagerdutyID: "some-pagerduty-id",
 		Name:        utils.PointerTo("some-name"),
@@ -76,7 +76,7 @@ func (s *modelSuite) TestPagerdutyIntegrationDeleteForbidden() {
 func (s *modelSuite) TestPagerdutyIntegrationDeleteWhileUsed() {
 	i := s.TestData.PagerdutyIntegration_ManuallyTriggeredTerraIncident()
 	s.TestData.Environment_Prod()
-	s.SetSuitableTestUserForDB()
+	s.SetSelfSuperAdminForDB()
 	s.ErrorContains(s.DB.
 		Delete(&i).
 		Error, errors.BadRequest)
@@ -84,7 +84,7 @@ func (s *modelSuite) TestPagerdutyIntegrationDeleteWhileUsed() {
 
 func (s *modelSuite) TestPagerdutyIntegrationUniqueness() {
 	pdi := s.TestData.PagerdutyIntegration_ManuallyTriggeredTerraIncident()
-	s.SetSuitableTestUserForDB()
+	s.SetSelfSuperAdminForDB()
 	s.ErrorContains(s.DB.Create(&PagerdutyIntegration{
 		PagerdutyID: pdi.PagerdutyID,
 		Name:        utils.PointerTo("some-name"),

--- a/sherlock/internal/models/role_assignment.go
+++ b/sherlock/internal/models/role_assignment.go
@@ -72,6 +72,16 @@ func (ra *RoleAssignment) IsActive() bool {
 	return ra.Suspended != nil && !*ra.Suspended && (ra.ExpiresAt == nil || ra.ExpiresAt.After(time.Now()))
 }
 
+func (ra *RoleAssignment) ErrIfNotActive() error {
+	if ra.Suspended != nil && *ra.Suspended {
+		return fmt.Errorf("(%s) role assignment is suspended", errors.Forbidden)
+	} else if ra.ExpiresAt != nil && ra.ExpiresAt.Before(time.Now()) {
+		return fmt.Errorf("(%s) role assignment has expired", errors.Forbidden)
+	} else {
+		return nil
+	}
+}
+
 func (ra *RoleAssignment) Description(db *gorm.DB) string {
 	var role Role
 	var user User

--- a/sherlock/internal/models/test_data.go
+++ b/sherlock/internal/models/test_data.go
@@ -646,6 +646,7 @@ func (td *testDataImpl) Cluster_TerraProd() Cluster {
 			Base:                utils.PointerTo("terra"),
 			Address:             utils.PointerTo("https://192.0.2.128"),
 			RequiresSuitability: utils.PointerTo(true),
+			RequiredRoleID:      utils.PointerTo(td.Role_TerraSuitableEngineer().ID),
 			HelmfileRef:         utils.PointerTo("HEAD"),
 		}
 		td.h.SetSuitableTestUserForDB()
@@ -718,6 +719,7 @@ func (td *testDataImpl) Cluster_DdpAksProd() Cluster {
 			Base:                utils.PointerTo("ddp"),
 			Address:             utils.PointerTo("https://192.0.2.132"),
 			RequiresSuitability: utils.PointerTo(true),
+			RequiredRoleID:      utils.PointerTo(td.Role_TerraSuitableEngineer().ID),
 			HelmfileRef:         utils.PointerTo("HEAD"),
 		}
 		td.h.SetSuitableTestUserForDB()
@@ -755,6 +757,7 @@ func (td *testDataImpl) Environment_Prod() Environment {
 			DefaultNamespace:          "terra-prod",
 			DefaultClusterID:          utils.PointerTo(td.Cluster_TerraProd().ID),
 			RequiresSuitability:       utils.PointerTo(true),
+			RequiredRoleID:            utils.PointerTo(td.Role_TerraSuitableEngineer().ID),
 			BaseDomain:                utils.PointerTo("dsde-prod.broadinstitute.org"),
 			NamePrefixesDomain:        utils.PointerTo(false),
 			HelmfileRef:               utils.PointerTo("HEAD"),
@@ -933,6 +936,7 @@ func (td *testDataImpl) Environment_DdpAzureProd() Environment {
 			DefaultNamespace:    "ddp-prod",
 			DefaultClusterID:    utils.PointerTo(td.Cluster_DdpAksProd().ID),
 			RequiresSuitability: utils.PointerTo(true),
+			RequiredRoleID:      utils.PointerTo(td.Role_TerraSuitableEngineer().ID),
 			HelmfileRef:         utils.PointerTo("HEAD"),
 			PreventDeletion:     utils.PointerTo(true),
 			Offline:             utils.PointerTo(false),

--- a/sherlock/internal/models/test_data.go
+++ b/sherlock/internal/models/test_data.go
@@ -456,7 +456,7 @@ func (td *testDataImpl) PagerdutyIntegration_ManuallyTriggeredTerraIncident() Pa
 			Key:         utils.PointerTo("some secret key"),
 			Type:        utils.PointerTo("service"),
 		}
-		td.h.SetSuitableTestUserForDB()
+		td.h.SetSelfSuperAdminForDB()
 		td.create(&td.pagerdutyIntegration_manuallyTriggeredTerraIncident)
 	}
 	return td.pagerdutyIntegration_manuallyTriggeredTerraIncident


### PR DESCRIPTION
1. PagerdutyIntegration: `User.ErrIfNotSuitable()` -> `User.ErrIfNotSuperAdmin()` (replaces suitability check with super-admin check, since we're the only ones that can use those endpoints anyway)
2. Environment: `User.ErrIfNotSuitable()` + `User.ErrIfNotActiveInRole()` (adds role check if new `required_role_id` column is filled; existing `requires_suitability` column still respected)
3. Cluster: `User.ErrIfNotSuitable()` + `User.ErrIfNotActiveInRole()` (adds role check if new `required_role_id` column is filled; existing `requires_suitability` column still respected)

Once this is fully rolled out I'll do a follow-up change to clean up the remaining usages of `User.ErrIfNotSuitable()`

## Testing

Adjusted lots of tests to get coverage here but in theory this is totally additive. The test data was updated to exercise the new code (there are tests in ci_hooks etc that actually still end up exercising the old code and I'm calling that good enough for a temporary state).

## Risk

Low. The risk is with messy UI changes that'll need to happen in Beehive.