### PR TITLE
[DDO-3911] improve chart name validation

### DIFF
--- a/sherlock/db/migrations/000101_chart_name_validation.down.sql
+++ b/sherlock/db/migrations/000101_chart_name_validation.down.sql
@@ -1,0 +1,6 @@
+alter table charts
+    add constraint name_present
+        check (name is not null and name != '');
+
+alter table environments
+    drop constraint if exists name_valid;

--- a/sherlock/db/migrations/000101_chart_name_validation.up.sql
+++ b/sherlock/db/migrations/000101_chart_name_validation.up.sql
@@ -1,0 +1,6 @@
+alter table charts
+    add constraint name_valid
+        check (name is not null and name != ''  and name similar to '[a-z0-9]([-a-z0-9]*[a-z0-9])?');
+
+alter table environments
+    drop constraint if exists name_present;

--- a/sherlock/internal/models/chart_test.go
+++ b/sherlock/internal/models/chart_test.go
@@ -14,6 +14,11 @@ func (s *modelSuite) TestChartNameValidationSqlEmpty() {
 	s.ErrorContains(err, "name")
 }
 
+func (s *modelSuite) TestChartNameValidationSqlBadCharacters() {
+	err := s.DB.Create(&Chart{ChartRepo: utils.PointerTo("repo"), Name: "special characters!!!"}).Error
+	s.ErrorContains(err, "name")
+}
+
 func (s *modelSuite) TestChartRepoValidationSqlMissing() {
 	err := s.DB.Create(&Chart{Name: "name"}).Error
 	s.ErrorContains(err, "chart_repo")


### PR DESCRIPTION
Sherlock checks that the chart name isn't empty, but it doesn't impose validation on it not having special characters. This is a problem when security scanners target Sherlock's API, because "garbage in garbage out" means Sherlock ingests and stores the garbage.

This PR changes the validation to not just check emptiness but also that it matches the same kind of regex we use to validate environment names.

It is possible for deployment of this change to fail if there's already garbage in the database. I've checked and prod doesn't suffer from this. Dev does so I'll clean up manually.

```sql
delete from charts where name not similar to '[a-z0-9]([-a-z0-9]*[a-z0-9])?';
```

## Testing

We have a ton of testing for all sorts of valid chart names; everything in TestData gets automatically created. I added a test that checks invalid characters and it now properly passes with this fix in place.

## Risk

Low. No impact to prod. Any issues would halt rollout.