### PR TITLE
[DDO-3890] Chunk permission change notifications

### DIFF
--- a/sherlock/internal/clients/slack/deployment_notification.go
+++ b/sherlock/internal/clients/slack/deployment_notification.go
@@ -76,7 +76,7 @@ func SendDeploymentChangelogNotification(ctx context.Context, channel, timestamp
 	}
 	if isEnabled() && timestamp != "" && len(sections) > 0 && len(blocks) > 0 {
 		var chunks [][]slack.Block
-		for 50 < len(blocks) {
+		for len(blocks) > 50 {
 			blocks, chunks = blocks[50:], append(chunks, blocks[0:50:50])
 		}
 		for _, chunk := range append(chunks, blocks) {

--- a/sherlock/internal/clients/slack/permission_change_notification.go
+++ b/sherlock/internal/clients/slack/permission_change_notification.go
@@ -104,9 +104,11 @@ func SendPermissionChangeNotificationReturnError(ctx context.Context, actor stri
 				// message.
 				var err error
 				if timestamp == "" {
-					_, timestamp, _, err = client.SendMessageContext(ctx, channel, slack.MsgOptionBlocks(chunk...))
+					_, timestamp, _, err = client.SendMessageContext(ctx, channel,
+						slack.MsgOptionBlocks(chunk...))
 				} else {
-					_, _, _, err = client.SendMessageContext(ctx, channel, slack.MsgOptionTS(timestamp), slack.MsgOptionBlocks(chunk...))
+					_, _, _, err = client.SendMessageContext(ctx, channel,
+						slack.MsgOptionTS(timestamp), slack.MsgOptionBlocks(chunk...))
 				}
 
 				// If we got an error, we do some legwork to make debugging easier. Blocks are bytes and should be able

--- a/sherlock/internal/clients/slack/permission_change_notification_test.go
+++ b/sherlock/internal/clients/slack/permission_change_notification_test.go
@@ -3,6 +3,7 @@ package slack
 import (
 	"context"
 	"fmt"
+	"github.com/broadinstitute/sherlock/go-shared/pkg/utils"
 	"github.com/broadinstitute/sherlock/sherlock/internal/clients/slack/slack_mocks"
 	"github.com/broadinstitute/sherlock/sherlock/internal/config"
 	"github.com/rs/zerolog"
@@ -49,6 +50,12 @@ func TestSendPermissionChangeNotification(t *testing.T) {
 	config.LoadTestConfig()
 	zerolog.SetGlobalLevel(zerolog.Disabled)
 	ctx := context.Background()
+
+	var fortyStrings []string
+	for i := 0; i < 40; i++ {
+		fortyStrings = append(fortyStrings, "string")
+	}
+
 	type args struct {
 		actor  string
 		inputs PermissionChangeNotificationInputs
@@ -85,6 +92,25 @@ func TestSendPermissionChangeNotification(t *testing.T) {
 			mockConfig: func(c *slack_mocks.MockMockableClient) {
 				c.EXPECT().SendMessageContext(ctx, "#notification-channel", mock.Anything).Return("", "", "", nil).Once()
 				c.EXPECT().SendMessageContext(ctx, "#permission-change-channel", mock.Anything).Return("", "", "", nil).Once()
+			},
+		},
+		{
+			name: "normal but chunked",
+			args: args{
+				actor: "test",
+				inputs: PermissionChangeNotificationInputs{
+					Summary: "summary",
+					Results: fortyStrings,
+					Errors:  utils.Map(fortyStrings, func(_ string) error { return fmt.Errorf("error") }),
+				},
+			},
+			mockConfig: func(c *slack_mocks.MockMockableClient) {
+				// Two messages to each channel, the second one to each is threaded
+				c.EXPECT().SendMessageContext(ctx, "#notification-channel", mock.Anything).Return("", "123", "", nil).Once()
+				c.EXPECT().SendMessageContext(ctx, "#notification-channel", mock.Anything, mock.Anything).Return("", "", "", nil).Once()
+
+				c.EXPECT().SendMessageContext(ctx, "#permission-change-channel", mock.Anything).Return("", "456", "", nil).Once()
+				c.EXPECT().SendMessageContext(ctx, "#permission-change-channel", mock.Anything, mock.Anything).Return("", "", "", nil).Once()
 			},
 		},
 		{


### PR DESCRIPTION
Gets rid of the "Sherlock error: invalid blocks" message that pops up in the security events channel whenever Sherlock makes a ton of changes at once. This is the same approach that's worked for deployment changelog notifications, but it's handled a bit differently for reasons explained inline.

This is split out from the main "meat" of DDO-3890 because the rest of it is high risk but this is very low risk.

## Testing

Tests updated to capture this exact behavior with mocks.

## Risk

Very low.