### PR TITLE
[DDO-3862] Prep for breakglass setup

### DIFF
--- a/sherlock/internal/boot/application.go
+++ b/sherlock/internal/boot/application.go
@@ -153,6 +153,7 @@ func (a *Application) Start() {
 	go firecloud_account_manager.RunManagersHourly(ctx)
 
 	go models.KeepAutoAssigningRoles(ctx, a.gormDB)
+	go models.KeepAutoExpiringRoleAssignments(ctx, a.gormDB, role_propagation.DoOnDemandPropagation)
 
 	log.Info().Msgf("BOOT | building Gin router...")
 	gin.SetMode(gin.ReleaseMode) // gin.DebugMode can help resolve routing issues

--- a/sherlock/internal/models/role_assignment_auto_expire.go
+++ b/sherlock/internal/models/role_assignment_auto_expire.go
@@ -1,0 +1,56 @@
+package models
+
+import (
+	"context"
+	"errors"
+	"github.com/broadinstitute/sherlock/sherlock/internal/clients/slack"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+	"time"
+)
+
+// KeepAutoExpiringRoleAssignments will periodically delete RoleAssignments that have expired.
+// It can accept functions to kick off propagation for impacted Roles.
+func KeepAutoExpiringRoleAssignments(ctx context.Context, db *gorm.DB, propagationFn ...func(ctx context.Context, db *gorm.DB, roleID uint)) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(time.Minute):
+			doAutoExpiration(ctx, db, propagationFn...)
+		}
+	}
+}
+
+func doAutoExpiration(ctx context.Context, db *gorm.DB, propagationFn ...func(ctx context.Context, db *gorm.DB, roleID uint)) {
+	var roleAssignmentsToExpire []RoleAssignment
+	if err := db.Model(&RoleAssignment{}).
+		Where("expires_at < current_timestamp").
+		Preload(clause.Associations).
+		Find(&roleAssignmentsToExpire).Error; err != nil {
+		slack.ReportError(ctx, "failed to find role assignments to expire", err)
+		return
+	}
+
+	if len(roleAssignmentsToExpire) > 0 {
+		// Need to run as super user to create role assignments
+		superUserDB := SetCurrentUserForDB(db, SelfUser)
+
+		rolesToPropagate := make(map[uint]struct{})
+		for _, ra := range roleAssignmentsToExpire {
+			if err := superUserDB.Omit(clause.Associations).Delete(&ra).Error; err != nil {
+				if !errors.Is(err, gorm.ErrRecordNotFound) {
+					slack.ReportError(ctx, "failed to delete role assignment", err)
+				}
+				continue
+			}
+			rolesToPropagate[ra.RoleID] = struct{}{}
+		}
+
+		for roleID := range rolesToPropagate {
+			for _, fn := range propagationFn {
+				fn(ctx, db, roleID)
+			}
+		}
+	}
+}

--- a/sherlock/internal/models/role_assignment_auto_expire_test.go
+++ b/sherlock/internal/models/role_assignment_auto_expire_test.go
@@ -1,0 +1,50 @@
+package models
+
+import (
+	"context"
+	"github.com/broadinstitute/sherlock/go-shared/pkg/utils"
+	"gorm.io/gorm"
+	"time"
+)
+
+func (s *modelSuite) Test_doAutoExpiration() {
+	s.TestData.User_Suitable()
+	s.TestData.User_NonSuitable()
+
+	ra := s.TestData.RoleAssignment_Suitable_TerraSuitableEngineer()
+
+	s.SetSelfSuperAdminForDB()
+	s.NoError(s.DB.Model(&ra).Updates(&RoleAssignment{
+		RoleAssignmentFields: RoleAssignmentFields{
+			ExpiresAt: utils.PointerTo(time.Now().Add(-time.Hour)),
+		},
+	}).Error)
+
+	var ras []RoleAssignment
+	s.NoError(s.DB.Where(&RoleAssignment{}).Find(&ras).Error)
+	existingCount := len(ras)
+
+	propagationFnCalled := false
+	propagationFn := func(_ context.Context, _ *gorm.DB, roleID uint) {
+		if roleID == s.TestData.Role_TerraSuitableEngineer().ID {
+			propagationFnCalled = true
+		}
+	}
+
+	doAutoExpiration(context.Background(), s.DB, propagationFn)
+
+	s.Run("check that the expired role assignment was deleted", func() {
+		var shouldStayEmpty []RoleAssignment
+		s.NoError(s.DB.Where(&RoleAssignment{UserID: s.TestData.User_Suitable().ID, RoleID: s.TestData.Role_TerraSuitableEngineer().ID}).Find(&shouldStayEmpty).Error)
+		s.Empty(shouldStayEmpty)
+	})
+
+	s.Run("check that nothing else got deleted", func() {
+		s.NoError(s.DB.Where(&RoleAssignment{}).Find(&ras).Error)
+		s.Len(ras, existingCount-1)
+	})
+
+	s.Run("check that the propagation function was called", func() {
+		s.True(propagationFnCalled)
+	})
+}

--- a/sherlock/internal/role_propagation/propagate_test.go
+++ b/sherlock/internal/role_propagation/propagate_test.go
@@ -46,7 +46,6 @@ func (s *propagateSuite) Test_waitToPropagate() {
 		c.EXPECT().Propagate(mock.Anything, mock.MatchedBy(func(r models.Role) bool {
 			return r.ID == roleID
 		})).Return(nil, nil)
-		c.EXPECT().Name().Return("mockedPropagator")
 	}, func() {
 		ctx := context.Background()
 		waitToPropagate(ctx, s.DB, roleID)
@@ -67,7 +66,6 @@ func (s *propagateSuite) Test_waitToPropagate() {
 			c.EXPECT().Propagate(mock.Anything, mock.MatchedBy(func(r models.Role) bool {
 				return r.ID == roleID
 			})).Return(nil, nil)
-			c.EXPECT().Name().Return("mockedPropagator")
 		}, func() {
 			ctx := context.Background()
 			waitToPropagate(ctx, s.DB, roleID)
@@ -90,7 +88,6 @@ func (s *propagateSuite) Test_tryToPropagateStale() {
 		c.EXPECT().Propagate(mock.Anything, mock.MatchedBy(func(r models.Role) bool {
 			return r.ID == roleID
 		})).Return(nil, nil)
-		c.EXPECT().Name().Return("mockedPropagator")
 	}, func() {
 		ctx := context.Background()
 		tryToPropagateStale(ctx, s.DB)

--- a/sherlock/internal/role_propagation/propagator_propagate.go
+++ b/sherlock/internal/role_propagation/propagator_propagate.go
@@ -40,9 +40,9 @@ func (p *propagatorImpl[Grant, Identifier, Fields]) Propagate(ctx context.Contex
 	for _, alignmentOperation := range alignmentOperations {
 		result, err := alignmentOperation()
 		if err != nil {
-			errors = append(errors, err)
+			errors = append(errors, fmt.Errorf("%s: %w", p.Name(), err))
 		} else {
-			results = append(results, result)
+			results = append(results, fmt.Sprintf("%s: %s", p.Name(), result))
 		}
 	}
 

--- a/sherlock/internal/role_propagation/propagator_propagate_test.go
+++ b/sherlock/internal/role_propagation/propagator_propagate_test.go
@@ -173,6 +173,7 @@ func Test_propagatorImpl_Propagate(t *testing.T) {
 	engine.EXPECT().Add(mock.Anything, "string", propagation_engines.GoogleWorkspaceGroupIdentifier{Email: "c@example.com"}, propagation_engines.GoogleWorkspaceGroupFields{}).
 		Return("oh no", fmt.Errorf("failed to add c")).Once()
 	p := propagatorImpl[string, propagation_engines.GoogleWorkspaceGroupIdentifier, propagation_engines.GoogleWorkspaceGroupFields]{
+		configKey: "test-config-key",
 		getGrant: func(role models.Role) *string {
 			return role.GrantsDevFirecloudGroup
 		},
@@ -180,6 +181,7 @@ func Test_propagatorImpl_Propagate(t *testing.T) {
 		_enable:  true,
 		_timeout: time.Minute,
 	}
+	p.Name()
 	var results []string
 	var errors []error
 	assert.NotPanics(t, func() {
@@ -190,6 +192,6 @@ func Test_propagatorImpl_Propagate(t *testing.T) {
 		})
 	})
 	slices.Sort(results)
-	assert.Equal(t, []string{"added b", "removed a"}, results)
-	assert.Equal(t, []error{fmt.Errorf("failed to add c")}, errors)
+	assert.Equal(t, []string{"test-config-key: added b", "test-config-key: removed a"}, results)
+	assert.Equal(t, []error{fmt.Errorf("test-config-key: %w", fmt.Errorf("failed to add c"))}, errors)
 }

--- a/sherlock/internal/suitability_synchronization/suspend_role_assignments.go
+++ b/sherlock/internal/suitability_synchronization/suspend_role_assignments.go
@@ -43,8 +43,12 @@ func suspendRoleAssignments(ctx context.Context, db *gorm.DB) error {
 	if len(roleIDsToSuspendAssignmentsFor) == 0 {
 		return nil
 	}
+
 	// Assume super-user privileges for this operation (required to edit RoleAssignments)
 	superUserDB := models.SetCurrentUserForDB(db, models.SelfUser)
+	// Squelch notifications where possible because we notify at the end
+	superUserDB = superUserDB.WithContext(slack.SetContextToSquelchPermissionChangeNotifications(ctx))
+
 	roleIDsRequiringPropagation := make(map[uint]struct{})
 	var summaries []string
 	var errors []error

--- a/sherlock/internal/suitability_synchronization/suspend_role_assignments.go
+++ b/sherlock/internal/suitability_synchronization/suspend_role_assignments.go
@@ -74,9 +74,9 @@ func suspendRoleAssignments(ctx context.Context, db *gorm.DB) error {
 							Suspended: utils.PointerTo(false),
 						},
 					}).Error; err != nil {
-						errors = append(errors, fmt.Errorf("failed to un-suspend %s's assignment for %s: %w", assignment.User.NameOrUsername(), *role.Name, err))
+						errors = append(errors, fmt.Errorf("failed to un-suspend %s's assignment for %s: %w", assignment.User.SlackReference(true), *role.Name, err))
 					} else {
-						summaries = append(summaries, fmt.Sprintf("un-suspended %s's assignment for %s", assignment.User.NameOrUsername(), *role.Name))
+						summaries = append(summaries, fmt.Sprintf("Un-suspended %s's assignment for %s", assignment.User.SlackReference(true), *role.Name))
 					}
 				} else if !suitable && (assignment.Suspended == nil || !*assignment.Suspended) {
 					roleIDsRequiringPropagation[roleID] = struct{}{}
@@ -85,15 +85,15 @@ func suspendRoleAssignments(ctx context.Context, db *gorm.DB) error {
 							Suspended: utils.PointerTo(true),
 						},
 					}).Error; err != nil {
-						errors = append(errors, fmt.Errorf("failed to suspend %s's assignment for %s: %w", assignment.User.NameOrUsername(), *role.Name, err))
+						errors = append(errors, fmt.Errorf("failed to suspend %s's assignment for %s: %w", assignment.User.SlackReference(true), *role.Name, err))
 					} else {
-						summaries = append(summaries, fmt.Sprintf("suspended %s's assignment for %s", assignment.User.NameOrUsername(), *role.Name))
+						summaries = append(summaries, fmt.Sprintf("Suspended %s's assignment for %s", assignment.User.SlackReference(true), *role.Name))
 					}
 				}
 			}
 		}
 	}
-	if len(summaries) > 0 {
+	if len(summaries) > 0 || len(errors) > 0 {
 		slack.SendPermissionChangeNotification(ctx, models.SelfUser.SlackReference(true), slack.PermissionChangeNotificationInputs{
 			Summary: "modified role assignments based on suitability",
 			Results: summaries,

--- a/sherlock/internal/suitability_synchronization/suspend_role_assignments_test.go
+++ b/sherlock/internal/suitability_synchronization/suspend_role_assignments_test.go
@@ -60,9 +60,8 @@ func (s *suspendRoleAssignmentsSuite) Test_suspendRoleAssignments() {
 	s.NoError(s.DB.Create(&assignment5).Error)
 
 	slack.UseMockedClient(s.T(), func(c *slack_mocks.MockMockableClient) {
-		// Two changes, two notifications in each channel each (one from this function and one from the RoleAssignment hook), = 4
-		c.EXPECT().SendMessageContext(mock.Anything, "#notification-channel", mock.Anything).Return("", "", "", nil).Times(4)
-		c.EXPECT().SendMessageContext(mock.Anything, "#permission-change-channel", mock.Anything).Return("", "", "", nil).Times(4)
+		c.EXPECT().SendMessageContext(mock.Anything, "#notification-channel", mock.Anything).Return("", "", "", nil).Once()
+		c.EXPECT().SendMessageContext(mock.Anything, "#permission-change-channel", mock.Anything).Return("", "", "", nil).Once()
 	}, func() {
 		s.NoError(suspendRoleAssignments(s.DB.Statement.Context, s.DB))
 	})


### PR DESCRIPTION
- Dedupe some Slack notifications to avoid spam in the security events channel
- Automatically expire-by-deletion role assignments to agree better with Beehive's prod access button
- Summarize role assignments better in Slack

## Testing 

Mocked tests have been updated/added

## Risk

Low