### PR TITLE
[DDO-3874] CiRun retry Slack message improvements

### DIFF
--- a/sherlock/internal/api/sherlock/ci_runs_v3_upsert.go
+++ b/sherlock/internal/api/sherlock/ci_runs_v3_upsert.go
@@ -122,6 +122,9 @@ func ciRunsV3Upsert(ctx *gin.Context) {
 			Where("github_actions_attempt_number < ? AND notify_slack_channels_upon_retry IS NOT NULL", body.GithubActionsAttemptNumber).
 			// Limit to the number of previous attempts there could've been, might as well get the speed boost
 			Limit(max(1, int(body.GithubActionsAttemptNumber)-1)).
+			// Order by the attempt number ascending so we iterate over more recent runs first
+			// (This matters for custom icon, where the first previous one we find takes precedence)
+			Order("github_actions_attempt_number DESC").
 			Find(&previousRuns).Error; recoverableErr != nil {
 
 			// If there was an error, just Slack it, no need to blow up
@@ -133,6 +136,11 @@ func ciRunsV3Upsert(ctx *gin.Context) {
 			// We dedupe later (for all fields of the body) so we don't worry about that here.
 			for _, previousRun := range previousRuns {
 				body.NotifySlackChannelsUponRetry = append(body.NotifySlackChannelsUponRetry, previousRun.NotifySlackChannelsUponRetry...)
+
+				// If a previous run had a custom icon and we don't have one so far, use the previous run's icon
+				if body.NotifySlackCustomIcon == nil && previousRun.NotifySlackCustomIcon != nil && *previousRun.NotifySlackCustomIcon != "" {
+					body.NotifySlackCustomIcon = previousRun.NotifySlackCustomIcon
+				}
 			}
 
 		}

--- a/sherlock/internal/api/sherlock/ci_runs_v3_upsert.go
+++ b/sherlock/internal/api/sherlock/ci_runs_v3_upsert.go
@@ -122,9 +122,9 @@ func ciRunsV3Upsert(ctx *gin.Context) {
 			Where("github_actions_attempt_number < ? AND notify_slack_channels_upon_retry IS NOT NULL", body.GithubActionsAttemptNumber).
 			// Limit to the number of previous attempts there could've been, might as well get the speed boost
 			Limit(max(1, int(body.GithubActionsAttemptNumber)-1)).
-			// Order by the attempt number ascending so we iterate over more recent runs first
+			// Order by the attempt number descending so we iterate over more recent runs first
 			// (This matters for custom icon, where the first previous one we find takes precedence)
-			Order("github_actions_attempt_number ASC").
+			Order("github_actions_attempt_number DESC").
 			Find(&previousRuns).Error; recoverableErr != nil {
 
 			// If there was an error, just Slack it, no need to blow up

--- a/sherlock/internal/api/sherlock/ci_runs_v3_upsert.go
+++ b/sherlock/internal/api/sherlock/ci_runs_v3_upsert.go
@@ -124,7 +124,7 @@ func ciRunsV3Upsert(ctx *gin.Context) {
 			Limit(max(1, int(body.GithubActionsAttemptNumber)-1)).
 			// Order by the attempt number ascending so we iterate over more recent runs first
 			// (This matters for custom icon, where the first previous one we find takes precedence)
-			Order("github_actions_attempt_number DESC").
+			Order("github_actions_attempt_number ASC").
 			Find(&previousRuns).Error; recoverableErr != nil {
 
 			// If there was an error, just Slack it, no need to blow up

--- a/sherlock/internal/models/ci_run.go
+++ b/sherlock/internal/models/ci_run.go
@@ -151,6 +151,10 @@ func (c *CiRun) SlackCompletionText(db *gorm.DB) (string, []error) {
 	if len(relatedResourceSummaryParts) > 0 {
 		against = fmt.Sprintf(" against %s", strings.Join(relatedResourceSummaryParts, ", "))
 	}
+	var attempt string
+	if c.GithubActionsAttemptNumber > 1 {
+		attempt = fmt.Sprintf(" (attempt %d)", c.GithubActionsAttemptNumber)
+	}
 	status := "unknown"
 	if c.Status != nil {
 		status = *c.Status
@@ -171,7 +175,7 @@ func (c *CiRun) SlackCompletionText(db *gorm.DB) (string, []error) {
 			status = fmt.Sprintf("%s (%s)", status, strings.Join(jobStatuses, ", "))
 		}
 	}
-	return fmt.Sprintf("%s%s: %s", c.Nickname(), against, status), errs
+	return fmt.Sprintf("%s%s%s: %s", c.Nickname(), against, attempt, status), errs
 }
 
 func (c *CiRun) WebURL() string {

--- a/sherlock/internal/models/ci_run_test.go
+++ b/sherlock/internal/models/ci_run_test.go
@@ -538,7 +538,7 @@ func TestCiRun_IsDeploy(t *testing.T) {
 	}
 }
 
-func (s *modelSuite) TestCiRun_SlackCompletionTextt() {
+func (s *modelSuite) TestCiRun_SlackCompletionText() {
 	environment := s.TestData.Environment_Dev()
 	chartRelease := s.TestData.ChartRelease_LeonardoDev()
 
@@ -585,7 +585,7 @@ func (s *modelSuite) TestCiRun_SlackCompletionTextt() {
 					{ResourceType: "environment", ResourceID: environment.ID},
 				},
 			},
-			want: "repo's workflow workflow against <https://beehive.dsp-devops-prod.broadinstitute.org/r/chart-release/leonardo-dev|leonardo-dev>: <https://github.com/owner/repo/actions/runs/1/attempts/3|success>",
+			want: "repo's workflow workflow against <https://beehive.dsp-devops-prod.broadinstitute.org/r/chart-release/leonardo-dev|leonardo-dev> (attempt 3): <https://github.com/owner/repo/actions/runs/1/attempts/3|success>",
 		},
 		{
 			name: "environment",
@@ -594,7 +594,7 @@ func (s *modelSuite) TestCiRun_SlackCompletionTextt() {
 				GithubActionsOwner:         "owner",
 				GithubActionsRepo:          "repo",
 				GithubActionsRunID:         1,
-				GithubActionsAttemptNumber: 3,
+				GithubActionsAttemptNumber: 1,
 				GithubActionsWorkflowPath:  "workflow",
 				StartedAt:                  utils.PointerTo(time.Now().Add(-time.Minute)),
 				TerminalAt:                 utils.PointerTo(time.Now()),
@@ -603,7 +603,7 @@ func (s *modelSuite) TestCiRun_SlackCompletionTextt() {
 					{ResourceType: "environment", ResourceID: environment.ID},
 				},
 			},
-			want: "repo's workflow workflow against <https://beehive.dsp-devops-prod.broadinstitute.org/r/environment/dev|dev>: <https://github.com/owner/repo/actions/runs/1/attempts/3|success>",
+			want: "repo's workflow workflow against <https://beehive.dsp-devops-prod.broadinstitute.org/r/environment/dev|dev>: <https://github.com/owner/repo/actions/runs/1/attempts/1|success>",
 		},
 		{
 			name: "with jobs",
@@ -652,7 +652,7 @@ func (s *modelSuite) TestCiRun_SlackCompletionTextt() {
 					Response: &http.Response{StatusCode: http.StatusOK},
 				}, nil).Once()
 			},
-			want: "repo's workflow workflow against <https://beehive.dsp-devops-prod.broadinstitute.org/r/environment/dev|dev>: <https://github.com/owner/repo/actions/runs/1/attempts/3|success> (job3: <https://github.com/owner/repo/actions/runs/1/job/3|failure>)",
+			want: "repo's workflow workflow against <https://beehive.dsp-devops-prod.broadinstitute.org/r/environment/dev|dev> (attempt 3): <https://github.com/owner/repo/actions/runs/1/attempts/3|success> (job3: <https://github.com/owner/repo/actions/runs/1/job/3|failure>)",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
From DCJ's channel:

<img width="529" alt="Screenshot 2024-09-13 at 11 07 18 AM" src="https://github.com/user-attachments/assets/25a98624-6d05-4552-807f-8bf1924665d7">

This PR makes two improvements:
1. Carry forward any custom icon set on a previous run, the same way we do for retry notification channels. Put differently, this fixes #533 to be aware of #442.
2. Note in Slack messages when a retry is a retry, i.e. "jade-data-repo-ui's test-unit workflow (attempt 2): [success](https://github.com/DataBiosphere/jade-data-repo-ui/actions/runs/10823918604/attempts/2)"

## Testing

Tests for both components updated to get full coverage

## Risk

Very low