### PR TITLE
[CTM-533] Use npx to validate swagger

### DIFF
--- a/.github/workflows/sherlock-check-api-diff.yaml
+++ b/.github/workflows/sherlock-check-api-diff.yaml
@@ -44,12 +44,16 @@ jobs:
         working-directory: head
         run: make generate-swagger
 
-        # This runs online, but if we hit issues with it, we can run it offline
-        # swaggerexpert/swagger-editor-validate
+      - name: Start Swagger Editor
+        run: |
+          docker run -d -p 8080:8080 --name swagger-editor swaggerapi/swagger-editor
+          until curl -sf http://localhost:8080 > /dev/null; do sleep 1; done
+
       - name: Validate Swagger source
         uses: swaggerexpert/swagger-editor-validate@v1
         with:
           definition-file: head/sherlock/docs/swagger.yaml
+          swagger-editor-url: http://localhost:8080
 
       - name: Create output directory
         if: ${{ github.actor != 'dependabot[bot]' }}

--- a/.github/workflows/sherlock-check-api-diff.yaml
+++ b/.github/workflows/sherlock-check-api-diff.yaml
@@ -44,16 +44,8 @@ jobs:
         working-directory: head
         run: make generate-swagger
 
-      - name: Start Swagger Editor
-        run: |
-          docker run -d -p 8080:8080 --name swagger-editor swaggerapi/swagger-editor
-          until curl -sf http://localhost:8080 > /dev/null; do sleep 1; done
-
       - name: Validate Swagger source
-        uses: swaggerexpert/swagger-editor-validate@v1
-        with:
-          definition-file: head/sherlock/docs/swagger.yaml
-          swagger-editor-url: http://localhost:8080
+        run: npx --yes @apidevtools/swagger-cli validate head/sherlock/docs/swagger.yaml
 
       - name: Create output directory
         if: ${{ github.actor != 'dependabot[bot]' }}

--- a/sherlock/internal/clients/bits_data_warehouse/boot.go
+++ b/sherlock/internal/clients/bits_data_warehouse/boot.go
@@ -3,7 +3,7 @@ package bits_data_warehouse
 import (
 	"cloud.google.com/go/bigquery"
 	"github.com/broadinstitute/sherlock/sherlock/internal/config"
-	"golang.org/x/net/context"
+	"context"
 )
 
 var client *bigquery.Client

--- a/sherlock/internal/clients/slack/permission_change_notification.go
+++ b/sherlock/internal/clients/slack/permission_change_notification.go
@@ -8,10 +8,12 @@ import (
 	"github.com/broadinstitute/sherlock/sherlock/internal/config"
 	"github.com/rs/zerolog/log"
 	"github.com/slack-go/slack"
-	"golang.org/x/net/context"
+	"context"
 )
 
-const permissionChangeSquelchContextKey = "sherlock-slack-permission-change-squelch"
+type squelchContextKey struct{}
+
+var permissionChangeSquelchContextKey = squelchContextKey{}
 
 // SetContextToSquelchPermissionChangeNotifications should be used very very carefully. It creates a new
 // context that, if passed to SendPermissionChangeNotification or SendPermissionChangeNotificationReturnError,


### PR DESCRIPTION
---

## Description
https://broadworkbench.atlassian.net/browse/CTM-533

Check-api-diff has been [failing for months](https://github.com/broadinstitute/sherlock/actions/workflows/sherlock-check-api-diff.yaml).  The problem seems to be that it is looking for a specific element at https://editor.swagger.io/, so it seems plausible that that site has been updated and no longer matches.  

This PR does `run: npx --yes @apidevtools/swagger-cli validate head/sherlock/docs/swagger.yaml` instead.    @apidevtools/swagger-cli is a Node.js command-line tool that validates a Swagger/OpenAPI spec file directly — it parses the YAML, resolves any $ref references, and checks it against the Swagger 2.0 JSON Schema. It exits with a non-zero code if the spec is invalid, which fails the CI step.

## Testing [required]

Describe how the changes have been tested.
Include screenshots where applicable to assist reviewers.

## Risk Assessment [recommended]

What are the risks associated with deploying this change(if any)?
Can it be easily reverted in the event of unanticipated problems?
If not, what alternative solutions are there?
