### PR TITLE
[DDO-3889] Content Security Policy

### DIFF
--- a/sherlock/go.mod
+++ b/sherlock/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/creasty/defaults v1.8.0
 	github.com/dustinkirkland/golang-petname v0.0.0-20240428194347-eebcea082ee0
 	github.com/gin-contrib/cors v1.7.2
+	github.com/gin-contrib/secure v1.1.0
 	github.com/gin-gonic/gin v1.10.0
 	github.com/go-jose/go-jose/v4 v4.0.4
 	github.com/golang-migrate/migrate/v4 v4.18.1
@@ -28,14 +29,17 @@ require (
 	github.com/jackc/pgx/v5 v5.7.1
 	github.com/jinzhu/copier v0.4.0
 	github.com/knadh/koanf v1.5.0
+	github.com/microsoft/kiota-abstractions-go v1.7.0
 	github.com/microsoftgraph/msgraph-sdk-go v1.48.0
+	github.com/microsoftgraph/msgraph-sdk-go-core v1.2.1
 	github.com/pact-foundation/pact-go/v2 v2.0.8
 	github.com/rs/zerolog v1.33.0
 	github.com/sanity-io/litter v1.5.5
+	github.com/sethvargo/go-password v0.3.1
 	github.com/slack-go/slack v0.14.0
 	github.com/stretchr/testify v1.9.0
 	github.com/swaggo/files v1.0.1
-	github.com/swaggo/gin-swagger v1.6.0
+	github.com/swaggo/gin-swagger v1.6.1-0.20231210095754-aa92a0ac3f26
 	github.com/swaggo/swag v1.16.3
 	github.com/zitadel/oidc/v3 v3.30.0
 	go.opencensus.io v0.24.0
@@ -120,14 +124,12 @@ require (
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
-	github.com/microsoft/kiota-abstractions-go v1.7.0 // indirect
 	github.com/microsoft/kiota-authentication-azure-go v1.1.0 // indirect
 	github.com/microsoft/kiota-http-go v1.4.4 // indirect
 	github.com/microsoft/kiota-serialization-form-go v1.0.0 // indirect
 	github.com/microsoft/kiota-serialization-json-go v1.0.8 // indirect
 	github.com/microsoft/kiota-serialization-multipart-go v1.0.0 // indirect
 	github.com/microsoft/kiota-serialization-text-go v1.0.0 // indirect
-	github.com/microsoftgraph/msgraph-sdk-go-core v1.2.1 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
@@ -146,7 +148,6 @@ require (
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/prometheus/statsd_exporter v0.27.1 // indirect
 	github.com/rs/cors v1.11.1 // indirect
-	github.com/sethvargo/go-password v0.3.1 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/spf13/afero v1.11.0 // indirect
 	github.com/spf13/cobra v1.8.1 // indirect

--- a/sherlock/go.sum
+++ b/sherlock/go.sum
@@ -176,6 +176,8 @@ github.com/gin-contrib/cors v1.7.2 h1:oLDHxdg8W/XDoN/8zamqk/Drgt4oVZDvaV0YmvVICQ
 github.com/gin-contrib/cors v1.7.2/go.mod h1:SUJVARKgQ40dmrzgXEVxj2m7Ig1v1qIboQkPDTQ9t2E=
 github.com/gin-contrib/gzip v0.0.6 h1:NjcunTcGAj5CO1gn4N8jHOSIeRFHIbn51z6K+xaN4d4=
 github.com/gin-contrib/gzip v0.0.6/go.mod h1:QOJlmV2xmayAjkNS2Y8NQsMneuRShOU/kjovCXNuzzk=
+github.com/gin-contrib/secure v1.1.0 h1:wy/psCWbgUBDCLH13KgB/m06NHXb1jczSTRp+H2hK7E=
+github.com/gin-contrib/secure v1.1.0/go.mod h1:LtEfyy326NRwgkUq8ac6npf845L0L9B8yfEaLcxMHIc=
 github.com/gin-contrib/sse v0.1.0 h1:Y/yl/+YNO8GZSjAhjMsSuLt29uWRFHdHYUb5lYOV9qE=
 github.com/gin-contrib/sse v0.1.0/go.mod h1:RHrZQHXnP2xjPF+u1gW/2HnVO7nvIa9PG3Gm+fLHvGI=
 github.com/gin-gonic/gin v1.10.0 h1:nTuyha1TYqgedzytsKYqna+DfLos46nTv2ygFy86HFU=
@@ -645,8 +647,8 @@ github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8
 github.com/stvp/go-udp-testing v0.0.0-20201019212854-469649b16807/go.mod h1:7jxmlfBCDBXRzr0eAQJ48XC1hBu1np4CS5+cHEYfwpc=
 github.com/swaggo/files v1.0.1 h1:J1bVJ4XHZNq0I46UU90611i9/YzdrF7x92oX1ig5IdE=
 github.com/swaggo/files v1.0.1/go.mod h1:0qXmMNH6sXNf+73t65aKeB+ApmgxdnkQzVTAj2uaMUg=
-github.com/swaggo/gin-swagger v1.6.0 h1:y8sxvQ3E20/RCyrXeFfg60r6H0Z+SwpTjMYsMm+zy8M=
-github.com/swaggo/gin-swagger v1.6.0/go.mod h1:BG00cCEy294xtVpyIAHG6+e2Qzj/xKlRdOqDkvq0uzo=
+github.com/swaggo/gin-swagger v1.6.1-0.20231210095754-aa92a0ac3f26 h1:7APoRVOgfnHlp4HfZ/5YudTmNZCEgPAmjJpDzESCUOY=
+github.com/swaggo/gin-swagger v1.6.1-0.20231210095754-aa92a0ac3f26/go.mod h1:BG00cCEy294xtVpyIAHG6+e2Qzj/xKlRdOqDkvq0uzo=
 github.com/swaggo/swag v1.16.3 h1:PnCYjPCah8FK4I26l2F/KQ4yz3sILcVUN3cTlBFA9Pg=
 github.com/swaggo/swag v1.16.3/go.mod h1:DImHIuOFXKpMFAQjcC7FG4m3Dg4+QuUgUzJmKjI/gRk=
 github.com/twitchyliquid64/golang-asm v0.15.1 h1:SU5vSMR7hnwNxj24w34ZyCi/FmDZTkS4MhqMhdFk5YI=

--- a/sherlock/html/close.html
+++ b/sherlock/html/close.html
@@ -4,9 +4,7 @@
     <title>Sherlock</title>
 </head>
 <!-- Attempt to window.close so that another app can direct users here with window.open for a clean experience -->
-<script>
-    window.close();
-</script>
+<script src="./close.js"></script>
 <h1>
     You may close this window.
 </h1>

--- a/sherlock/html/close.js
+++ b/sherlock/html/close.js
@@ -1,0 +1,1 @@
+window.close();

--- a/sherlock/html/html.go
+++ b/sherlock/html/html.go
@@ -2,5 +2,5 @@ package html
 
 import "embed"
 
-//go:embed *.html
+//go:embed *.html *.js
 var StaticHtmlFiles embed.FS

--- a/sherlock/html/html_test.go
+++ b/sherlock/html/html_test.go
@@ -5,6 +5,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/net/html"
 	"path"
+	"strings"
 	"testing"
 )
 
@@ -19,7 +20,7 @@ func validateHtmlInStaticDirectory(t *testing.T, subdirectory string) {
 		filesystemPath := path.Join(subdirectory, entry.Name())
 		if entry.IsDir() {
 			validateHtmlInStaticDirectory(t, filesystemPath)
-		} else {
+		} else if strings.HasSuffix(filesystemPath, ".html") {
 			data, err := StaticHtmlFiles.ReadFile(filesystemPath)
 			assert.NoErrorf(t, err, "file %s read error", filesystemPath)
 			_, err = html.Parse(bytes.NewBuffer(data))
@@ -32,6 +33,6 @@ func TestStaticCloseHtml(t *testing.T) {
 	data, err := StaticHtmlFiles.ReadFile("close.html")
 	assert.NoError(t, err)
 	t.Run("will close if opened from JavaScript", func(t *testing.T) {
-		assert.Contains(t, string(data), "<script>\n    window.close();\n</script>")
+		assert.Contains(t, string(data), "<script src=\"./close.js\">")
 	})
 }

--- a/sherlock/internal/boot/router.go
+++ b/sherlock/internal/boot/router.go
@@ -17,6 +17,7 @@ import (
 	"github.com/broadinstitute/sherlock/sherlock/internal/middleware/csrf_protection"
 	"github.com/broadinstitute/sherlock/sherlock/internal/middleware/headers"
 	"github.com/broadinstitute/sherlock/sherlock/internal/middleware/logger"
+	"github.com/broadinstitute/sherlock/sherlock/internal/middleware/security"
 	"github.com/broadinstitute/sherlock/sherlock/internal/oidc_models"
 	"github.com/gin-gonic/gin"
 	swaggo_files "github.com/swaggo/files"
@@ -60,7 +61,8 @@ func BuildRouter(ctx context.Context, db *gorm.DB) *gin.Engine {
 		gin.Recovery(),
 		logger.Logger(),
 		cors.Cors(),
-		headers.Headers())
+		headers.Headers(),
+		security.Security())
 
 	resourceMiddleware := make(gin.HandlersChain, 0)
 	resourceMiddleware = append(resourceMiddleware, csrf_protection.CsrfProtection())

--- a/sherlock/internal/middleware/security/middleware.go
+++ b/sherlock/internal/middleware/security/middleware.go
@@ -1,0 +1,39 @@
+package security
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"github.com/gin-contrib/secure"
+	"github.com/gin-gonic/gin"
+	"strings"
+)
+
+var styleAttributeValuesToAllow = []string{
+	"position:absolute;width:0;height:0",
+}
+
+func Security() gin.HandlerFunc {
+	styleAttributeHashes := make([]string, len(styleAttributeValuesToAllow))
+	for i, value := range styleAttributeValuesToAllow {
+		hash := sha256.Sum256([]byte(value))
+		styleAttributeHashes[i] = fmt.Sprintf("'sha256-%s'", base64.StdEncoding.EncodeToString(hash[:]))
+	}
+	styleDirective := fmt.Sprintf("style-src 'self' 'unsafe-hashes' %s; ", strings.Join(styleAttributeHashes, " "))
+
+	c := secure.Config{
+		// TLS is terminated at the proxy and/or load balancer, so we
+		// don't enable any TLS-related behavior. Some of the rest of
+		// this is just a freebie so might as well.
+		FrameDeny:          true,
+		ContentTypeNosniff: true,
+		BrowserXssFilter:   true,
+		ContentSecurityPolicy: "default-src 'self'; " +
+			"img-src 'self' data:; " +
+			styleDirective +
+			"frame-ancestors 'none'; ",
+		IENoOpen:       true,
+		ReferrerPolicy: "strict-origin-when-cross-origin",
+	}
+	return secure.New(c)
+}

--- a/sherlock/internal/middleware/security/middleware_test.go
+++ b/sherlock/internal/middleware/security/middleware_test.go
@@ -1,0 +1,29 @@
+package security
+
+import (
+	"github.com/broadinstitute/sherlock/sherlock/internal/config"
+	"github.com/gin-gonic/gin"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestSecurity(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	config.LoadTestConfig()
+	zerolog.SetGlobalLevel(zerolog.Disabled)
+	router := gin.New()
+	router.Use(Security())
+	router.GET("/", func(ctx *gin.Context) {
+		ctx.JSON(200, gin.H{})
+	})
+	t.Run("csp", func(t *testing.T) {
+		recorder := httptest.NewRecorder()
+		request := httptest.NewRequest("GET", "/", nil)
+		router.ServeHTTP(recorder, request)
+
+		assert.Contains(t, recorder.Header().Get("Content-Security-Policy"), "default-src 'self'; ")
+		assert.Contains(t, recorder.Header().Get("Content-Security-Policy"), "style-src 'self' 'unsafe-hashes' 'sha256-")
+	})
+}


### PR DESCRIPTION
Adds a Content-Security-Policy header to Sherlock's responses. A lot of Terra services got a ticket filed -- I think Sherlock hasn't yet but it's vulnerable in the same way. I did a research project on CSPs in college so I figured I'd just knock this out since I had a minute while working on other stuff. Changes:

1. Bump gin-swagger from 1.6.0 to v1.6.1-0.20231210095754-aa92a0ac3f26 (on master) to include the merged-but-not-yet-released https://github.com/swaggo/gin-swagger/pull/280 that makes the Swagger page much much more compatible with CSPs. Dependabot still understands what's going on here so when it does become released we'll get it for free.
2. Change the close.html file to have the Javascript in a separate close.js file, again to make it much more compatible with CSPs.
3. Pull in https://github.com/gin-contrib/secure, Gin's thing for CSP. It lets us add some other free security wins too so why not. The only interesting thing here is a usage of a hash content source to permit a style attribute that the Swagger page still has on it.
4. `go mod tidy` which shuffled things around a bit.

## Testing

Loaded up the Swagger page locally -- no issues. I confirmed that the CSP was being used by changing it to `default-src 'none'` and immediately it fails to load and the console floods with errors.

Here's the CSP header that gets set:

```
default-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-hashes' 'sha256-ezdv1bOGcoOD7FKudKN0Y2Mb763O6qVtM8LT2mtanIU='; frame-ancestors 'none';
```

## Risk

Low! Doesn't impact API usage, just humans using the Swagger page.