### PR TITLE
[DDO-3863] Fix notification context for suspending users

### DIFF
--- a/sherlock/internal/suitability_synchronization/suspend_role_assignments.go
+++ b/sherlock/internal/suitability_synchronization/suspend_role_assignments.go
@@ -47,7 +47,7 @@ func suspendRoleAssignments(ctx context.Context, db *gorm.DB) error {
 	// Assume super-user privileges for this operation (required to edit RoleAssignments)
 	superUserDB := models.SetCurrentUserForDB(db, models.SelfUser)
 	// Squelch notifications where possible because we notify at the end
-	superUserDB = superUserDB.WithContext(slack.SetContextToSquelchPermissionChangeNotifications(ctx))
+	superUserDB = superUserDB.WithContext(slack.SetContextToSquelchPermissionChangeNotifications(superUserDB.Statement.Context))
 
 	roleIDsRequiringPropagation := make(map[uint]struct{})
 	var summaries []string

--- a/sherlock/internal/suitability_synchronization/suspend_role_assignments_test.go
+++ b/sherlock/internal/suitability_synchronization/suspend_role_assignments_test.go
@@ -59,6 +59,8 @@ func (s *suspendRoleAssignmentsSuite) Test_suspendRoleAssignments() {
 	s.NoError(s.DB.Create(&assignment4).Error)
 	s.NoError(s.DB.Create(&assignment5).Error)
 
+	s.SetSuitableTestUserForDB() // Check that it elevates its own permissions properly
+
 	slack.UseMockedClient(s.T(), func(c *slack_mocks.MockMockableClient) {
 		c.EXPECT().SendMessageContext(mock.Anything, "#notification-channel", mock.Anything).Return("", "", "", nil).Once()
 		c.EXPECT().SendMessageContext(mock.Anything, "#permission-change-channel", mock.Anything).Return("", "", "", nil).Once()


### PR DESCRIPTION
I got my wires crossed with how to assemble the context here and tests didn't catch it. Updates tests and uses the right context.

## Testing

Updated

## Risk

Low