### PR TITLE
[DDO-3793] Weekly Container Scan

### DIFF
--- a/.github/workflows/sherlock-container-scan.yaml
+++ b/.github/workflows/sherlock-container-scan.yaml
@@ -1,0 +1,44 @@
+name: Standalone Sherlock Trivy Scan
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to scan'
+        required: false
+        type: string
+        default: 'latest'
+  schedule:
+    - cron: '0 0 * * 0'
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - name: Auth to GCP
+        id: auth
+        uses: google-github-actions/auth@v2
+        with:
+          token_format: access_token
+          workload_identity_provider: projects/1038484894585/locations/global/workloadIdentityPools/github-wi-pool/providers/github-wi-provider
+          service_account: dsp-artifact-registry-push@dsp-artifact-registry.iam.gserviceaccount.com
+
+      - name: Login to GAR
+        uses: docker/login-action@v3
+        with:
+          registry: us-central1-docker.pkg.dev
+          username: oauth2accesstoken
+          password: ${{ steps.auth.outputs.access_token }}
+
+      - name: Run Trivy vulnerability scanner
+        uses: broadinstitute/dsp-appsec-trivy-action@v1
+        with:
+          image: us-central1-docker.pkg.dev/dsp-artifact-registry/sherlock/sherlock:${{ inputs.tag || 'latest' }}
+
+  report-workflow:
+    uses: ./.github/workflows/client-report-workflow.yaml
+    with:
+      notify-slack-channels-upon-workflow-failure: "#trivy-weekly-scans-notblessedimages"
+    permissions:
+      id-token: write

--- a/.github/workflows/sherlock-container-scan.yaml
+++ b/.github/workflows/sherlock-container-scan.yaml
@@ -34,6 +34,9 @@ jobs:
       - name: Run Trivy vulnerability scanner
         uses: broadinstitute/dsp-appsec-trivy-action@v1
         with:
+          # sherlock-build.yaml pushes to both normal GAR and super-prod GAR. It pushes the same image. We pull
+          # from the normal one here so that we don't need to pull from the more private and secure one for this
+          # technically-non-prod usage.
           image: us-central1-docker.pkg.dev/dsp-artifact-registry/sherlock/sherlock:${{ inputs.tag || 'latest' }}
 
   report-workflow:

--- a/.github/workflows/sherlock-container-scan.yaml
+++ b/.github/workflows/sherlock-container-scan.yaml
@@ -9,7 +9,6 @@ on:
         default: 'latest'
   schedule:
     - cron: '0 0 * * 0'
-  push: # temporary for testing
 
 jobs:
   scan:

--- a/.github/workflows/sherlock-container-scan.yaml
+++ b/.github/workflows/sherlock-container-scan.yaml
@@ -9,7 +9,6 @@ on:
         default: 'latest'
   schedule:
     - cron: '0 0 * * 0'
-  push:
 
 jobs:
   scan:
@@ -40,6 +39,6 @@ jobs:
   report-workflow:
     uses: ./.github/workflows/client-report-workflow.yaml
     with:
-      notify-slack-channels-upon-workflow-completion: "#trivy-weekly-scans-notblessedimages"
+      notify-slack-channels-upon-workflow-failure: "#trivy-weekly-scans-notblessedimages"
     permissions:
       id-token: write

--- a/.github/workflows/sherlock-container-scan.yaml
+++ b/.github/workflows/sherlock-container-scan.yaml
@@ -9,6 +9,7 @@ on:
         default: 'latest'
   schedule:
     - cron: '0 0 * * 0'
+  push:
 
 jobs:
   scan:
@@ -39,6 +40,6 @@ jobs:
   report-workflow:
     uses: ./.github/workflows/client-report-workflow.yaml
     with:
-      notify-slack-channels-upon-workflow-failure: "#trivy-weekly-scans-notblessedimages"
+      notify-slack-channels-upon-workflow-completion: "#trivy-weekly-scans-notblessedimages"
     permissions:
       id-token: write

--- a/.github/workflows/sherlock-container-scan.yaml
+++ b/.github/workflows/sherlock-container-scan.yaml
@@ -9,6 +9,7 @@ on:
         default: 'latest'
   schedule:
     - cron: '0 0 * * 0'
+  push: # temporary for testing
 
 jobs:
   scan:


### PR DESCRIPTION
for appsec. We automatically move the `:latest` tag in sherlock-build.yaml so we can just have this workflow use it rather than trying to read version data from Sherlock or something more complex.

## Testing

Added push trigger temporarily, [it ran.](https://github.com/broadinstitute/sherlock/actions/runs/10098933680/job/27927018804?pr=612)

## Risk

Very low.