### PR TITLE
[DDO-3900] Fix clearing banner bucket

### DIFF
--- a/sherlock/internal/api/sherlock/environments_v3_edit.go
+++ b/sherlock/internal/api/sherlock/environments_v3_edit.go
@@ -65,5 +65,14 @@ func environmentsV3Edit(ctx *gin.Context) {
 		}
 	}
 
+	// Allow clearing serviceBannerBucket by setting an empty string.
+	if body.ServiceBannerBucket != nil && *body.ServiceBannerBucket == "" {
+		toEdit.ServiceBannerBucket = nil
+		if err = db.Model(&toEdit).Omit(clause.Associations).Update("service_banner_bucket", nil).Error; err != nil {
+			errors.AbortRequest(ctx, err)
+			return
+		}
+	}
+
 	ctx.JSON(http.StatusOK, environmentFromModel(toEdit))
 }

--- a/sherlock/internal/api/sherlock/environments_v3_edit_test.go
+++ b/sherlock/internal/api/sherlock/environments_v3_edit_test.go
@@ -204,3 +204,30 @@ func (s *handlerSuite) TestEnvironmentsV3Edit_deleteAfter_failToParse() {
 	s.Equal(errors.BadRequest, got.Type)
 	s.Contains(got.Message, "foobar")
 }
+
+func (s *handlerSuite) TestEnvironmentsV3Edit_clearExistingBannerBucket() {
+	edit := s.TestData.Environment_Swatomation_TestBee()
+	var got EnvironmentV3
+	code := s.HandleRequest(
+		s.NewRequest("PATCH", fmt.Sprintf("/api/environments/v3/%d", edit.ID), EnvironmentV3Edit{
+			ServiceBannerBucket: utils.PointerTo(""),
+		}),
+		&got)
+	s.Equal(http.StatusOK, code)
+	println(got.ServiceBannerBucket)
+	s.Nil(got.ServiceBannerBucket)
+}
+
+func (s *handlerSuite) TestEnvironmentsV3Edit_setMissingBannerBucket() {
+	edit := s.TestData.Environment_DdpAzureDev()
+	var got EnvironmentV3
+	code := s.HandleRequest(
+		s.NewRequest("PATCH", fmt.Sprintf("/api/environments/v3/%d", edit.ID), EnvironmentV3Edit{
+			ServiceBannerBucket: utils.PointerTo("firecloud-alerts-ddp-azure-dev"),
+		}),
+		&got)
+	s.Equal(http.StatusOK, code)
+	if s.NotNil(got.ServiceBannerBucket) {
+		s.Equal("firecloud-alerts-ddp-azure-dev", *got.ServiceBannerBucket)
+	}
+}


### PR DESCRIPTION
In #713 I missed an edge case, where trying to clear the banner bucket sets the db value to the empty string instead of null.

# Testing
Tests added for this case and I verified with local Sherlock + Beehive.