### PR TITLE
[DDO-3907] Update swagger-ui

### DIFF
--- a/sherlock/go.mod
+++ b/sherlock/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/sethvargo/go-password v0.3.1
 	github.com/slack-go/slack v0.14.0
 	github.com/stretchr/testify v1.9.0
-	github.com/swaggo/files v1.0.1
+	github.com/swaggo/files/v2 v2.0.2-0.20240712141554-0590c09f83eb
 	github.com/swaggo/gin-swagger v1.6.1-0.20231210095754-aa92a0ac3f26
 	github.com/swaggo/swag v1.16.3
 	github.com/zitadel/oidc/v3 v3.30.1

--- a/sherlock/go.sum
+++ b/sherlock/go.sum
@@ -657,6 +657,9 @@ github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8
 github.com/stvp/go-udp-testing v0.0.0-20201019212854-469649b16807/go.mod h1:7jxmlfBCDBXRzr0eAQJ48XC1hBu1np4CS5+cHEYfwpc=
 github.com/swaggo/files v1.0.1 h1:J1bVJ4XHZNq0I46UU90611i9/YzdrF7x92oX1ig5IdE=
 github.com/swaggo/files v1.0.1/go.mod h1:0qXmMNH6sXNf+73t65aKeB+ApmgxdnkQzVTAj2uaMUg=
+github.com/swaggo/files/v2 v2.0.1/go.mod h1:24kk2Y9NYEJ5lHuCra6iVwkMjIekMCaFq/0JQj66kyM=
+github.com/swaggo/files/v2 v2.0.2-0.20240712141554-0590c09f83eb h1:rAois/AXxsf+CK1cBbGg6hQdauV62sDimiepyJa3BTM=
+github.com/swaggo/files/v2 v2.0.2-0.20240712141554-0590c09f83eb/go.mod h1:24kk2Y9NYEJ5lHuCra6iVwkMjIekMCaFq/0JQj66kyM=
 github.com/swaggo/gin-swagger v1.6.1-0.20231210095754-aa92a0ac3f26 h1:7APoRVOgfnHlp4HfZ/5YudTmNZCEgPAmjJpDzESCUOY=
 github.com/swaggo/gin-swagger v1.6.1-0.20231210095754-aa92a0ac3f26/go.mod h1:BG00cCEy294xtVpyIAHG6+e2Qzj/xKlRdOqDkvq0uzo=
 github.com/swaggo/swag v1.16.3 h1:PnCYjPCah8FK4I26l2F/KQ4yz3sILcVUN3cTlBFA9Pg=

--- a/sherlock/internal/middleware/security/middleware.go
+++ b/sherlock/internal/middleware/security/middleware.go
@@ -1,26 +1,11 @@
 package security
 
 import (
-	"crypto/sha256"
-	"encoding/base64"
-	"fmt"
 	"github.com/gin-contrib/secure"
 	"github.com/gin-gonic/gin"
-	"strings"
 )
 
-var styleAttributeValuesToAllow = []string{
-	"position:absolute;width:0;height:0",
-}
-
 func Security() gin.HandlerFunc {
-	styleAttributeHashes := make([]string, len(styleAttributeValuesToAllow))
-	for i, value := range styleAttributeValuesToAllow {
-		hash := sha256.Sum256([]byte(value))
-		styleAttributeHashes[i] = fmt.Sprintf("'sha256-%s'", base64.StdEncoding.EncodeToString(hash[:]))
-	}
-	styleDirective := fmt.Sprintf("style-src 'self' 'unsafe-hashes' %s; ", strings.Join(styleAttributeHashes, " "))
-
 	c := secure.Config{
 		// TLS is terminated at the proxy and/or load balancer, so we
 		// don't enable any TLS-related behavior. Some of the rest of
@@ -30,7 +15,7 @@ func Security() gin.HandlerFunc {
 		BrowserXssFilter:   true,
 		ContentSecurityPolicy: "default-src 'self'; " +
 			"img-src 'self' data:; " +
-			styleDirective +
+			"style-src 'self' 'unsafe-inline'; " +
 			"frame-ancestors 'none'; ",
 		IENoOpen:       true,
 		ReferrerPolicy: "strict-origin-when-cross-origin",

--- a/sherlock/internal/middleware/security/middleware_test.go
+++ b/sherlock/internal/middleware/security/middleware_test.go
@@ -24,6 +24,6 @@ func TestSecurity(t *testing.T) {
 		router.ServeHTTP(recorder, request)
 
 		assert.Contains(t, recorder.Header().Get("Content-Security-Policy"), "default-src 'self'; ")
-		assert.Contains(t, recorder.Header().Get("Content-Security-Policy"), "style-src 'self' 'unsafe-hashes' 'sha256-")
+		assert.Contains(t, recorder.Header().Get("Content-Security-Policy"), "style-src 'self' 'unsafe-inline'; ")
 	})
 }


### PR DESCRIPTION
So swagger-ui is vulnerable. We don't directly rely on it. We rely on github.com/swaggo/files, which _submodules in_ swagger-ui. Javascript code but not through npm. I'm not kidding -- that took a minute to figure out.

So anyway, looks like someone bumped the v2 branch of swaggo/files to have a non-vulnerable swagger-ui a few months back. But the v2 branch of swaggo/files is incompatible with swaggo/gin-swagger. Ugh. So we have to adapt the `fs.FS` that swaggo/files now provides with the `webdav.FileSystem`/`webdav.Handler` that swaggo/gin-swagger expects. It's not that bad because it's just a stub.

Fun fact, the newer swagger-ui now uses React to apply inline styles imperatively. So it started failing Sherlock's hash-based CSP. _Whatever_. Sarah Gibson directly confirmed that including `unsafe-inline` for `style-src` is okay so that's what I'm doing.

## Testing

We have tests that check that Sherlock can boot the router properly. This is also trivial to test locally because you can just load up the Swagger page and if it works then we can be pretty sure _that the files making up the page_ are there.

## Risk

Low. Even if this goes super-super sideways somehow, we're still behind IAP and nothing depends on Swagger.