### PR TITLE
[DDO-3829] Document host on Swagger page

### DIFF
--- a/sherlock/config/default_config.yaml
+++ b/sherlock/config/default_config.yaml
@@ -5,6 +5,12 @@
 #   It will use mock authentication and authorization.
 mode: debug
 
+# The primary host name that Sherlock should document itself as running on, used in the
+# Swagger docs hosted dynamically. The Swagger page will work with this empty, but other
+# tools (like AppSec's scanners) that need a fully valid config will fail.
+# Example: "sherlock.dsp-devops-prod.broadinstitute.org"
+primaryHost:
+
 # Origins is the list of allowed origins for requests (used for CORS and CSRF protection).
 # Each entry should include the scheme, like "https://example.com".
 # When empty, all origins will be allowed, which is only suitable for local development where

--- a/sherlock/docs/docs.go
+++ b/sherlock/docs/docs.go
@@ -10191,7 +10191,7 @@ const docTemplate = `{
 var SwaggerInfo = &swag.Spec{
 	Version:          "development",
 	Host:             "sherlock.dsp-devops-prod.broadinstitute.org",
-	BasePath:         "",
+	BasePath:         "/",
 	Schemes:          []string{"https"},
 	Title:            "Sherlock",
 	Description:      "The Data Science Platform's source-of-truth service.\nNote: this API will try to load and return associations in responses, so clients won't need to make as many requests. This behavior isn't recursive, though, so associations of associations are *not* fully loaded (even if it might seem that way from looking at the data types).",

--- a/sherlock/docs/swagger.json
+++ b/sherlock/docs/swagger.json
@@ -23,6 +23,7 @@
         "version": "development"
     },
     "host": "sherlock.dsp-devops-prod.broadinstitute.org",
+    "basePath": "/",
     "paths": {
         "/api/app-versions/procedures/v3/changelog": {
             "get": {

--- a/sherlock/docs/swagger.yaml
+++ b/sherlock/docs/swagger.yaml
@@ -1,3 +1,4 @@
+basePath: /
 consumes:
 - application/json
 definitions:

--- a/sherlock/internal/boot/router.go
+++ b/sherlock/internal/boot/router.go
@@ -43,9 +43,11 @@ import (
 //	@license.url	https://github.com/broadinstitute/sherlock/blob/main/LICENSE.txt
 
 func BuildRouter(ctx context.Context, db *gorm.DB) *gin.Engine {
-	// At runtime, we want Sherlock's own hosted Swagger page to refer to itself, however/wherever it's deployed
-	// (setting the host to an empty string achieves that behavior, like if we didn't specify a host at all)
-	docs.SwaggerInfo.Host = ""
+	// primaryHost may be unset or empty, which means this could be an empty string. That's potentially
+	// okay, because the Swagger page itself will still work. In production, though, having this set
+	// is important to provide a fully valid config that other tools like security scanners can use.
+	// See default_config.yaml's primaryHost for more information.
+	docs.SwaggerInfo.Host = config.Config.String("primaryHost")
 	docs.SwaggerInfo.Version = version.BuildVersion
 	if config.Config.String("mode") == "debug" {
 		// When running locally, make the Swagger page have a scheme dropdown with http as the default

--- a/sherlock/internal/boot/router.go
+++ b/sherlock/internal/boot/router.go
@@ -33,8 +33,8 @@ import (
 //	@schemes		https
 //	@accept			json
 //	@produce		json
-
-//	@host	sherlock.dsp-devops-prod.broadinstitute.org
+//	@host			sherlock.dsp-devops-prod.broadinstitute.org
+//	@BasePath		/
 
 //	@contact.name	DSP DevOps
 //	@contact.email	dsp-devops@broadinstitute.org


### PR DESCRIPTION
Making a fully valid Swagger spec from Sherlock's dynamic doc.json endpoint helps appsec's tools run against it. We'll need to specify the primaryHost from helmfile. Can't borrow origins here because origins is a list for use with CORS, and those have schemes anyway.

Also adds `/` as a base path. I've confirmed on the Swagger page that there's no difference in behavior here. Since doc.json sets basepath to an empty string if you don't provide it, that too was failing some validation.

Setting basepath to `/` is the same as what should be done automatically: https://swagger.io/docs/specification/2-0/api-host-and-base-path/

It's okay for this to ship immediately because the empty primaryHost value is the same behavior as we've got right now.

## Testing

I used the Swagger page generated on this PR and confirmed that there is no difference in behavior. I don't expect this to cause any downstream issues. If there is an issue, downstream tests would catch it before a broken usage of the Swagger spec got promoted. The API here isn't changing.

## Risk

Low.