### PR TITLE
[DDO-3828] Remove spurious notifications when suspending role assignments

### DIFF
--- a/sherlock/internal/suitability_synchronization/suspend_role_assignments.go
+++ b/sherlock/internal/suitability_synchronization/suspend_role_assignments.go
@@ -10,6 +10,7 @@ import (
 	"github.com/broadinstitute/sherlock/sherlock/internal/role_propagation"
 	"github.com/rs/zerolog/log"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 	"time"
 )
 
@@ -68,7 +69,7 @@ func suspendRoleAssignments(ctx context.Context, db *gorm.DB) error {
 				suitable := assignment.User.Suitability != nil && assignment.User.Suitability.Suitable != nil && *assignment.User.Suitability.Suitable
 				if suitable && (assignment.Suspended == nil || *assignment.Suspended) {
 					roleIDsRequiringPropagation[roleID] = struct{}{}
-					if err := superUserDB.Model(&assignment).Updates(&models.RoleAssignment{
+					if err := superUserDB.Model(&assignment).Omit(clause.Associations).Updates(&models.RoleAssignment{
 						RoleAssignmentFields: models.RoleAssignmentFields{
 							Suspended: utils.PointerTo(false),
 						},
@@ -79,7 +80,7 @@ func suspendRoleAssignments(ctx context.Context, db *gorm.DB) error {
 					}
 				} else if !suitable && (assignment.Suspended == nil || !*assignment.Suspended) {
 					roleIDsRequiringPropagation[roleID] = struct{}{}
-					if err := superUserDB.Model(&assignment).Updates(&models.RoleAssignment{
+					if err := superUserDB.Model(&assignment).Omit(clause.Associations).Updates(&models.RoleAssignment{
 						RoleAssignmentFields: models.RoleAssignmentFields{
 							Suspended: utils.PointerTo(true),
 						},

--- a/sherlock/internal/suitability_synchronization/suspend_role_assignments_test.go
+++ b/sherlock/internal/suitability_synchronization/suspend_role_assignments_test.go
@@ -60,8 +60,9 @@ func (s *suspendRoleAssignmentsSuite) Test_suspendRoleAssignments() {
 	s.NoError(s.DB.Create(&assignment5).Error)
 
 	slack.UseMockedClient(s.T(), func(c *slack_mocks.MockMockableClient) {
-		c.EXPECT().SendMessageContext(mock.Anything, "#notification-channel", mock.Anything).Return("", "", "", nil)
-		c.EXPECT().SendMessageContext(mock.Anything, "#permission-change-channel", mock.Anything).Return("", "", "", nil)
+		// Two changes, two notifications in each channel each (one from this function and one from the RoleAssignment hook), = 4
+		c.EXPECT().SendMessageContext(mock.Anything, "#notification-channel", mock.Anything).Return("", "", "", nil).Times(4)
+		c.EXPECT().SendMessageContext(mock.Anything, "#permission-change-channel", mock.Anything).Return("", "", "", nil).Times(4)
 	}, func() {
 		s.NoError(suspendRoleAssignments(s.DB.Statement.Context, s.DB))
 	})


### PR DESCRIPTION
Right now it sends three notifications per change per channel -- "modified role assignments based on suitability" (expected), "created User" (???), "edited RoleAssignment ..." (expected).

Turns out it's our friend, Gorm's automatic upsert of associations. Gotta do the usual `Omit(clause.Associations)`.

## Testing

Modified the mocked test for this function to enforce a specific count of the notifications that are sent. The test now fails without this fix.

## Risk

Very low