### PR TITLE
[DDO-3789] Enable Janitor Toggle

### DIFF
--- a/sherlock/db/migrations/000094_add_enable_janitor.down.sql
+++ b/sherlock/db/migrations/000094_add_enable_janitor.down.sql
@@ -1,0 +1,2 @@
+alter table environments
+    drop column if exists enable_janitor;

--- a/sherlock/db/migrations/000094_add_enable_janitor.up.sql
+++ b/sherlock/db/migrations/000094_add_enable_janitor.up.sql
@@ -1,9 +1,2 @@
 alter table environments
-    add column if not exists enable_janitor boolean;
-
-update environments
-    set enable_janitor = (case when lifecycle = 'static' then false else true end)
-    where enable_janitor is null;
-
-alter table environments
-    alter column enable_janitor set not null;
+    add column if not exists enable_janitor boolean not null default (case when lifecycle = 'static' then false else true end);

--- a/sherlock/db/migrations/000094_add_enable_janitor.up.sql
+++ b/sherlock/db/migrations/000094_add_enable_janitor.up.sql
@@ -1,0 +1,6 @@
+alter table environments
+    add column if not exists enable_janitor boolean;
+
+update environments
+    set enable_janitor = (case when lifecycle = 'static' then true else false end)
+    where enable_janitor is null;

--- a/sherlock/db/migrations/000094_add_enable_janitor.up.sql
+++ b/sherlock/db/migrations/000094_add_enable_janitor.up.sql
@@ -2,7 +2,7 @@ alter table environments
     add column if not exists enable_janitor boolean;
 
 update environments
-    set enable_janitor = (case when lifecycle = 'static' then true else false end)
+    set enable_janitor = (case when lifecycle = 'static' then false else true end)
     where enable_janitor is null;
 
 alter table environments

--- a/sherlock/db/migrations/000094_add_enable_janitor.up.sql
+++ b/sherlock/db/migrations/000094_add_enable_janitor.up.sql
@@ -1,2 +1,12 @@
 alter table environments
-    add column if not exists enable_janitor boolean not null default (case when lifecycle = 'static' then false else true end);
+    add column if not exists enable_janitor boolean;
+
+update environments
+    set enable_janitor = (case when lifecycle = 'static' then false else true end)
+    where enable_janitor is null;
+
+alter table environments
+    alter column enable_janitor set default false;
+
+alter table environments
+    alter column enable_janitor set not null;

--- a/sherlock/db/migrations/000094_add_enable_janitor.up.sql
+++ b/sherlock/db/migrations/000094_add_enable_janitor.up.sql
@@ -4,3 +4,6 @@ alter table environments
 update environments
     set enable_janitor = (case when lifecycle = 'static' then true else false end)
     where enable_janitor is null;
+
+alter table environments
+    alter column enable_janitor set not null;

--- a/sherlock/internal/api/sherlock/environments_v3.go
+++ b/sherlock/internal/api/sherlock/environments_v3.go
@@ -55,7 +55,7 @@ type EnvironmentV3Edit struct {
 	OfflineScheduleEndEnabled   *bool      `json:"offlineScheduleEndEnabled,omitempty" form:"offlineScheduleEndEnabled"`                   // When enabled, the BEE will be slated to come online around the end time each weekday (each day if weekends enabled)
 	OfflineScheduleEndTime      *time.Time `json:"offlineScheduleEndTime,omitempty" form:"offlineScheduleEndTime"  format:"date-time"`     // Stored with timezone to determine day of the week
 	OfflineScheduleEndWeekends  *bool      `json:"offlineScheduleEndWeekends,omitempty" form:"offlineScheduleEndWeekends"`
-	EnableJanitor               *bool      `json:"enableJanitor,omitempty" form:"enableJanitor"` // If true, janitor resource cleanup will be enabled for this environment. BEEs default to template or true, templates default to true, and static live environments default to false.
+	EnableJanitor               *bool      `json:"enableJanitor,omitempty" form:"enableJanitor"` // If true, janitor resource cleanup will be enabled for this environment. BEEs default to template's value, templates default to true, and static/live environments default to false.
 }
 
 func (e EnvironmentV3) toModel(db *gorm.DB) (models.Environment, error) {

--- a/sherlock/internal/api/sherlock/environments_v3.go
+++ b/sherlock/internal/api/sherlock/environments_v3.go
@@ -55,6 +55,7 @@ type EnvironmentV3Edit struct {
 	OfflineScheduleEndEnabled   *bool      `json:"offlineScheduleEndEnabled,omitempty" form:"offlineScheduleEndEnabled"`                   // When enabled, the BEE will be slated to come online around the end time each weekday (each day if weekends enabled)
 	OfflineScheduleEndTime      *time.Time `json:"offlineScheduleEndTime,omitempty" form:"offlineScheduleEndTime"  format:"date-time"`     // Stored with timezone to determine day of the week
 	OfflineScheduleEndWeekends  *bool      `json:"offlineScheduleEndWeekends,omitempty" form:"offlineScheduleEndWeekends"`
+	EnableJanitor               *bool      `json:"enableJanitor,omitempty" form:"enableJanitor"` // If true, janitor resource cleanup will be enabled for this environment. BEEs default to template or true, templates default to true, and static live environments default to false.
 }
 
 func (e EnvironmentV3) toModel(db *gorm.DB) (models.Environment, error) {
@@ -80,6 +81,7 @@ func (e EnvironmentV3) toModel(db *gorm.DB) (models.Environment, error) {
 		OfflineScheduleEndTime:      utils.TimePtrToISO8601(e.OfflineScheduleEndTime),
 		OfflineScheduleEndWeekends:  e.OfflineScheduleEndWeekends,
 		PactIdentifier:              e.PactIdentifier,
+		EnableJanitor:               e.EnableJanitor,
 	}
 	if e.DeleteAfter != nil {
 		if *e.DeleteAfter == "" {
@@ -196,6 +198,7 @@ func environmentFromModel(model models.Environment) EnvironmentV3 {
 				OfflineScheduleBeginEnabled: model.OfflineScheduleBeginEnabled,
 				OfflineScheduleEndEnabled:   model.OfflineScheduleEndEnabled,
 				OfflineScheduleEndWeekends:  model.OfflineScheduleEndWeekends,
+				EnableJanitor:               model.EnableJanitor,
 			},
 		},
 	}

--- a/sherlock/internal/api/sherlock/environments_v3_test.go
+++ b/sherlock/internal/api/sherlock/environments_v3_test.go
@@ -173,6 +173,7 @@ func (s *handlerSuite) TestEnvironmentV3_toModel() {
 						OfflineScheduleEndEnabled:   utils.PointerTo(true),
 						OfflineScheduleEndTime:      utils.PointerTo(now),
 						OfflineScheduleEndWeekends:  utils.PointerTo(true),
+						EnableJanitor:               utils.PointerTo(true),
 					},
 				},
 			},
@@ -212,6 +213,7 @@ func (s *handlerSuite) TestEnvironmentV3_toModel() {
 				OfflineScheduleEndTime:      utils.TimePtrToISO8601(&now),
 				OfflineScheduleEndWeekends:  utils.PointerTo(true),
 				PactIdentifier:              &pactUuid,
+				EnableJanitor:               utils.PointerTo(true),
 			},
 		},
 		{
@@ -249,6 +251,7 @@ func (s *handlerSuite) TestEnvironmentV3_toModel() {
 						OfflineScheduleEndEnabled:   utils.PointerTo(true),
 						OfflineScheduleEndTime:      utils.PointerTo(now),
 						OfflineScheduleEndWeekends:  utils.PointerTo(true),
+						EnableJanitor:               utils.PointerTo(true),
 					},
 				},
 			},
@@ -287,6 +290,7 @@ func (s *handlerSuite) TestEnvironmentV3_toModel() {
 				OfflineScheduleEndTime:      utils.TimePtrToISO8601(&now),
 				OfflineScheduleEndWeekends:  utils.PointerTo(true),
 				PactIdentifier:              &pactUuid,
+				EnableJanitor:               utils.PointerTo(true),
 			},
 		},
 	}
@@ -367,6 +371,7 @@ func Test_environmentFromModel(t *testing.T) {
 				OfflineScheduleEndTime:      utils.TimePtrToISO8601(&now),
 				OfflineScheduleEndWeekends:  utils.PointerTo(true),
 				PactIdentifier:              &pactUuid,
+				EnableJanitor:               utils.PointerTo(true),
 			}},
 			want: EnvironmentV3{
 				CommonFields: CommonFields{
@@ -409,6 +414,7 @@ func Test_environmentFromModel(t *testing.T) {
 						OfflineScheduleEndEnabled:   utils.PointerTo(true),
 						OfflineScheduleEndTime:      nowTimeParsedAgain,
 						OfflineScheduleEndWeekends:  utils.PointerTo(true),
+						EnableJanitor:               utils.PointerTo(true),
 					},
 				},
 			},

--- a/sherlock/internal/models/environment.go
+++ b/sherlock/internal/models/environment.go
@@ -315,11 +315,12 @@ func (e *Environment) setCreationDefaults(tx *gorm.DB) error {
 	}
 
 	if e.EnableJanitor == nil {
-		// BEEs may have been filled from templates already, but if not we default here
-		if e.Lifecycle == "dynamic" || e.Lifecycle == "template" {
-			e.EnableJanitor = utils.PointerTo(true)
-		} else {
+		// Yes there's a DB-level default but we don't want to rely on that for business logic
+		if e.Lifecycle == "static" {
 			e.EnableJanitor = utils.PointerTo(false)
+		} else {
+			// Templates, BEEs if somehow we missed them above
+			e.EnableJanitor = utils.PointerTo(true)
 		}
 	}
 


### PR DESCRIPTION
Adds an editable boolean field to Environment, "enableJanitor". BEEs default to template, template envs default to true, static envs default to false. DB migration sets fields that way for all existing environments.

## Testing

Added to existing field input/output tests

## Risk

Very low