### PR TITLE
[DDO-3857] Firecloud account manager: ignore suspended users

### DIFF
--- a/sherlock/internal/firecloud_account_manager/suspend_accounts.go
+++ b/sherlock/internal/firecloud_account_manager/suspend_accounts.go
@@ -54,6 +54,11 @@ func (m *firecloudAccountManager) suspendAccounts(ctx context.Context) ([]string
 				continue
 			}
 
+			// If the user is already suspended, skip them.
+			if user.Suspended {
+				continue
+			}
+
 			// suspensionReason, if not empty, is why we should suspend the user. If it's empty that means
 			// there's no reason to. It starts empty and we'll fill it in as we go.
 			var suspensionReason string

--- a/sherlock/internal/firecloud_account_manager/suspend_accounts_test.go
+++ b/sherlock/internal/firecloud_account_manager/suspend_accounts_test.go
@@ -92,6 +92,19 @@ func TestConfig_suspendAccounts(t *testing.T) {
 			wantErrs:    []string{},
 		},
 		{
+			name: "user already suspended",
+			manager: &firecloudAccountManager{
+				Domain: "test.firecloud.org",
+			},
+			workspaceMockConfig: func(c *firecloud_account_manager_mocks.MockMockableWorkspaceClient) {
+				c.EXPECT().GetCurrentUsers(ctx, "test.firecloud.org").Return([]*admin.User{
+					{PrimaryEmail: "already-suspended@test.firecloud.org", Suspended: true},
+				}, nil).Once()
+			},
+			wantResults: []string{},
+			wantErrs:    []string{},
+		},
+		{
 			name: "failed to parse new user account creation time",
 			manager: &firecloudAccountManager{
 				Domain:                "test.firecloud.org",
@@ -368,6 +381,7 @@ func TestConfig_suspendAccounts(t *testing.T) {
 			workspaceMockConfig: func(c *firecloud_account_manager_mocks.MockMockableWorkspaceClient) {
 				c.EXPECT().GetCurrentUsers(ctx, "test.firecloud.org").Return([]*admin.User{
 					{PrimaryEmail: "never-affect-me@test.firecloud.org"},
+					{PrimaryEmail: "already-suspended@test.firecloud.org", Suspended: true},
 					{PrimaryEmail: "invalid-creation-time-user@test.firecloud.org", CreationTime: "not-a-time"},
 					{PrimaryEmail: "never-logged-in-user@test.firecloud.org", CreationTime: time.Now().Add(-2 * 24 * time.Hour).Format(time.RFC3339)},
 					{PrimaryEmail: "never-logged-in-user-fail@test.firecloud.org", CreationTime: time.Now().Add(-2 * 24 * time.Hour).Format(time.RFC3339)},
@@ -428,6 +442,7 @@ func TestConfig_suspendAccounts(t *testing.T) {
 			workspaceMockConfig: func(c *firecloud_account_manager_mocks.MockMockableWorkspaceClient) {
 				c.EXPECT().GetCurrentUsers(ctx, "test.firecloud.org").Return([]*admin.User{
 					{PrimaryEmail: "never-affect-me@test.firecloud.org"},
+					{PrimaryEmail: "already-suspended@test.firecloud.org", Suspended: true},
 					{PrimaryEmail: "invalid-creation-time-user@test.firecloud.org", CreationTime: "not-a-time"},
 					{PrimaryEmail: "never-logged-in-user@test.firecloud.org", CreationTime: time.Now().Add(-2 * 24 * time.Hour).Format(time.RFC3339)},
 					{PrimaryEmail: "never-logged-in-user-fail@test.firecloud.org", CreationTime: time.Now().Add(-2 * 24 * time.Hour).Format(time.RFC3339)},


### PR DESCRIPTION
An impressive thing to forget when writing this code but whatever. Before it would've just repeatedly kept suspending people which would've flooded us with notifications (as in, it would've sent one ever hour).

## Testing

Modified test cases

## Risk

Very low (security impact non-zero but we haven't even turned this on, and again, the actual functionality would've been okay, it just would've notified us too much)