### PR TITLE
[DDO-4044] Use official swaggerexpert/swagger-editor-validate action

### DIFF
--- a/.github/workflows/sherlock-check-api-diff.yaml
+++ b/.github/workflows/sherlock-check-api-diff.yaml
@@ -45,9 +45,9 @@ jobs:
         run: make generate-swagger
 
         # This runs online, but if we hit issues with it, we can run it offline
-        # https://github.com/char0n/swagger-editor-validate/tree/master
+        # swaggerexpert/swagger-editor-validate
       - name: Validate Swagger source
-        uses: char0n/swagger-editor-validate@v1
+        uses: swaggerexpert/swagger-editor-validate@v1
         with:
           definition-file: head/sherlock/docs/swagger.yaml
 


### PR DESCRIPTION
This action appears to be broken in several dependabot PRs; turns out https://github.com/char0n/swagger-editor-validate/ has moved to https://github.com/char0n/swagger-editor-validate/.