### PR TITLE
A demo/draft of spreadsheet code for asset management

### DIFF
--- a/sherlock/config/default_config.yaml
+++ b/sherlock/config/default_config.yaml
@@ -662,3 +662,7 @@ firecloudAccountManager:
   #   # The largest unit that can be passed here is hours (so it's unambiguous about leap secs etc.)
   #   inactivityThreshold: 2160h
   # ```
+
+assetInventory:
+  enable: true
+  requiredRole: ""

--- a/sherlock/docs/docs.go
+++ b/sherlock/docs/docs.go
@@ -433,6 +433,76 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/asset-inventory/procedures/v3/generate": {
+            "post": {
+                "description": "Update the given Google Sheet with the latest asset inventory data",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "AssetInventory"
+                ],
+                "summary": "Generate an asset inventory",
+                "parameters": [
+                    {
+                        "description": "Configuration for the request",
+                        "name": "config",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/sherlock.AssetInventoryV3GenerateRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/sherlock.AssetInventoryV3GenerateResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "407": {
+                        "description": "Proxy Authentication Required",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/changesets/procedures/v3/apply": {
             "post": {
                 "description": "Looks up and applies previously-planned version diffs given by the ID. Other stored plans against the same Chart Releases are marked as superseded.\nMultiple Changesets can be specified simply by passing multiple IDs in the list.",
@@ -8025,6 +8095,21 @@ const docTemplate = `{
                     "type": "string"
                 }
             }
+        },
+        "sherlock.AssetInventoryV3GenerateRequest": {
+            "type": "object",
+            "properties": {
+                "googleSheetURL": {
+                    "type": "string"
+                },
+                "skipLeadingRows": {
+                    "type": "integer",
+                    "default": 1
+                }
+            }
+        },
+        "sherlock.AssetInventoryV3GenerateResponse": {
+            "type": "object"
         },
         "sherlock.ChangesetV3": {
             "type": "object",

--- a/sherlock/docs/swagger.json
+++ b/sherlock/docs/swagger.json
@@ -430,6 +430,76 @@
                 }
             }
         },
+        "/api/asset-inventory/procedures/v3/generate": {
+            "post": {
+                "description": "Update the given Google Sheet with the latest asset inventory data",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "AssetInventory"
+                ],
+                "summary": "Generate an asset inventory",
+                "parameters": [
+                    {
+                        "description": "Configuration for the request",
+                        "name": "config",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/sherlock.AssetInventoryV3GenerateRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/sherlock.AssetInventoryV3GenerateResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "407": {
+                        "description": "Proxy Authentication Required",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/changesets/procedures/v3/apply": {
             "post": {
                 "description": "Looks up and applies previously-planned version diffs given by the ID. Other stored plans against the same Chart Releases are marked as superseded.\nMultiple Changesets can be specified simply by passing multiple IDs in the list.",
@@ -8022,6 +8092,21 @@
                     "type": "string"
                 }
             }
+        },
+        "sherlock.AssetInventoryV3GenerateRequest": {
+            "type": "object",
+            "properties": {
+                "googleSheetURL": {
+                    "type": "string"
+                },
+                "skipLeadingRows": {
+                    "type": "integer",
+                    "default": 1
+                }
+            }
+        },
+        "sherlock.AssetInventoryV3GenerateResponse": {
+            "type": "object"
         },
         "sherlock.ChangesetV3": {
             "type": "object",

--- a/sherlock/docs/swagger.yaml
+++ b/sherlock/docs/swagger.yaml
@@ -116,6 +116,16 @@ definitions:
         description: Generally the Git commit message
         type: string
     type: object
+  sherlock.AssetInventoryV3GenerateRequest:
+    properties:
+      googleSheetURL:
+        type: string
+      skipLeadingRows:
+        default: 1
+        type: integer
+    type: object
+  sherlock.AssetInventoryV3GenerateResponse:
+    type: object
   sherlock.ChangesetV3:
     properties:
       appliedAt:
@@ -2168,6 +2178,52 @@ paths:
       summary: Edit an individual AppVersion
       tags:
       - AppVersions
+  /api/asset-inventory/procedures/v3/generate:
+    post:
+      consumes:
+      - application/json
+      description: Update the given Google Sheet with the latest asset inventory data
+      parameters:
+      - description: Configuration for the request
+        in: body
+        name: config
+        required: true
+        schema:
+          $ref: '#/definitions/sherlock.AssetInventoryV3GenerateRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/sherlock.AssetInventoryV3GenerateResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/errors.ErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/errors.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/errors.ErrorResponse'
+        "407":
+          description: Proxy Authentication Required
+          schema:
+            $ref: '#/definitions/errors.ErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/errors.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/errors.ErrorResponse'
+      summary: Generate an asset inventory
+      tags:
+      - AssetInventory
   /api/changesets/procedures/v3/apply:
     post:
       consumes:

--- a/sherlock/internal/api/sherlock/asset_inventory_procedures_v3_generate.go
+++ b/sherlock/internal/api/sherlock/asset_inventory_procedures_v3_generate.go
@@ -1,0 +1,140 @@
+package sherlock
+
+import (
+	"fmt"
+	"github.com/broadinstitute/sherlock/sherlock/internal/asset_inventory"
+	"github.com/broadinstitute/sherlock/sherlock/internal/config"
+	"github.com/broadinstitute/sherlock/sherlock/internal/errors"
+	"github.com/broadinstitute/sherlock/sherlock/internal/middleware/authentication"
+	"github.com/broadinstitute/sherlock/sherlock/internal/models"
+	"github.com/creasty/defaults"
+	"github.com/gin-gonic/gin"
+	"google.golang.org/api/sheets/v4"
+	"regexp"
+	"strconv"
+)
+
+type AssetInventoryV3GenerateRequest struct {
+	GoogleSheetURL  string `json:"googleSheetURL"`
+	SkipLeadingRows int    `json:"skipLeadingRows" default:"1"`
+}
+
+type AssetInventoryV3GenerateResponse struct {
+}
+
+// assetInventoryProceduresV3Generate godoc
+//
+//	@summary		Generate an asset inventory
+//	@description	Update the given Google Sheet with the latest asset inventory data
+//	@tags			AssetInventory
+//	@accept			json
+//	@produce		json
+//	@param			config					body		AssetInventoryV3GenerateRequest	true	"Configuration for the request"
+//	@success		200						{object}	AssetInventoryV3GenerateResponse
+//	@failure		400,403,404,407,409,500	{object}	errors.ErrorResponse
+//	@router			/api/asset-inventory/procedures/v3/generate [post]
+func assetInventoryProceduresV3Generate(ctx *gin.Context) {
+	// Authenticate request
+	user, err := authentication.MustUseUser(ctx)
+	if err != nil {
+		return
+	}
+	db, err := authentication.MustUseDB(ctx)
+	if err != nil {
+		return
+	}
+
+	// Bail if this endpoint is disabled in config
+	if !config.Config.Bool("assetInventory.enable") {
+		errors.AbortRequest(ctx, fmt.Errorf("asset inventory functionality is disabled"))
+		return
+	}
+
+	// Authorize request based on config
+	if requiredRoleReference := config.Config.String("assetInventory.requiredRole"); requiredRoleReference != "" {
+		var requiredRole, requiredRoleQuery models.Role
+		if requiredRoleQuery, err = roleModelFromSelector(requiredRoleReference); err != nil {
+			errors.AbortRequest(ctx, fmt.Errorf("error parsing assetInventory.requiredRole: %w", err))
+			return
+		} else if err = db.Where(&requiredRoleQuery).Select("id").First(&requiredRole).Error; err != nil {
+			errors.AbortRequest(ctx, fmt.Errorf("error querying assetInventory.requiredRole %s: %w", config.Config.String("assetInventory.requiredRole"), err))
+			return
+		} else if err = user.ErrIfNotActiveInRole(db, &requiredRole.ID); err != nil {
+			errors.AbortRequest(ctx, fmt.Errorf("caller not authorized to generate asset inventory: %w", err))
+			return
+		}
+	}
+
+	// Parse request
+	var body AssetInventoryV3GenerateRequest
+	if err = ctx.ShouldBindJSON(&body); err != nil {
+		errors.AbortRequest(ctx, fmt.Errorf("(%s) request validation error: %w", errors.BadRequest, err))
+		return
+	}
+	if err = defaults.Set(&body); err != nil {
+		errors.AbortRequest(ctx, fmt.Errorf("error setting defaults: %w", err))
+		return
+	}
+
+	// Parse Google Sheets URL
+	//   - Format per https://developers.google.com/sheets/api/guides/concepts
+	//   - https://docs.google.com/spreadsheets/d/<SPREADSHEET_ID>/edit?gid=<SHEET_ID>#gid=<SHEET_ID>
+	var spreadsheetID, sheetID string
+	if matches := regexp.
+		MustCompile(`https://docs.google.com/spreadsheets/d/([^/]+)/`).
+		FindStringSubmatch(body.GoogleSheetURL); len(matches) != 2 {
+		errors.AbortRequest(ctx, fmt.Errorf("(%s) invalid Google Sheet URL", errors.BadRequest))
+		return
+	} else {
+		spreadsheetID = matches[1]
+	}
+	if matches := regexp.
+		MustCompile(`[#&?]gid=([^#&?]+)`).
+		FindStringSubmatch(body.GoogleSheetURL); len(matches) != 2 {
+		errors.AbortRequest(ctx, fmt.Errorf("(%s) invalid Google Sheet URL", errors.BadRequest))
+		return
+	} else {
+		sheetID = matches[1]
+	}
+
+	// Load spreadsheet
+	sheetsService, err := sheets.NewService(ctx)
+	if err != nil {
+		errors.AbortRequest(ctx, fmt.Errorf("error creating Google Sheets service: %w", err))
+		return
+	}
+	spreadsheetData, err := sheetsService.Spreadsheets.Get(spreadsheetID).Context(ctx).Do()
+	if err != nil {
+		errors.AbortRequest(ctx, fmt.Errorf("error querying Google Sheets service for spreadsheet metadata: %w", err))
+		return
+	}
+	var sheetTitle string
+	for _, sheet := range spreadsheetData.Sheets {
+		if sheet.Properties != nil && strconv.FormatInt(sheet.Properties.SheetId, 10) == sheetID {
+			sheetTitle = sheet.Properties.Title
+			break
+		}
+	}
+	if sheetTitle == "" {
+		errors.AbortRequest(ctx, fmt.Errorf("(%s) Google Sheet URL possibly incorrect, no match for sheet ID found", errors.BadRequest))
+		return
+	}
+	existingSpreadsheetValues, err := sheetsService.Spreadsheets.Values.Get(spreadsheetID, sheetTitle).Context(ctx).Do()
+	if err != nil {
+		errors.AbortRequest(ctx, fmt.Errorf("error querying Google Sheets service: %w", err))
+		return
+	}
+
+	spreadsheet, err := asset_inventory.NewSpreadsheet(existingSpreadsheetValues.Values, body.SkipLeadingRows)
+	if err != nil {
+		errors.AbortRequest(ctx, fmt.Errorf("error creating asset inventory spreadsheet object: %w", err))
+		return
+	}
+
+	// grab new data from the cloud asset api
+
+	// update the spreadsheet with the new data
+
+	// This call won't print much because there's nothing that reads in the current assets to it... it's just sorta a demo
+	fmt.Printf("Values: %v\n", spreadsheet.ToRows())
+}

--- a/sherlock/internal/api/sherlock/routes.go
+++ b/sherlock/internal/api/sherlock/routes.go
@@ -48,6 +48,8 @@ func ConfigureRoutes(apiRouter gin.IRoutes) {
 	apiRouter.PATCH("app-versions/v3/*selector", appVersionsV3Edit)
 	apiRouter.GET("app-versions/v3/*selector", appVersionsV3Get)
 
+	apiRouter.POST("asset-inventory/procedures/v3/generate", assetInventoryProceduresV3Generate)
+
 	apiRouter.POST("changesets/procedures/v3/apply", changesetsProceduresV3Apply)
 	apiRouter.GET("changesets/procedures/v3/chart-release-history/*chart-release", changesetsProceduresV3ChartReleaseHistory)
 	apiRouter.POST("changesets/procedures/v3/plan", changesetsProceduresV3Plan)

--- a/sherlock/internal/asset_inventory/spreadsheet.go
+++ b/sherlock/internal/asset_inventory/spreadsheet.go
@@ -1,0 +1,96 @@
+package asset_inventory
+
+import (
+	"fmt"
+	"reflect"
+	"regexp"
+	"slices"
+	"strings"
+)
+
+type Spreadsheet interface {
+	ToRows() [][]any
+}
+
+var columnReplacementRegex = regexp.MustCompile(`[^a-zA-Z0-9]`)
+
+type spreadsheet struct {
+	mapping        spreadsheetColumnMapping
+	width          int
+	skippedRows    [][]any
+	previousAssets map[string]assetRow
+	currentAssets  []assetRow
+}
+
+type assetRow []any
+
+func NewSpreadsheet(rows [][]any, skip int) (Spreadsheet, error) {
+	s := &spreadsheet{}
+
+	// Find and store the index of each column based on the header row
+	mappingType := reflect.TypeOf(s.mapping)
+columnFindLoop:
+	for i := 0; i < mappingType.NumField(); i++ {
+		field := mappingType.Field(i)
+		columnName := field.Tag.Get("column")
+		columnNameToFind := strings.ToLower(columnReplacementRegex.ReplaceAllString(columnName, ""))
+
+		for j := 0; j < len(rows[skip]); j++ {
+			if cellAsString, ok := rows[skip][j].(string); !ok {
+				return nil, fmt.Errorf("expected column name to be a string but got %T", rows[skip][j])
+			} else {
+				if strings.Contains(strings.ToLower(columnReplacementRegex.ReplaceAllString(cellAsString, "")), columnNameToFind) {
+					s.width = max(s.width, j) // Record that rows should be at least this wide to accommodate this column
+					reflect.ValueOf(&s.mapping).Elem().Field(i).SetInt(int64(j))
+					continue columnFindLoop
+				}
+			}
+		}
+
+		return nil, fmt.Errorf("could not find a column header containing %q (whitespace-, symbol-, and case-insensitive)", columnName)
+	}
+
+	// We looked for the width already, but in case any rows happen to be longer, we'll standardize
+	for _, row := range rows {
+		s.width = max(s.width, len(row))
+	}
+
+	s.skippedRows = rows[:skip+1] // Skipped plus the header row
+
+	// Now we populate our list of existing assets, to persist cells we wouldn't otherwise set.
+	// We make sure each is at least width long, so that we can index into it without checking bounds.
+	s.previousAssets = make(map[string]assetRow)
+	for _, rawRow := range rows[skip+1:] {
+		var row assetRow
+		if len(rawRow) < s.width {
+			row = make(assetRow, s.width)
+			copy(row, rawRow)
+		} else {
+			row = rawRow
+		}
+
+		if uniqueAssetIdentifier := s.mapping.getUniqueAssetIdentifier(row); uniqueAssetIdentifier != "" {
+			s.previousAssets[uniqueAssetIdentifier] = row
+		}
+	}
+
+	return s, nil
+}
+
+func (s *spreadsheet) ToRows() [][]any {
+	rows := make([][]any, 0, len(s.skippedRows)+len(s.currentAssets))
+	rows = append(rows, s.skippedRows...)
+
+	slices.SortFunc(s.currentAssets, func(a, b assetRow) int {
+		return strings.Compare(s.mapping.getTeam(a), s.mapping.getTeam(b))<<4 +
+			strings.Compare(s.mapping.getTerraServiceComponent(a), s.mapping.getTerraServiceComponent(b))<<3 +
+			strings.Compare(s.mapping.getGcpProjectOrAzureSubscription(a), s.mapping.getGcpProjectOrAzureSubscription(b))<<2 +
+			strings.Compare(s.mapping.getAssetType(a), s.mapping.getAssetType(b))<<1 +
+			strings.Compare(s.mapping.getUniqueAssetIdentifier(a), s.mapping.getUniqueAssetIdentifier(b))
+	})
+	for _, row := range s.currentAssets {
+		rows = append(rows, row)
+	}
+
+	return rows
+}

--- a/sherlock/internal/asset_inventory/spreadsheet_column_mapping.go
+++ b/sherlock/internal/asset_inventory/spreadsheet_column_mapping.go
@@ -1,0 +1,170 @@
+package asset_inventory
+
+// spreadsheetColumnMapping is how we interact with the assetRow ([]any) type that represents a row
+// in the actual Google Sheet.
+//
+// Here's the deal--there's a lot of ways you could dice this onion. This approach here helps us do
+// two cool things:
+//  1. We actually get a lot of type safety here. We need a string to match to each header cell, but
+//     having it as a struct tag means we can't mismatch (and accessing it later is super simple).
+//  2. Just parsing indices and going from there makes this system incredibly tolerant of common
+//     operations like reordering columns, adding new columns, editing cells, etc. By contrast, if
+//     we fully parsed each row into a struct and back, we'd have to be a lot stricter about what
+//     human behaviors we could tolerate.
+type spreadsheetColumnMapping struct {
+	TeamColumnIndex                          int `column:"Team"`
+	TerraServiceComponentColumnIndex         int `column:"Terra Service Component"`
+	GcpProjectOrAzureSubscriptionColumnIndex int `column:"GCP Project or Azure Subscription"`
+	AssetShortNameColumnIndex                int `column:"Asset Short Name"`
+	UniqueAssetIdentifierColumnIndex         int `column:"Unique Asset Identifier"`
+	Ipv4OrIpv6AddressColumnIndex             int `column:"IPv4 or IPv6"`
+	VirtualColumnIndex                       int `column:"Virtual"`
+	PublicColumnIndex                        int `column:"Public"`
+	DnsNameOrUrlColumnIndex                  int `column:"DNS Name or URL"`
+	NetBiosNameColumnIndex                   int `column:"NetBIOS Name"`
+	MacAddressColumnIndex                    int `column:"MAC Address"`
+	AuthenticatedScanColumnIndex             int `column:"Authenticated Scan"`
+	BaselineConfigurationNameColumnIndex     int `column:"Baseline Configuration Name"`
+	OsNameAndVersionColumnIndex              int `column:"OS Name and Version"`
+	LocationColumnIndex                      int `column:"Location"`
+	AssetTypeColumnIndex                     int `column:"Asset Type"`
+	HardwareMakeModelColumnIndex             int `column:"Hardware Make/Model"`
+	InLatestScanColumnIndex                  int `column:"In Latest Scan"`
+	SoftwareDatabaseVendorColumnIndex        int `column:"Software/Database Vendor"`
+	SoftwareDatabaseNameVersionColumnIndex   int `column:"Software/Database Name & Version"`
+	PatchLevelColumnIndex                    int `column:"Patch Level"`
+	DiagramLabelColumnIndex                  int `column:"Diagram Label"`
+	CommentsColumnIndex                      int `column:"Comments"`
+	SerialAssetTagColumnIndex                int `column:"Serial #/Asset Tag#"`
+	VlanNetworkIDColumnIndex                 int `column:"VLAN/Network ID"`
+	SystemAdministratorOwnerColumnIndex      int `column:"System Administrator/Owner"`
+	ApplicationAdministratorOwnerColumnIndex int `column:"Application Administrator/Owner"`
+	FunctionColumnIndex                      int `column:"Function"`
+	EndOfLifeDateColumnIndex                 int `column:"End-of-Life"`
+}
+
+// Don't bother editing these one by one. Multicursor is your friend here.
+
+func (mapping *spreadsheetColumnMapping) getTeam(row assetRow) string {
+	if value, ok := row[mapping.TeamColumnIndex].(string); !ok {
+		return ""
+	} else {
+		return value
+	}
+}
+func (mapping *spreadsheetColumnMapping) getTerraServiceComponent(row assetRow) string {
+	if value, ok := row[mapping.TerraServiceComponentColumnIndex].(string); !ok {
+		return ""
+	} else {
+		return value
+	}
+}
+func (mapping *spreadsheetColumnMapping) getGcpProjectOrAzureSubscription(row assetRow) string {
+	if value, ok := row[mapping.GcpProjectOrAzureSubscriptionColumnIndex].(string); !ok {
+		return ""
+	} else {
+		return value
+	}
+}
+func (mapping *spreadsheetColumnMapping) getUniqueAssetIdentifier(row assetRow) string {
+	if value, ok := row[mapping.UniqueAssetIdentifierColumnIndex].(string); !ok {
+		return ""
+	} else {
+		return value
+	}
+}
+func (mapping *spreadsheetColumnMapping) getAssetType(row assetRow) string {
+	if value, ok := row[mapping.AssetTypeColumnIndex].(string); !ok {
+		return ""
+	} else {
+		return value
+	}
+}
+
+func (mapping *spreadsheetColumnMapping) setTeam(row assetRow, value string) {
+	row[mapping.TeamColumnIndex] = value
+}
+func (mapping *spreadsheetColumnMapping) setTerraServiceComponent(row assetRow, value string) {
+	row[mapping.TerraServiceComponentColumnIndex] = value
+}
+func (mapping *spreadsheetColumnMapping) setAssetShortName(row assetRow, value string) {
+	row[mapping.AssetShortNameColumnIndex] = value
+}
+func (mapping *spreadsheetColumnMapping) setGcpProjectOrAzureSubscription(row assetRow, value string) {
+	row[mapping.GcpProjectOrAzureSubscriptionColumnIndex] = value
+}
+func (mapping *spreadsheetColumnMapping) setUniqueAssetIdentifier(row assetRow, value string) {
+	row[mapping.UniqueAssetIdentifierColumnIndex] = value
+}
+func (mapping *spreadsheetColumnMapping) setIpv4OrIpv6Address(row assetRow, value string) {
+	row[mapping.Ipv4OrIpv6AddressColumnIndex] = value
+}
+func (mapping *spreadsheetColumnMapping) setVirtual(row assetRow, value string) {
+	row[mapping.VirtualColumnIndex] = value
+}
+func (mapping *spreadsheetColumnMapping) setPublic(row assetRow, value string) {
+	row[mapping.PublicColumnIndex] = value
+}
+func (mapping *spreadsheetColumnMapping) setDnsNameOrUrl(row assetRow, value string) {
+	row[mapping.DnsNameOrUrlColumnIndex] = value
+}
+func (mapping *spreadsheetColumnMapping) setNetBiosName(row assetRow, value string) {
+	row[mapping.NetBiosNameColumnIndex] = value
+}
+func (mapping *spreadsheetColumnMapping) setMacAddress(row assetRow, value string) {
+	row[mapping.MacAddressColumnIndex] = value
+}
+func (mapping *spreadsheetColumnMapping) setAuthenticatedScan(row assetRow, value string) {
+	row[mapping.AuthenticatedScanColumnIndex] = value
+}
+func (mapping *spreadsheetColumnMapping) setBaselineConfigurationName(row assetRow, value string) {
+	row[mapping.BaselineConfigurationNameColumnIndex] = value
+}
+func (mapping *spreadsheetColumnMapping) setOsNameAndVersion(row assetRow, value string) {
+	row[mapping.OsNameAndVersionColumnIndex] = value
+}
+func (mapping *spreadsheetColumnMapping) setLocation(row assetRow, value string) {
+	row[mapping.LocationColumnIndex] = value
+}
+func (mapping *spreadsheetColumnMapping) setAssetType(row assetRow, value string) {
+	row[mapping.AssetTypeColumnIndex] = value
+}
+func (mapping *spreadsheetColumnMapping) setHardwareMakeModel(row assetRow, value string) {
+	row[mapping.HardwareMakeModelColumnIndex] = value
+}
+func (mapping *spreadsheetColumnMapping) setInLatestScan(row assetRow, value string) {
+	row[mapping.InLatestScanColumnIndex] = value
+}
+func (mapping *spreadsheetColumnMapping) setSoftwareDatabaseVendor(row assetRow, value string) {
+	row[mapping.SoftwareDatabaseVendorColumnIndex] = value
+}
+func (mapping *spreadsheetColumnMapping) setSoftwareDatabaseNameVersion(row assetRow, value string) {
+	row[mapping.SoftwareDatabaseNameVersionColumnIndex] = value
+}
+func (mapping *spreadsheetColumnMapping) setPatchLevel(row assetRow, value string) {
+	row[mapping.PatchLevelColumnIndex] = value
+}
+func (mapping *spreadsheetColumnMapping) setDiagramLabel(row assetRow, value string) {
+	row[mapping.DiagramLabelColumnIndex] = value
+}
+func (mapping *spreadsheetColumnMapping) setComments(row assetRow, value string) {
+	row[mapping.CommentsColumnIndex] = value
+}
+func (mapping *spreadsheetColumnMapping) setSerialAssetTag(row assetRow, value string) {
+	row[mapping.SerialAssetTagColumnIndex] = value
+}
+func (mapping *spreadsheetColumnMapping) setVlanNetworkID(row assetRow, value string) {
+	row[mapping.VlanNetworkIDColumnIndex] = value
+}
+func (mapping *spreadsheetColumnMapping) setSystemAdministratorOwner(row assetRow, value string) {
+	row[mapping.SystemAdministratorOwnerColumnIndex] = value
+}
+func (mapping *spreadsheetColumnMapping) setApplicationAdministratorOwner(row assetRow, value string) {
+	row[mapping.ApplicationAdministratorOwnerColumnIndex] = value
+}
+func (mapping *spreadsheetColumnMapping) setFunction(row assetRow, value string) {
+	row[mapping.FunctionColumnIndex] = value
+}
+func (mapping *spreadsheetColumnMapping) setEndOfLifeDate(row assetRow, value string) {
+	row[mapping.EndOfLifeDateColumnIndex] = value
+}


### PR DESCRIPTION
I put a test spreadsheet in the shared drive: https://docs.google.com/spreadsheets/d/1isOybP49rb6n7uX2vtT_azKj-sgRzp7RWkOHxFSsSKE/edit?gid=591394540#gid=591394540

Idea is you paste that link in and it'll do the thing. For the "unique resource identifier", that'll need to be the full resource name you get from the cloud asset API. Sarah T said that because that full name is long and verbose, it'd be great to also have the tail end of it put in a separate short asset name column.

You'll need to set up ADC in a specific way for this to work.

```bash
gcloud auth application-default login --scopes=https://www.googleapis.com/auth/userinfo.email,https://www.googleapis.com/auth/accounts.reauth,https://www.googleapis.com/auth/userinfo.profile,https://www.googleapis.com/auth/sqlservice.login,openid,https://www.googleapis.com/auth/cloud-platform,https://www.googleapis.com/auth/calendar,https://www.googleapis.com/auth/spreadsheets
```

The calendar scope is helpful for Beehive's read-workbench-protection-calendar feature, while the spreadsheet scope is what powers this read-and-mutate-spreadsheet thingy. I don't think we'll need to explicitly list those scopes for Kubernetes or anything but you will need to enable the API in the project.

That cloud asset API is here https://pkg.go.dev/cloud.google.com/go/asset/apiv1. https://pkg.go.dev/cloud.google.com/go/asset/apiv1#Client.QueryAssets is probably what you want.