### PR TITLE
[DDO-3890] Add models.User.DeactivatedAt

### DIFF
--- a/sherlock/db/migrations/000100_deactivated_users.down.sql
+++ b/sherlock/db/migrations/000100_deactivated_users.down.sql
@@ -1,0 +1,2 @@
+alter table users
+    drop column if exists deactivated_at;

--- a/sherlock/db/migrations/000100_deactivated_users.up.sql
+++ b/sherlock/db/migrations/000100_deactivated_users.up.sql
@@ -1,0 +1,2 @@
+alter table users
+    add column if not exists deactivated_at timestamp with time zone;

--- a/sherlock/internal/api/login/login_test.go
+++ b/sherlock/internal/api/login/login_test.go
@@ -1,12 +1,14 @@
 package login
 
 import (
+	"github.com/broadinstitute/sherlock/go-shared/pkg/utils"
 	"github.com/broadinstitute/sherlock/sherlock/internal/oidc_models"
 	"github.com/google/uuid"
 	"github.com/zitadel/oidc/v3/pkg/oidc"
 	"gorm.io/gorm/clause"
 	"net/http"
 	"net/http/httptest"
+	"time"
 )
 
 func (s *handlerSuite) TestLoginGet_noAuthRequestID() {
@@ -55,4 +57,38 @@ func (s *handlerSuite) TestLoginGet() {
 	s.NoError(s.DB.Where("id = ?", authRequest.ID.String()).First(&reloadedAuthRequest).Error)
 	s.True(reloadedAuthRequest.DoneAt.Valid)
 	s.Equal(s.TestData.User_Suitable().ID, *reloadedAuthRequest.UserID)
+}
+
+func (s *handlerSuite) TestLoginGet_DeactivatedUser() {
+	clientID, _, err := s.GenerateClient(s.DB)
+	s.NoError(err)
+
+	authRequest := oidc_models.AuthRequest{
+		ID:          uuid.New(),
+		ClientID:    clientID,
+		Nonce:       "some-nonce",
+		RedirectURI: s.GeneratedClientRedirectURI(),
+		Scopes:      []string{oidc.ScopeOpenID, oidc.ScopeProfile, oidc.ScopeEmail, "groups"},
+		State:       "some-state",
+	}
+
+	s.NoError(s.DB.Omit(clause.Associations).Create(&authRequest).Error)
+
+	request, err := http.NewRequest("GET", "/login?id="+authRequest.GetID(), nil)
+	s.NoError(err)
+	s.UseSuitableUserFor(request)
+
+	// Deactivate the user right before making the request
+	s.SetUserForDB(utils.PointerTo(s.TestData.User_SuperAdmin()))
+	s.NoError(s.DB.Model(utils.PointerTo(s.TestData.User_Suitable())).Omit(clause.Associations).Update("deactivated_at", utils.PointerTo(time.Now())).Error)
+
+	recorder := httptest.NewRecorder()
+	s.internalRouter.ServeHTTP(recorder, request)
+
+	s.Equal(http.StatusForbidden, recorder.Code)
+
+	// Check that the auth request was not marked as done
+	var reloadedAuthRequest oidc_models.AuthRequest
+	s.NoError(s.DB.Where("id = ?", authRequest.ID.String()).First(&reloadedAuthRequest).Error)
+	s.False(reloadedAuthRequest.DoneAt.Valid)
 }

--- a/sherlock/internal/api/sherlock/users_v3.go
+++ b/sherlock/internal/api/sherlock/users_v3.go
@@ -3,6 +3,7 @@ package sherlock
 import (
 	"github.com/broadinstitute/sherlock/go-shared/pkg/utils"
 	"github.com/broadinstitute/sherlock/sherlock/internal/models"
+	"time"
 )
 
 type UserV3 struct {
@@ -15,6 +16,7 @@ type UserV3 struct {
 	SlackID                *string             `json:"slackID,omitempty" form:"slackID"`
 	Suitable               *bool               `json:"suitable,omitempty" form:"suitable"`                             // Available only in responses; indicates whether the user is production-suitable
 	SuitabilityDescription *string             `json:"suitabilityDescription,omitempty" form:"suitabilityDescription"` // Available only in responses; describes the user's production-suitability
+	DeactivatedAt          *time.Time          `json:"deactivatedAt,omitempty" form:"deactivatedAt"`                   // Indicates that the user is currently deactivated
 	Assignments            []*RoleAssignmentV3 `json:"assignments,omitempty" form:"-"`
 	userDirectlyEditableFields
 }
@@ -35,6 +37,7 @@ func (u UserV3) toModel() models.User {
 		SlackID:        u.SlackID,
 		Name:           u.Name,
 		NameFrom:       u.NameFrom,
+		DeactivatedAt:  u.DeactivatedAt,
 	}
 	return ret
 }
@@ -54,6 +57,7 @@ func userFromModel(model models.User) UserV3 {
 		GithubID:               model.GithubID,
 		SlackUsername:          model.SlackUsername,
 		SlackID:                model.SlackID,
+		DeactivatedAt:          model.DeactivatedAt,
 		Suitable:               &suitable,
 		SuitabilityDescription: &suitabilityDescription,
 		userDirectlyEditableFields: userDirectlyEditableFields{

--- a/sherlock/internal/api/sherlock/users_v3_list_test.go
+++ b/sherlock/internal/api/sherlock/users_v3_list_test.go
@@ -8,6 +8,38 @@ import (
 	"net/http"
 )
 
+func (s *handlerSuite) TestUsersV3List_includeDeactivated() {
+	var got []UserV3
+	code := s.HandleRequest(
+		s.NewRequest("GET", "/api/users/v3", nil),
+		&got)
+	s.Equal(http.StatusOK, code)
+	baseline := len(got)
+
+	s.TestData.User_Deactivated()
+	s.Run("default false", func() {
+		code = s.HandleRequest(
+			s.NewRequest("GET", "/api/users/v3", nil),
+			&got)
+		s.Equal(http.StatusOK, code)
+		s.Len(got, baseline) // no new users
+	})
+	s.Run("explicit false", func() {
+		code = s.HandleRequest(
+			s.NewRequest("GET", "/api/users/v3?include-deactivated=false", nil),
+			&got)
+		s.Equal(http.StatusOK, code)
+		s.Len(got, baseline) // no new users
+	})
+	s.Run("explicit true", func() {
+		code = s.HandleRequest(
+			s.NewRequest("GET", "/api/users/v3?include-deactivated=true", nil),
+			&got)
+		s.Equal(http.StatusOK, code)
+		s.Len(got, baseline+1) // one new user
+	})
+}
+
 func (s *handlerSuite) TestUsersV3List_minimal() {
 	var got []UserV3
 	code := s.HandleRequest(

--- a/sherlock/internal/boot/application.go
+++ b/sherlock/internal/boot/application.go
@@ -153,7 +153,7 @@ func (a *Application) Start() {
 	go firecloud_account_manager.RunManagersHourly(ctx)
 
 	go models.KeepAutoAssigningRoles(ctx, a.gormDB)
-	go models.KeepAutoExpiringRoleAssignments(ctx, a.gormDB, role_propagation.DoOnDemandPropagation)
+	go models.KeepAutoDeletingRoleAssignments(ctx, a.gormDB, role_propagation.DoOnDemandPropagation)
 
 	log.Info().Msgf("BOOT | building Gin router...")
 	gin.SetMode(gin.ReleaseMode) // gin.DebugMode can help resolve routing issues

--- a/sherlock/internal/middleware/authentication/middleware.go
+++ b/sherlock/internal/middleware/authentication/middleware.go
@@ -25,6 +25,7 @@ func Middleware(db *gorm.DB) gin.HandlersChain {
 	return gin.HandlersChain{
 		userWhoConnectedMiddleware,
 		setGithubClaimsAndEscalateUser(db),
+		forbidDeactivatedUsers(),
 		setDatabaseWithUser(db),
 	}
 }
@@ -35,6 +36,7 @@ func TestMiddleware(db *gorm.DB, td models.TestData) gin.HandlersChain {
 	return gin.HandlersChain{
 		setUserWhoConnected(db, test_users.MakeHeaderParser(td.User_SuperAdmin(), td.User_Suitable(), td.User_NonSuitable()), authentication_method.TEST),
 		setGithubClaimsAndEscalateUser(db),
+		forbidDeactivatedUsers(),
 		setDatabaseWithUser(db),
 	}
 }

--- a/sherlock/internal/middleware/authentication/user_provider_test.go
+++ b/sherlock/internal/middleware/authentication/user_provider_test.go
@@ -1,0 +1,83 @@
+package authentication
+
+import (
+	"github.com/broadinstitute/sherlock/go-shared/pkg/utils"
+	"github.com/broadinstitute/sherlock/sherlock/internal/config"
+	"github.com/broadinstitute/sherlock/sherlock/internal/models"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"gorm.io/gorm"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func Test_forbidDeactivatedUsers(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	config.LoadTestConfig()
+	tests := []struct {
+		name        string
+		user        *models.User
+		expectError bool
+	}{
+		{
+			name:        "nil",
+			user:        nil,
+			expectError: true,
+		},
+		{
+			name:        "active",
+			user:        &models.User{},
+			expectError: false,
+		},
+		{
+			name: "deactivated",
+			user: &models.User{
+				DeactivatedAt: utils.PointerTo(time.Now()),
+			},
+			expectError: true,
+		},
+		{
+			name: "deleted",
+			user: &models.User{
+				Model: gorm.Model{DeletedAt: gorm.DeletedAt{Time: time.Now(), Valid: true}},
+			},
+			expectError: true,
+		},
+		{
+			name: "via active",
+			user: &models.User{
+				Via: &models.User{},
+			},
+		},
+		{
+			name: "via deactivated",
+			user: &models.User{
+				Via: &models.User{
+					DeactivatedAt: utils.PointerTo(time.Now()),
+					Via:           &models.User{},
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "via deleted",
+			user: &models.User{
+				Via: &models.User{
+					Model: gorm.Model{DeletedAt: gorm.DeletedAt{Time: time.Now(), Valid: true}},
+					Via:   &models.User{},
+				},
+			},
+			expectError: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			recorder := httptest.NewRecorder()
+			ctx, _ := gin.CreateTestContext(recorder)
+			ctx.Set(ctxUserFieldName, tt.user)
+			forbidDeactivatedUsers()(ctx)
+			assert.Equal(t, tt.expectError, ctx.IsAborted())
+		})
+	}
+}

--- a/sherlock/internal/models/role_assignment_auto_delete.go
+++ b/sherlock/internal/models/role_assignment_auto_delete.go
@@ -9,35 +9,38 @@ import (
 	"time"
 )
 
-// KeepAutoExpiringRoleAssignments will periodically delete RoleAssignments that have expired.
+// KeepAutoDeletingRoleAssignments will periodically delete RoleAssignments that have expired.
 // It can accept functions to kick off propagation for impacted Roles.
-func KeepAutoExpiringRoleAssignments(ctx context.Context, db *gorm.DB, propagationFn ...func(ctx context.Context, db *gorm.DB, roleID uint)) {
+func KeepAutoDeletingRoleAssignments(ctx context.Context, db *gorm.DB, propagationFn ...func(ctx context.Context, db *gorm.DB, roleID uint)) {
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		case <-time.After(time.Minute):
-			doAutoExpiration(ctx, db, propagationFn...)
+			doAutoDeletion(ctx, db, propagationFn...)
 		}
 	}
 }
 
-func doAutoExpiration(ctx context.Context, db *gorm.DB, propagationFn ...func(ctx context.Context, db *gorm.DB, roleID uint)) {
-	var roleAssignmentsToExpire []RoleAssignment
+func doAutoDeletion(ctx context.Context, db *gorm.DB, propagationFn ...func(ctx context.Context, db *gorm.DB, roleID uint)) {
+	var roleAssignmentsToDelete []RoleAssignment
 	if err := db.Model(&RoleAssignment{}).
 		Where("expires_at < current_timestamp").
+		Or("users.deactivated_at IS NOT NULL").
+		Or("users.deleted_at IS NOT NULL").
+		Joins("JOIN users ON role_assignments.user_id = users.id").
 		Preload(clause.Associations).
-		Find(&roleAssignmentsToExpire).Error; err != nil {
+		Find(&roleAssignmentsToDelete).Error; err != nil {
 		slack.ReportError(ctx, "failed to find role assignments to expire", err)
 		return
 	}
 
-	if len(roleAssignmentsToExpire) > 0 {
-		// Need to run as super user to create role assignments
+	if len(roleAssignmentsToDelete) > 0 {
+		// Need to run as super user to delete role assignments
 		superUserDB := SetCurrentUserForDB(db, SelfUser)
 
 		rolesToPropagate := make(map[uint]struct{})
-		for _, ra := range roleAssignmentsToExpire {
+		for _, ra := range roleAssignmentsToDelete {
 			if err := superUserDB.Omit(clause.Associations).Delete(&ra).Error; err != nil {
 				if !errors.Is(err, gorm.ErrRecordNotFound) {
 					slack.ReportError(ctx, "failed to delete role assignment", err)

--- a/sherlock/internal/models/role_assignment_test.go
+++ b/sherlock/internal/models/role_assignment_test.go
@@ -36,6 +36,19 @@ func (s *modelSuite) TestRoleAssignmentForbiddenCreate() {
 	s.ErrorContains(err, errors.Forbidden)
 }
 
+func (s *modelSuite) TestRoleAssignmentDeactivatedCreate() {
+	roleAssignment := RoleAssignment{
+		RoleID: s.TestData.Role_SherlockSuperAdmin().ID,
+		UserID: s.TestData.User_Deactivated().ID,
+		RoleAssignmentFields: RoleAssignmentFields{
+			Suspended: utils.PointerTo(false),
+		},
+	}
+	s.SetSelfSuperAdminForDB()
+	err := s.DB.Create(&roleAssignment).Error
+	s.ErrorContains(err, errors.Forbidden)
+}
+
 func (s *modelSuite) TestRoleAssignmentAllowedCreate() {
 	roleAssignment := s.TestData.RoleAssignment_NonSuitable_TerraEngineer()
 	s.Run("journaled", func() {

--- a/sherlock/internal/models/role_auto_assign.go
+++ b/sherlock/internal/models/role_auto_assign.go
@@ -45,7 +45,7 @@ func doAutoAssignment(ctx context.Context, db *gorm.DB) {
 			}
 			var userIDs []uint
 			if err := db.Raw(`
-				SELECT users.id FROM users WHERE users.deleted_at IS NULL AND NOT EXISTS
+				SELECT users.id FROM users WHERE users.deleted_at IS NULL AND users.deactivated_at IS NULL AND NOT EXISTS
 					(SELECT * FROM role_assignments WHERE role_assignments.role_id = ? AND role_assignments.user_id = users.id)
 			`, role.ID).Scan(&userIDs).Error; err != nil {
 				slack.ReportError(ctx, fmt.Sprintf("failed to find users to auto-assign to role %s", *role.Name), err)

--- a/sherlock/internal/models/test_data.go
+++ b/sherlock/internal/models/test_data.go
@@ -19,6 +19,7 @@ type TestData interface {
 	User_SuperAdmin() User
 	User_Suitable() User
 	User_NonSuitable() User
+	User_Deactivated() User
 
 	Role_SherlockSuperAdmin() Role
 	Role_TerraEngineer() Role
@@ -135,6 +136,7 @@ type testDataImpl struct {
 	user_superAdmin  User
 	user_suitable    User
 	user_nonSuitable User
+	user_deactivated User
 
 	role_sherlockSuperAdmin    Role
 	role_terraEngineer         Role
@@ -323,6 +325,23 @@ func (td *testDataImpl) User_NonSuitable() User {
 		}
 	}
 	return td.user_nonSuitable
+}
+
+func (td *testDataImpl) User_Deactivated() User {
+	if td.user_deactivated.ID == 0 {
+		td.user_deactivated = User{
+			Email:         "deactivated-test-email@broadinstitute.org",
+			GoogleID:      "403403403",
+			DeactivatedAt: utils.PointerTo(time.Now().Add(-time.Hour)),
+		}
+		td.create(&td.user_deactivated)
+
+		// Reload user from the database so we get suitability and other records
+		if err := td.h.DB.Scopes(ReadUserScope).Take(&td.user_deactivated, td.user_deactivated.ID).Error; err != nil {
+			panic(err)
+		}
+	}
+	return td.user_deactivated
 }
 
 func (td *testDataImpl) Role_SherlockSuperAdmin() Role {


### PR DESCRIPTION
Adds a currently read-only field to represent a models.User being deactivated. This PR adds the field and other related logic that reads it:

- Preventing a deactivated user from authenticating (to either API or OIDC)
- Preventing a user from modifying their own deactivated state (just an extra check)
- Preventing a role assignment being created for a deactivated user
- Automatically deleting role assignments for deactivated users (just like expired role assignments)
- Not adding deactivated users to auto-assign roles
- Hiding deactivated users by default when listing users

This PR also allows super admins to modify the user records of other users through the API. Users could previously only edit themselves and super admins had to go through the database. This is in preparation for the deactivation field being mutable via a super-admin-only procedure endpoint.

Note that propagation is unaffected here. That whole system is unaware of a user being deactivated and it's only concerned with role assignment state. That's why it's important that we delete role assignments for deactivated users.

## Testing

Tests for each feature updated to add coverage. Sherlock's strategy of testing the API JSON-to-JSON means that we've got high existing coverage protecting against regressions.

## Risk

Low, and this one's an easy one to roll back which is some of why I'm splitting this out.