### PR TITLE
[DDO-3776] Allow clearing role requirement

### DIFF
--- a/sherlock/internal/api/sherlock/clusters_v3.go
+++ b/sherlock/internal/api/sherlock/clusters_v3.go
@@ -27,7 +27,7 @@ type ClusterV3Edit struct {
 	Base                *string `json:"base"  form:"base"`      // Required when creating
 	Address             *string `json:"address" form:"address"` // Required when creating
 	RequiresSuitability *bool   `json:"requiresSuitability" form:"requiresSuitability"`
-	RequiredRole        *string `json:"requiredRole" form:"requiredRole"` // If present, requires membership in the given role for mutations
+	RequiredRole        *string `json:"requiredRole" form:"requiredRole"` // If present, requires membership in the given role for mutations. Set to an empty string to clear.
 	HelmfileRef         *string `json:"helmfileRef" form:"helmfileRef" default:"HEAD"`
 }
 

--- a/sherlock/internal/api/sherlock/clusters_v3_edit.go
+++ b/sherlock/internal/api/sherlock/clusters_v3_edit.go
@@ -55,5 +55,15 @@ func clustersV3Edit(ctx *gin.Context) {
 		return
 	}
 
+	// Allow clearing requiredRole by setting an empty string
+	if body.RequiredRole != nil && *body.RequiredRole == "" && toEdit.RequiredRoleID != nil {
+		toEdit.RequiredRoleID = nil
+		toEdit.RequiredRole = nil
+		if err = db.Model(&toEdit).Omit(clause.Associations).Update("required_role_id", nil).Error; err != nil {
+			errors.AbortRequest(ctx, err)
+			return
+		}
+	}
+
 	ctx.JSON(http.StatusOK, clusterFromModel(toEdit))
 }

--- a/sherlock/internal/api/sherlock/clusters_v3_edit_test.go
+++ b/sherlock/internal/api/sherlock/clusters_v3_edit_test.go
@@ -171,3 +171,19 @@ func (s *handlerSuite) TestClustersV3Edit_suitabilityAfter() {
 	s.Equal(http.StatusForbidden, code)
 	s.Equal(errors.Forbidden, got.Type)
 }
+
+func (s *handlerSuite) TestClusterV3Edit_clearRequiredRole() {
+	toEdit := s.TestData.Cluster_TerraProd()
+	s.NotNil(toEdit.RequiredRoleID)
+	var got ClusterV3
+	code := s.HandleRequest(
+		s.NewSuitableRequest("PATCH", fmt.Sprintf("/api/clusters/v3/%d", toEdit.ID), ClusterV3Edit{
+			RequiredRole: utils.PointerTo(""),
+		}),
+		&got)
+	s.Equal(http.StatusOK, code)
+	s.Nil(got.RequiredRole)
+	var inDB models.Cluster
+	s.NoError(s.DB.First(&inDB, toEdit.ID).Error)
+	s.Nil(inDB.RequiredRoleID)
+}

--- a/sherlock/internal/api/sherlock/environments_v3.go
+++ b/sherlock/internal/api/sherlock/environments_v3.go
@@ -40,7 +40,7 @@ type EnvironmentV3Edit struct {
 	DefaultCluster              *string    `json:"defaultCluster" form:"defaultCluster"`
 	Owner                       *string    `json:"owner" form:"owner"` // When creating, will default to you
 	RequiresSuitability         *bool      `json:"requiresSuitability" form:"requiresSuitability"`
-	RequiredRole                *string    `json:"requiredRole" form:"requiredRole"` // If present, requires membership in the given role for mutations
+	RequiredRole                *string    `json:"requiredRole" form:"requiredRole"` // If present, requires membership in the given role for mutations. Set to an empty string to clear.
 	BaseDomain                  *string    `json:"baseDomain" form:"baseDomain" default:"bee.envs-terra.bio"`
 	NamePrefixesDomain          *bool      `json:"namePrefixesDomain" form:"namePrefixesDomain" default:"true"`
 	HelmfileRef                 *string    `json:"helmfileRef" form:"helmfileRef" default:"HEAD"`

--- a/sherlock/internal/api/sherlock/environments_v3_edit.go
+++ b/sherlock/internal/api/sherlock/environments_v3_edit.go
@@ -55,5 +55,15 @@ func environmentsV3Edit(ctx *gin.Context) {
 		return
 	}
 
+	// Allow clearing requiredRole by setting an empty string
+	if body.RequiredRole != nil && *body.RequiredRole == "" && toEdit.RequiredRoleID != nil {
+		toEdit.RequiredRoleID = nil
+		toEdit.RequiredRole = nil
+		if err = db.Model(&toEdit).Omit(clause.Associations).Update("required_role_id", nil).Error; err != nil {
+			errors.AbortRequest(ctx, err)
+			return
+		}
+	}
+
 	ctx.JSON(http.StatusOK, environmentFromModel(toEdit))
 }

--- a/sherlock/internal/api/sherlock/environments_v3_edit_test.go
+++ b/sherlock/internal/api/sherlock/environments_v3_edit_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/broadinstitute/sherlock/go-shared/pkg/utils"
 	"github.com/broadinstitute/sherlock/sherlock/internal/errors"
+	"github.com/broadinstitute/sherlock/sherlock/internal/models"
 	"github.com/gin-gonic/gin"
 	"net/http"
 	"time"
@@ -116,6 +117,22 @@ func (s *handlerSuite) TestEnvironmentsV3Edit_suitabilityAfter() {
 		&got)
 	s.Equal(http.StatusForbidden, code)
 	s.Equal(errors.Forbidden, got.Type)
+}
+
+func (s *handlerSuite) TestEnvironmentsV3Edit_clearRequiredRole() {
+	toEdit := s.TestData.Environment_Prod()
+	s.NotNil(toEdit.RequiredRoleID)
+	var got EnvironmentV3
+	code := s.HandleRequest(
+		s.NewSuitableRequest("PATCH", fmt.Sprintf("/api/environments/v3/%d", toEdit.ID), EnvironmentV3Edit{
+			RequiredRole: utils.PointerTo(""),
+		}),
+		&got)
+	s.Equal(http.StatusOK, code)
+	s.Nil(got.RequiredRole)
+	var inDB models.Environment
+	s.NoError(s.DB.First(&inDB, toEdit.ID).Error)
+	s.Nil(inDB.RequiredRoleID)
 }
 
 func (s *handlerSuite) TestEnvironmentsV3Edit_deleteAfter() {


### PR DESCRIPTION
In developing the UI for configuring Environments and Clusters with a required Role I realized that it wasn't possible to clear out the field once it was set. Hello Go.

This fix manually clears out the field when an edit request is made with it set to an empty string. This is what the UI will already do so there's no changes to that (upcoming) PR.

## Testing

Unit test for both Environments and Clusters

## Risk

Low