### PR TITLE
[DDO-3854] Propagate to FC Microsoft accounts

### DIFF
--- a/sherlock/config/default_config.yaml
+++ b/sherlock/config/default_config.yaml
@@ -387,7 +387,7 @@ rolePropagation:
       # The suffix of all member emails. This can be thought of as a filter for what Azure users Sherlock
       # will attempt to propagate roles to. This may contain a "@" (especially useful for "#EXT#@" emails);
       # if it does, then the userEmailSuffixesToReplace must as well.
-      memberEmailSuffix: "_broadinstitute.org#EXT#@devazureterra.onmicrosoft.com"
+      memberEmailSuffix: "@test.firecloud.org"
       # Suffixes of Sherlock users' emails that should be swapped out with the memberEmailSuffix to match
       # Sherlock users to Azure Entra ID users.
       userEmailSuffixesToReplace:
@@ -404,7 +404,7 @@ rolePropagation:
       # The suffix of all member emails. This can be thought of as a filter for what Azure users Sherlock
       # will attempt to propagate roles to. This may contain a "@" (especially useful for "#EXT#@" emails);
       # if it does, then the userEmailSuffixesToReplace must as well.
-      memberEmailSuffix: "_broadinstitute.org#EXT#@terraazureprod.onmicrosoft.com"
+      memberEmailSuffix: "@firecloud.org"
       # Suffixes of Sherlock users' emails that should be swapped out with the memberEmailSuffix to match
       # Sherlock users to Azure Entra ID users.
       userEmailSuffixesToReplace:


### PR DESCRIPTION
The previous config would've propagated roles to people's BI Microsoft accounts, but Mike and I think that test.firecloud.org / firecloud.org is actually what we want here.

Role propagation can handle this change so I'm not calling this breaking.

## Testing

This is a default config tweak -- there's existing tests for how this suffix gets used and substituted

## Risk

Low