### PR TITLE
[DDO-3831] Add Changeset filterToMatchingBranches

### DIFF
--- a/sherlock/internal/models/chart_release_version.go
+++ b/sherlock/internal/models/chart_release_version.go
@@ -35,6 +35,24 @@ type ChartReleaseVersion struct {
 	HelmfileRefEnabled *bool
 }
 
+// ClearAppVersion sets the app version fields of this ChartReleaseVersion to nil.
+//
+// This is helpful for customizing a Changeset being passed to PlanChangesets. These fields being empty will cause
+// Changeset.fillEmptyToFieldsBasedOnFrom to fill them from the "From" side of the Changeset -- so there's no change.
+//
+// This function exists because we want to encapsulate the "clearing" of the fields within this package, rather than
+// relying on the caller to know which fields to clear.
+func (crv *ChartReleaseVersion) ClearAppVersion() {
+	crv.AppVersionResolver = nil
+	crv.AppVersionExact = nil
+	crv.AppVersionBranch = nil
+	crv.AppVersionCommit = nil
+	crv.AppVersionFollowChartRelease = nil
+	crv.AppVersionFollowChartReleaseID = nil
+	crv.AppVersion = nil
+	crv.AppVersionID = nil
+}
+
 // resolve uses what's currently in the ChartReleaseVersion to fill in as many of the rest of the fields as possible.
 // In other words, this function "figures out" the ChartReleaseVersion. This means it figures out the actual version
 // from a branch or commit, sets the right terra-helmfile ref, etc.

--- a/sherlock/internal/models/chart_release_version_test.go
+++ b/sherlock/internal/models/chart_release_version_test.go
@@ -1,6 +1,11 @@
 package models
 
-import "github.com/broadinstitute/sherlock/go-shared/pkg/utils"
+import (
+	"github.com/broadinstitute/sherlock/go-shared/pkg/utils"
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
 
 func (s *modelSuite) TestChartReleaseVersion_resolve_follow() {
 	s.SetSuitableTestUserForDB()
@@ -213,4 +218,99 @@ func (s *modelSuite) TestChartReleaseVersion_resolveChartVersion_followNoID() {
 	}
 	err := chartReleaseVersion.resolveChartVersion(s.DB, s.TestData.Chart_Leonardo())
 	s.ErrorContains(err, "chartVersionResolver was set to 'follow' but no chart release ID was given to follow")
+}
+
+func TestChartReleaseVersion_ClearAppVersion(t *testing.T) {
+	type fields struct {
+		ResolvedAt                       *time.Time
+		AppVersionResolver               *string
+		AppVersionExact                  *string
+		AppVersionBranch                 *string
+		AppVersionCommit                 *string
+		AppVersionFollowChartReleaseID   *uint
+		AppVersionID                     *uint
+		ChartVersionResolver             *string
+		ChartVersionExact                *string
+		ChartVersionFollowChartReleaseID *uint
+		ChartVersionID                   *uint
+		HelmfileRef                      *string
+		HelmfileRefEnabled               *bool
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   fields
+	}{
+		{
+			name: "all fields set",
+			fields: fields{
+				AppVersionResolver:               utils.PointerTo("exact"),
+				AppVersionExact:                  utils.PointerTo("v1.2.4"),
+				AppVersionBranch:                 utils.PointerTo("main"),
+				AppVersionCommit:                 utils.PointerTo("1234567"),
+				AppVersionFollowChartReleaseID:   utils.PointerTo(uint(1)),
+				AppVersionID:                     utils.PointerTo(uint(1)),
+				ChartVersionResolver:             utils.PointerTo("exact"),
+				ChartVersionExact:                utils.PointerTo("v1.2.4"),
+				ChartVersionFollowChartReleaseID: utils.PointerTo(uint(1)),
+				ChartVersionID:                   utils.PointerTo(uint(1)),
+				HelmfileRef:                      utils.PointerTo("v1.2.4"),
+				HelmfileRefEnabled:               utils.PointerTo(true),
+			},
+			want: fields{
+				AppVersionResolver:               nil,
+				AppVersionExact:                  nil,
+				AppVersionBranch:                 nil,
+				AppVersionCommit:                 nil,
+				AppVersionFollowChartReleaseID:   nil,
+				AppVersionID:                     nil,
+				ChartVersionResolver:             utils.PointerTo("exact"),
+				ChartVersionExact:                utils.PointerTo("v1.2.4"),
+				ChartVersionFollowChartReleaseID: utils.PointerTo(uint(1)),
+				ChartVersionID:                   utils.PointerTo(uint(1)),
+				HelmfileRef:                      utils.PointerTo("v1.2.4"),
+				HelmfileRefEnabled:               utils.PointerTo(true),
+			},
+		},
+		{
+			name:   "no fields set",
+			fields: fields{},
+			want:   fields{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			crv := &ChartReleaseVersion{
+				ResolvedAt:                       tt.fields.ResolvedAt,
+				AppVersionResolver:               tt.fields.AppVersionResolver,
+				AppVersionExact:                  tt.fields.AppVersionExact,
+				AppVersionBranch:                 tt.fields.AppVersionBranch,
+				AppVersionCommit:                 tt.fields.AppVersionCommit,
+				AppVersionFollowChartReleaseID:   tt.fields.AppVersionFollowChartReleaseID,
+				AppVersionID:                     tt.fields.AppVersionID,
+				ChartVersionResolver:             tt.fields.ChartVersionResolver,
+				ChartVersionExact:                tt.fields.ChartVersionExact,
+				ChartVersionFollowChartReleaseID: tt.fields.ChartVersionFollowChartReleaseID,
+				ChartVersionID:                   tt.fields.ChartVersionID,
+				HelmfileRef:                      tt.fields.HelmfileRef,
+				HelmfileRefEnabled:               tt.fields.HelmfileRefEnabled,
+			}
+			crv.ClearAppVersion()
+			assert.Equal(t, &ChartReleaseVersion{
+				ResolvedAt:                       tt.want.ResolvedAt,
+				AppVersionResolver:               tt.want.AppVersionResolver,
+				AppVersionExact:                  tt.want.AppVersionExact,
+				AppVersionBranch:                 tt.want.AppVersionBranch,
+				AppVersionCommit:                 tt.want.AppVersionCommit,
+				AppVersionFollowChartReleaseID:   tt.want.AppVersionFollowChartReleaseID,
+				AppVersionID:                     tt.want.AppVersionID,
+				ChartVersionResolver:             tt.want.ChartVersionResolver,
+				ChartVersionExact:                tt.want.ChartVersionExact,
+				ChartVersionFollowChartReleaseID: tt.want.ChartVersionFollowChartReleaseID,
+				ChartVersionID:                   tt.want.ChartVersionID,
+				HelmfileRef:                      tt.want.HelmfileRef,
+				HelmfileRefEnabled:               tt.want.HelmfileRefEnabled,
+			}, crv)
+		})
+	}
 }


### PR DESCRIPTION
To resolve https://broadinstitute.slack.com/archives/CADU7L0SZ/p1723044063825579 and https://broadinstitute.slack.com/archives/CADM7MZ35/p1722878301943999, add an option to Changeset Environment entries `filterToMatchingBranches` which will omit app version promotions if there's a branch mismatch.

This requires the repos to properly report app versions to Sherlock, but it's better than nothing. We can set this to true in [the automatic promotion to staging](https://github.com/broadinstitute/terra-github-workflows/blob/main/.github/workflows/staging-promotion.yaml#L83) and it'll block the issue that we've seen.

## Testing

Added an exact test for both sides of this flag; existing tests thoroughly check against regressions

## Risk

Low