### PR TITLE
[DDO-3785] Update OIDC docs and b64 encode refresh tokens

### DIFF
--- a/.github/workflows/sherlock-build.yaml
+++ b/.github/workflows/sherlock-build.yaml
@@ -177,6 +177,9 @@ jobs:
             BUILD_VERSION=${{ needs.generate-tag.outputs.tag }}
 
       - name: Run Trivy vulnerability scanner
+        # We only run Trivy here as dependabot, because otherwise we run it afterwards so as to not block an intentional
+        # build (so we can fix or work around Trivy issues)
+        if: ${{ github.actor == 'dependabot[bot]' }}
         uses: broadinstitute/dsp-appsec-trivy-action@v1
         with:
           image: us-central1-docker.pkg.dev/dsp-artifact-registry/sherlock/sherlock:${{ needs.generate-tag.outputs.tag }}
@@ -245,6 +248,16 @@ jobs:
           cache-to: type=gha,mode=max
           build-args: |
             BUILD_VERSION=${{ needs.generate-tag.outputs.tag }}
+
+  trivy-scan:
+    needs: [ generate-tag, build-and-publish ]
+    runs-on: ubuntu-latest
+    if: ${{ needs.generate-tag.outputs.tag != '' && github.actor != 'dependabot[bot]' }}
+    steps:
+        - name: Run Trivy vulnerability scanner
+          uses: broadinstitute/dsp-appsec-trivy-action@v1
+          with:
+            image: us-central1-docker.pkg.dev/dsp-artifact-registry/sherlock/sherlock:${{ needs.generate-tag.outputs.tag }}
 
   comment-published-image:
     needs: [ generate-tag, build-and-publish ]

--- a/sherlock/config/default_config.yaml
+++ b/sherlock/config/default_config.yaml
@@ -74,18 +74,30 @@ db:
 oidc:
   enable: true
   # The issuer URL of Sherlock itself. This should be scheme + host + "/oidc", because Sherlock
-  # serves its own OIDC provider at that sub-path. This should also generally be an in-cluster
-  # address, because the IAP in front of the public endpoints isn't in-spec. This is fine as long
-  # as we just use Sherlock as an in-cluster authorization service.
+  # serves its own OIDC provider at that sub-path.
+  #
+  # You can choose whether to provide a publicly addressable URL or not (e.g. a .svc.cluster.local address).
+  # If you provide an in-cluster address, that'll work only for stuff that's in the cluster. CLIs or other
+  # services won't be able to authenticate against Sherlock (at least not without /etc/hosts tweaks).
+  # If you provide a publicly addressable URL (presumably behind IAP), you may need to worry about services
+  # being able to get through IAP to contact it. For stuff in the same cluster you can use either hostAliases
+  # with a static clusterIP on Sherlock or a CoreDNS rewrite to make in-cluster clients route in-cluster and
+  # dodge IAP.
+  #
+  # (In either case, you can find yourself needing to tweak hostname resolution. Be careful that you don't
+  # accidentally set it up such that /api/* requests dodge IAP, because Sherlock will reject that outright.
+  # This is why the examples make use of sherlock-oidc as a subdomain and Sherlock supports multiple origins:
+  # you can use a separate hostname that goes to the same place as a way to more safely tweak resolution.)
   #
   # An example is https://sherlock-api-service.sherlock.svc.cluster.local/oidc
+  # Another example is https://sherlock-oidc.dsp-devops-prod.broadinstitute.org/oidc
   issuerUrl: http://localhost:8080/oidc
   # The *public* side of Sherlock's OIDC issuer. This should be a normally-accessible URL that should
   # go to the same destination as issuerUrl above. This is automatically used in the OIDC discovery
-  # config to tell clients how to have *users* authenticate against Sherlock. The downstream system
-  # will talk to issuerUrl in-cluster, but end-users will need to talk to publicIssuerUrl.
+  # config to tell clients how to have *users* authenticate against Sherlock. It's okay for this to be
+  # the same as the issuerUrl if that's publicly addressable.
   #
-  # An example is https://sherlock.dsp-devops-prod.broadinstitute.org/oidc
+  # An example is https://sherlock-oidc.dsp-devops-prod.broadinstitute.org/oidc
   publicIssuerUrl: http://localhost:8080/oidc
 
   # The key that Sherlock should use to AES-256 encrypt internal data it sends to clients. This is


### PR DESCRIPTION
- Update docs to explain how the OIDC issuer URLs are used now, because the setup we landed on is a bit different than what the docs I wrote anticipated
- Base64 encode the random bytes used for refresh tokens. We don't bother decoding (that way Sherlock will still respect previously-generated refresh tokens); it's that this way the refresh tokens Sherlock returns are safer to store in yaml files like ArgoCD wants to do

## Testing

Added test for refresh token being b64

## Risk

Very low