### PR TITLE
[DDO-3865] Remove spurious notifications for Role/RoleAssignments

### DIFF
--- a/sherlock/internal/models/role.go
+++ b/sherlock/internal/models/role.go
@@ -8,6 +8,7 @@ import (
 	"github.com/jinzhu/copier"
 	"github.com/sanity-io/litter"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 	"time"
 )
 
@@ -176,7 +177,7 @@ func (r *Role) BeforeCreate(tx *gorm.DB) error {
 func (r *Role) AfterCreate(tx *gorm.DB) error {
 	if user, err := GetCurrentUserForDB(tx); err != nil {
 		return err
-	} else if err = tx.Create(&RoleOperation{
+	} else if err = tx.Omit(clause.Associations).Create(&RoleOperation{
 		RoleID:    r.ID,
 		AuthorID:  user.ID,
 		Operation: "create",
@@ -210,7 +211,7 @@ func (r *Role) AfterUpdate(tx *gorm.DB) error {
 		return err
 	} else if err = user.ErrIfNotSuperAdmin(); err != nil {
 		return err
-	} else if err = tx.Create(&RoleOperation{
+	} else if err = tx.Omit(clause.Associations).Create(&RoleOperation{
 		RoleID:    r.ID,
 		AuthorID:  user.ID,
 		Operation: "update",
@@ -238,7 +239,7 @@ func (r *Role) BeforeDelete(tx *gorm.DB) error {
 		return err
 	} else if err = tx.First(&current, r.ID).Error; err != nil {
 		return fmt.Errorf("failed to find current Role: %w", err)
-	} else if err = tx.Create(&RoleOperation{
+	} else if err = tx.Omit(clause.Associations).Create(&RoleOperation{
 		RoleID:    r.ID,
 		AuthorID:  user.ID,
 		Operation: "delete",

--- a/sherlock/internal/models/role_assignment.go
+++ b/sherlock/internal/models/role_assignment.go
@@ -7,6 +7,7 @@ import (
 	"github.com/broadinstitute/sherlock/sherlock/internal/errors"
 	"github.com/jinzhu/copier"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 	"time"
 )
 
@@ -182,7 +183,7 @@ func (ra *RoleAssignment) AfterCreate(tx *gorm.DB) error {
 		return err
 	} else if err = ra.errorIfForbidden(tx); err != nil {
 		return err
-	} else if err = tx.Create(&RoleAssignmentOperation{
+	} else if err = tx.Omit(clause.Associations).Create(&RoleAssignmentOperation{
 		RoleID:    ra.RoleID,
 		UserID:    ra.UserID,
 		AuthorID:  user.ID,
@@ -215,7 +216,7 @@ func (ra *RoleAssignment) AfterUpdate(tx *gorm.DB) error {
 		return err
 	} else if err = ra.errorIfForbidden(tx); err != nil {
 		return err
-	} else if err = tx.Create(&RoleAssignmentOperation{
+	} else if err = tx.Omit(clause.Associations).Create(&RoleAssignmentOperation{
 		RoleID:    ra.RoleID,
 		UserID:    ra.UserID,
 		AuthorID:  user.ID,
@@ -244,7 +245,7 @@ func (ra *RoleAssignment) BeforeDelete(tx *gorm.DB) error {
 		return err
 	} else if err = tx.Where(&RoleAssignment{RoleID: ra.RoleID, UserID: ra.UserID}).First(&current).Error; err != nil {
 		return fmt.Errorf("failed to find current RoleAssignment: %w", err)
-	} else if err = tx.Create(&RoleAssignmentOperation{
+	} else if err = tx.Omit(clause.Associations).Create(&RoleAssignmentOperation{
 		RoleID:    ra.RoleID,
 		UserID:    ra.UserID,
 		AuthorID:  user.ID,


### PR DESCRIPTION
...by stopping Gorm's upsert-associations-by-default behavior when creating the database journal rows.

I've already got tests ensuring that the rows get created. This upsert is "safe" because it's in-transaction journaling, but it was running hooks unnecessarily. Unnecessary hooks are fine when it's quiet... but these ones are not. It runs the create hook, so it's erroneously telling us that it's being created when it isn't.

## Testing

We've got tests that notifications get sent and journal rows get created. We test the functionality we need -- we're just removing some extra cycles that were cruft.

## Risk

Low